### PR TITLE
Mark enum as nullable for null enum members

### DIFF
--- a/.changeset/smooth-camels-fold.md
+++ b/.changeset/smooth-camels-fold.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-oas": patch
+---
+
+Mark enum as nullable for null enum members

--- a/packages/plugin-oas/src/SchemaGenerator.ts
+++ b/packages/plugin-oas/src/SchemaGenerator.ts
@@ -560,6 +560,12 @@ export abstract class SchemaGenerator<
         type: 'type',
       })
 
+      const nullableEnum = schema.enum.includes(null);
+      if (nullableEnum) {
+        baseItems.push({ keyword: schemaKeywords.nullable })
+      }
+      const filteredValues = schema.enum.filter((value) => value !== null);
+
       // x-enumNames has priority
       const extensionEnums = ['x-enumNames', 'x-enum-varnames']
         .filter((extensionKey) => extensionKey in schema)
@@ -600,7 +606,7 @@ export abstract class SchemaGenerator<
                     value,
                     format: 'number',
                   }))
-                : [...new Set(schema.enum)].map((value: string) => {
+                : [...new Set(filteredValues)].map((value: string) => {
                     return {
                       name: value,
                       value,
@@ -624,7 +630,7 @@ export abstract class SchemaGenerator<
             name: enumName,
             typeName,
             asConst: false,
-            items: [...new Set(schema.enum)].map((value: string) => ({
+            items: [...new Set(filteredValues)].map((value: string) => ({
               name: transformers.stringify(value),
               value,
               format: isNumber(value) ? 'number' : 'string',

--- a/packages/swagger-ts/mocks/enums.yaml
+++ b/packages/swagger-ts/mocks/enums.yaml
@@ -1,91 +1,105 @@
-
-definitions:
-  enumVarNames.Type:
-    enum:
-    - 0
-    - 1
-    type: integer
-    x-enum-varnames:
-    - Pending
-    - Received
-  enumNames.Type:
-    enum:
-    - 0
-    - 1
-    x-enumNames:
+components:
+  schemas:
+    enumVarNames.Type:
+      enum:
+      - 0
+      - 1
+      type: integer
+      x-enum-varnames:
       - Pending
       - Received
-  enum.String:
-    type: string
-    enum:
-      - created_at
-      - description
-      - FILE.UPLOADED
-      - FILE.DOWNLOADED
-  enum.InObject:
-    type: object
-    properties:
-      reason:
-        type: string
-        enum:
-          - created_at
-          - description
-  enum.AllOf:
-    type: object
-    properties:
-      reason:
-        allOf:
-          - type: string
-            enum:
-              - created_at
-              - description
-
-  enum.Array:
-    type: object
-    properties:
-     identifier:
-        type: array
-        prefixItems:
-          - type: integer
-            description: Number of items
-          - type: string
-            description: Description
-          - enum:
-              - "NW"
-              - "NE"
-              - "SW"
-              - "SE"
-            description: Wind direction
-
-  enum.Items:
-    type: array
-    minItems: 1
-    uniqueItems: true
-    items:
+    enumNames.Type:
+      enum:
+      - 0
+      - 1
+      x-enumNames:
+        - Pending
+        - Received
+    enum.String:
       type: string
       enum:
         - created_at
         - description
-swagger: "2.0"
+        - FILE.UPLOADED
+        - FILE.DOWNLOADED
+    enum.NullableMember:
+      type: string
+      enum:
+        - first
+        - second
+        - null
+    enum.NullableType:
+      type:
+        - string
+        - "null"
+      enum:
+        - first
+        - second
+    enum.InObject:
+      type: object
+      properties:
+        reason:
+          type: string
+          enum:
+            - created_at
+            - description
+    enum.AllOf:
+      type: object
+      properties:
+        reason:
+          allOf:
+            - type: string
+              enum:
+                - created_at
+                - description
+
+    enum.Array:
+      type: object
+      properties:
+      identifier:
+          type: array
+          prefixItems:
+            - type: integer
+              description: Number of items
+            - type: string
+              description: Description
+            - enum:
+                - "NW"
+                - "NE"
+                - "SW"
+                - "SE"
+              description: Wind direction
+
+    enum.Items:
+      type: array
+      minItems: 1
+      uniqueItems: true
+      items:
+        type: string
+        enum:
+          - created_at
+          - description
+
+openapi: "3.1.0"
 info:
   title: test
   version: "1.0.0"
 paths:
   /var-names:
     get:
-      consumes:
-      - application/json
       responses:
         200:
           description: Success
-          schema:
-            $ref: '#/definitions/enumVarNames.Type'
+          content:
+            application/json:
+              schema:
+                $ref: '#/definitions/enumVarNames.Type'
   /names:
     get:
-      consumes:
-      - application/json
       responses:
         200:
           description: Success
-          schema:
-            $ref: '#/definitions/enumNames.Type'
+          content:
+            application/json:
+              schema:
+                $ref: '#/definitions/enumNames.Type'

--- a/packages/swagger-ts/mocks/enums_2.0.yaml
+++ b/packages/swagger-ts/mocks/enums_2.0.yaml
@@ -1,0 +1,23 @@
+definitions:
+  enum.Array:
+    type: object
+    properties:
+      identifier:
+        type: array
+        prefixItems:
+          - type: integer
+            description: Number of items
+          - type: string
+            description: Description
+          - enum:
+              - "NW"
+              - "NE"
+              - "SW"
+              - "SE"
+            description: Wind direction
+
+swagger: "2.0"
+info:
+  title: test
+  version: "1.0.0"
+paths: {}

--- a/packages/swagger-ts/src/SchemaGenerator.test.tsx
+++ b/packages/swagger-ts/src/SchemaGenerator.test.tsx
@@ -157,6 +157,24 @@ describe('TypeScript SchemaGenerator', async () => {
       },
     },
     {
+      name: 'EnumNullableMember',
+      input: '../mocks/enums.yaml',
+      path: 'enum.NullableMember',
+      options: {
+        enumType: 'asConst',
+        optionalType: 'questionToken',
+      },
+    },
+    {
+      name: 'EnumNullableType',
+      input: '../mocks/enums.yaml',
+      path: 'enum.NullableType',
+      options: {
+        enumType: 'asConst',
+        optionalType: 'questionToken',
+      },
+    },
+    {
       name: 'EnumAllOf',
       input: '../mocks/enums.yaml',
       path: 'enum.AllOf',
@@ -176,7 +194,7 @@ describe('TypeScript SchemaGenerator', async () => {
     },
     {
       name: 'EnumArray',
-      input: '../mocks/enums.yaml',
+      input: '../mocks/enums_2.0.yaml',
       path: 'enum.Array',
       options: {
         enumType: 'asConst',

--- a/packages/swagger-ts/src/__snapshots__/SchemaGenerator.test.tsx.snap
+++ b/packages/swagger-ts/src/__snapshots__/SchemaGenerator.test.tsx.snap
@@ -138,6 +138,26 @@ export type enumNamesType = EnumNamesTypeEnum
 "
 `;
 
+exports[`TypeScript SchemaGenerator > 'EnumNullableMember' 1`] = `
+"export const enumNullableMemberEnum = {
+  first: 'first',
+  second: 'second',
+} as const
+export type EnumNullableMemberEnum = (typeof enumNullableMemberEnum)[keyof typeof enumNullableMemberEnum]
+export type enumNullableMember = EnumNullableMemberEnum | null
+"
+`;
+
+exports[`TypeScript SchemaGenerator > 'EnumNullableType' 1`] = `
+"export const enumNullableTypeEnum = {
+  first: 'first',
+  second: 'second',
+} as const
+export type EnumNullableTypeEnum = (typeof enumNullableTypeEnum)[keyof typeof enumNullableTypeEnum]
+export type enumNullableType = EnumNullableTypeEnum | null
+"
+`;
+
 exports[`TypeScript SchemaGenerator > 'EnumString' 1`] = `
 "export const enumStringEnum = {
   created_at: 'created_at',

--- a/packages/swagger-zod/mocks/enums3_1.yaml
+++ b/packages/swagger-zod/mocks/enums3_1.yaml
@@ -12,6 +12,7 @@ components:
       enum:
       - Pending
       - Received
+      - null
 
 paths:
   /var-names:


### PR DESCRIPTION
Fixes #1030 

According to the [3.0 docs](https://swagger.io/docs/specification/data-models/enums/) and [this FAQ](https://github.com/OAI/OpenAPI-Specification/blob/main/proposals/2019-10-31-Clarify-Nullable.md#if-a-schema-specifies-nullable-true-and-enum-1-2-3-does-that-schema-allow-null-values-see-1900), an enum is nullable when both it's type is nullable and when null is a member of the enum. Currently kubb will crash with a null member, so this PR fixes this case.

I added a couple of test cases as well, but let me know if there are more ways I should test this.