### PR TITLE
Fix/object type

### DIFF
--- a/.changeset/big-hotels-join.md
+++ b/.changeset/big-hotels-join.md
@@ -1,0 +1,5 @@
+---
+"@kubb/swagger-ts": patch
+---
+
+Avoid the use of non-nullish value and replace it by `object`

--- a/packages/swagger-ts/src/parser/__snapshots__/index.test.ts.snap
+++ b/packages/swagger-ts/src/parser/__snapshots__/index.test.ts.snap
@@ -1151,19 +1151,14 @@ NodeObject {
 `;
 
 exports[`type parse > 'objectEmpty' 1`] = `
-NodeObject {
+TokenObject {
   "emitNode": undefined,
   "end": -1,
   "flags": 16,
   "id": 0,
-  "kind": 187,
-  "localSymbol": undefined,
-  "members": [],
-  "modifierFlagsCache": 0,
-  "original": undefined,
+  "kind": 151,
   "parent": undefined,
   "pos": -1,
-  "symbol": undefined,
   "transformFlags": 1,
 }
 `;

--- a/packages/swagger-ts/src/parser/index.ts
+++ b/packages/swagger-ts/src/parser/index.ts
@@ -11,7 +11,7 @@ export const typeKeywordMapper = {
   number: () => factory.keywordTypeNodes.number,
   integer: () => factory.keywordTypeNodes.number,
   object: (nodes?: ts.TypeElement[]) => {
-    if (!nodes) {
+    if (!nodes || !nodes.length) {
       return factory.keywordTypeNodes.object
     }
 


### PR DESCRIPTION
# Issue
If you have `typescript-eslint` enabled in your project, you might run into a situation where you get some errors related about the use of `{}` as type after generating the code.

# Solution
This adds a check to see if `nodes.length` is 0, meaning the node doesnt have any children and thus should be treated as an object instead of creating a new literal node...probably the original condition was wrong since `![]` is a falsy value, but decided to keep it as it was to avoid any potential regression
