### PR TITLE
Fix "Error: Negative numbers should be created in combination with createPrefixUnaryExpression factory."

### DIFF
--- a/packages/parser/src/factory.ts
+++ b/packages/parser/src/factory.ts
@@ -458,7 +458,18 @@ export function createEnumDeclaration({
                     let initializer: ts.Expression = factory.createStringLiteral(`${value?.toString()}`)
 
                     if (isNumber(value)) {
-                      initializer = factory.createNumericLiteral(value)
+                      // Error: Negative numbers should be created in combination with createPrefixUnaryExpression factory.
+                      // The method createNumericLiteral only accepts positive numbers
+                      // or those combined with createPrefixUnaryExpression.
+                      // Therefore, we need to ensure that the number is not negative.
+                      if (value < 0) {
+                        initializer = factory.createPrefixUnaryExpression(
+                          ts.SyntaxKind.MinusToken,
+                          factory.createNumericLiteral(Math.abs(value))
+                        )
+                      } else {
+                        initializer = factory.createNumericLiteral(value)
+                      }
                     }
 
                     if (typeof value === 'boolean') {


### PR DESCRIPTION
```
  [  Error: Negative numbers should be created in combination with createPrefixUnaryExpression
    
    - typescript.js:21097 Object.createNumericLiteral
      [app]/[parser]/[typescript]/lib/typescript.js:21097:13
    
    - factory.ts:461 
      [app]/[@kubb]/parser/src/factory.ts:461:45
    
    - Array.map
    
    - factory.ts:457 Module.createEnumDeclaration
      [app]/[@kubb]/parser/src/factory.ts:457:20
    
    - typeParser.ts:312 
      [app]/[@kubb]/swagger-ts/src/typeParser.ts:312:20
    
    - Array.forEach
    
    - typeParser.ts:310 typeParser
      [app]/[@kubb]/swagger-ts/src/typeParser.ts:310:17
    
    - SchemaGenerator.tsx:48 SchemaGenerator2.getSource
      [app]/[@kubb]/swagger-ts/src/SchemaGenerator.tsx:48:24
    
    - Schema.tsx:146 Component
      [app]/[@kubb]/swagger/src/components/Schema.tsx:146:28
    
    - react-reconciler.development.js:7478 renderWithHooks
      [app]/[react-reconciler@0.29.0_react@18.2.0]/[react-reconciler]/cjs/react-reconciler.development.js:7478:18
    
  ]
]
✖   Error: Debug Failure. False expression: Negative numbers should be created in combination with createPrefixUnaryExpression

```

Having negative enumerated values causes this error during generation.

Here are the lines that caused this error:
```
          application/json:
            schema:
              type: object
              properties:
                rating:
                  type: integer
                  enum:
                    - -1
                    - 0
                    - 1
```

This is a known issue. You can also take a look at this issue for OpenAPI-TS: https://github.com/hey-api/openapi-ts/issues/466