### PR TITLE
Ts-plugin with custom mapper(experimental)

### DIFF
--- a/.changeset/moody-gorillas-sing.md
+++ b/.changeset/moody-gorillas-sing.md
@@ -1,0 +1,5 @@
+---
+"@kubb/swagger-ts": patch
+---
+
+Experimental mapper for plugin-ts

--- a/docs/plugins/swagger-client/index.md
+++ b/docs/plugins/swagger-client/index.md
@@ -107,7 +107,7 @@ const plugin = pluginClient({
     exportType: 'barrel',
   },
 })
-
+```
 :::
 
 ### group
@@ -122,6 +122,9 @@ Type: `'tag'` <br/>
 Required: `true`
 
 #### group.output
+::: tip
+When defining a custom output path, you should also update `output.path` to contain the same root path.
+:::
 
 ::: v-pre
 Relative path to save the grouped clients.
@@ -153,6 +156,9 @@ Default: `'{{tag}}Service'`
 import { pluginClient } from '@kubb/swagger-client'
 
 const plugin = pluginClient({
+  output: {
+    path: './clients/axios'
+  },
   group: { type: 'tag', output: './clients/axios/{{tag}}Service' },
 })
 ```

--- a/docs/plugins/swagger-faker/index.md
+++ b/docs/plugins/swagger-faker/index.md
@@ -124,6 +124,9 @@ Type: `'tag'` <br/>
 Required: `true`
 
 #### group.output
+::: tip
+When defining a custom output path, you should also update `output.path` to contain the same root path.
+:::
 
 ::: v-pre
 Relative path to save the grouped Faker mocks.
@@ -151,6 +154,9 @@ Default: `'{{tag}}Mocks'`
 import { pluginFaker } from '@kubb/swagger-faker'
 
 const plugin = pluginFaker({
+  output: {
+    path: './mocks'
+  },
   group: {
     type: 'tag',
     output: './mocks/{{tag}}Mocks',

--- a/docs/plugins/swagger-msw/index.md
+++ b/docs/plugins/swagger-msw/index.md
@@ -134,6 +134,9 @@ Type: `'tag'` <br/>
 Required: `true`
 
 #### group.output
+::: tip
+When defining a custom output path, you should also update `output.path` to contain the same root path.
+:::
 
 ::: v-pre
 Relative path to save the grouped MSW mocks.
@@ -161,6 +164,9 @@ Default: `'{{tag}}Handlers'`
 import { pluginMsw } from '@kubb/swagger-msw'
 
 const plugin = pluginMsw({
+  output: {
+    path: './mocks'
+  },
   group: { type: 'tag', output: './mocks/{{tag}}Handlers' },
 })
 ```

--- a/docs/plugins/swagger-swr/index.md
+++ b/docs/plugins/swagger-swr/index.md
@@ -129,6 +129,9 @@ Type: `'tag'` <br/>
 Required: `true`
 
 #### group.output
+::: tip
+When defining a custom output path, you should also update `output.path` to contain the same root path.
+:::
 
 ::: v-pre
 Relative path to save the grouped SWR hooks.
@@ -158,6 +161,9 @@ Default: `'{{tag}}SWRHooks'`
 import { pluginSwr } from '@kubb/swagger-swr'
 
 const plugin = pluginSwr({
+  output: {
+    path: './hooks'
+  },
   group: { type: 'tag', output: './hooks/{{tag}}Controller' },
 })
 ```

--- a/docs/plugins/swagger-tanstack-query/index.md
+++ b/docs/plugins/swagger-tanstack-query/index.md
@@ -140,6 +140,9 @@ Type: `'tag'` <br/>
 Required: `true`
 
 #### group.output
+::: tip
+When defining a custom output path, you should also update `output.path` to contain the same root path.
+:::
 
 ::: v-pre
 Relative path to save the grouped [Tanstack Query](https://tanstack.com/query) hooks.
@@ -169,6 +172,9 @@ Default: `'{{tag}}Hooks'`
 import { pluginTanstackQuery } from '@kubb/swagger-tanstack-query'
 
 const plugin = pluginTanstackQuery({
+  output: {
+    path: './hooks'
+  },
   group: { type: 'tag', output: './hooks/{{tag}}Hooks' },
 })
 ```

--- a/docs/plugins/swagger-ts/index.md
+++ b/docs/plugins/swagger-ts/index.md
@@ -125,6 +125,9 @@ Type: `'tag'` <br/>
 Required: `true`
 
 #### group.output
+::: tip
+When defining a custom output path, you should also update `output.path` to contain the same root path.
+:::
 
 ::: v-pre
 Relative path to save the grouped TypeScript Types.
@@ -143,6 +146,9 @@ Default: `'${output}/{{tag}}Controller'`
 import { pluginTs } from '@kubb/swagger-ts'
 
 const plugin = pluginTs({
+  output: {
+    path: './types'
+  },
   group: { type: 'tag', output: './types/{{tag}}Controller' },
 })
 ```

--- a/docs/plugins/swagger-zod/index.md
+++ b/docs/plugins/swagger-zod/index.md
@@ -122,6 +122,9 @@ Type: `'tag'` <br/>
 Required: `true`
 
 #### group.output
+::: tip
+When defining a custom output path, you should also update `output.path` to contain the same root path.
+:::
 
 ::: v-pre
 Relative path to save the grouped Zod schemas.
@@ -151,6 +154,9 @@ Default: `'{{tag}}Schemas'`
 import { pluginZod } from '@kubb/swagger-zod'
 
 const plugin = pluginZod({
+  output: {
+    path: './schemas'
+  },
   group: { type: 'tag', output: './schemas/{{tag}}Schemas' },
 })
 ```

--- a/examples/typescript/kubb.config.ts
+++ b/examples/typescript/kubb.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from '@kubb/core'
 import { pluginOas } from '@kubb/plugin-oas'
 import { pluginTs } from '@kubb/swagger-ts'
+import ts, { factory } from 'typescript'
 
 export default defineConfig({
   root: '.',
@@ -54,6 +55,14 @@ export default defineConfig({
         exportType: 'barrelNamed',
       },
       oasType: 'infer',
+      mapper: {
+        category: factory.createPropertySignature(
+          undefined,
+          factory.createIdentifier('category'),
+          factory.createToken(ts.SyntaxKind.QuestionToken),
+          factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
+        ),
+      },
     }),
   ],
 })

--- a/examples/typescript/src/gen/ts/models/AddPetRequest.ts
+++ b/examples/typescript/src/gen/ts/models/AddPetRequest.ts
@@ -1,4 +1,3 @@
-import type { Category } from './Category'
 import type { Tag } from './Tag'
 
 export const addPetRequestStatus = {
@@ -16,7 +15,7 @@ export type AddPetRequest = {
    * @type string
    */
   name: string
-  category?: Category
+  category?: string
   /**
    * @type array
    */

--- a/examples/typescript/src/gen/ts/models/Pet.ts
+++ b/examples/typescript/src/gen/ts/models/Pet.ts
@@ -1,4 +1,3 @@
-import type { Category } from './Category'
 import type { Tag } from './Tag'
 
 export const petStatus = {
@@ -16,7 +15,7 @@ export type Pet = {
    * @type string
    */
   name: string
-  category?: Category
+  category?: string
   /**
    * @type array
    */

--- a/packages/swagger-faker/src/types.ts
+++ b/packages/swagger-faker/src/types.ts
@@ -117,7 +117,7 @@ type ResolvedOptions = {
   transformers: NonNullable<Options['transformers']>
   override: NonNullable<Options['override']>
   seed: NonNullable<Options['seed']> | undefined
-  mapper: Record<string, string>
+  mapper: NonNullable<Options['mapper']>
   regexGenerator: NonNullable<Options['regexGenerator']>
 }
 

--- a/packages/swagger-ts/src/OperationGenerator.test.tsx
+++ b/packages/swagger-ts/src/OperationGenerator.test.tsx
@@ -73,6 +73,7 @@ describe('OperationGenerator', async () => {
       oasType: false,
       unknownType: 'any',
       override: [],
+      mapper: {},
       ...props.options,
     }
     const plugin = { options } as Plugin<PluginTs>

--- a/packages/swagger-ts/src/SchemaGenerator.test.tsx
+++ b/packages/swagger-ts/src/SchemaGenerator.test.tsx
@@ -329,6 +329,7 @@ describe('TypeScript SchemaGenerator', async () => {
       oasType: false,
       unknownType: 'any',
       override: [],
+      mapper: {},
       ...props.options,
     }
     const plugin = { options } as Plugin<PluginTs>

--- a/packages/swagger-ts/src/components/OperationSchema.test.tsx
+++ b/packages/swagger-ts/src/components/OperationSchema.test.tsx
@@ -29,6 +29,7 @@ describe('<OperationSchema/>', async () => {
     optionalType: 'undefined',
     usedEnumNames: {},
     override: [],
+    mapper: {},
   }
 
   const plugin = { options } as Plugin<PluginTs>

--- a/packages/swagger-ts/src/components/Schema.test.tsx
+++ b/packages/swagger-ts/src/components/Schema.test.tsx
@@ -20,6 +20,7 @@ describe('<Schema/> ', () => {
     enumSuffix: '',
     oasType: false,
     usedEnumNames: {},
+    mapper: {},
   }
 
   const plugin = { options } as Plugin<PluginTs>

--- a/packages/swagger-ts/src/components/Schema.tsx
+++ b/packages/swagger-ts/src/components/Schema.tsx
@@ -22,7 +22,7 @@ export function Schema(props: Props): ReactNode {
   const {
     pluginManager,
     plugin: {
-      options: { enumType, optionalType },
+      options: { mapper, enumType, optionalType },
     },
   } = useApp<PluginTs>()
 
@@ -52,7 +52,7 @@ export function Schema(props: Props): ReactNode {
 
   let type =
     (tree
-      .map((schema) => parse(undefined, schema, { name: resolvedName, typeName, description, keysToOmit, optionalType, enumType }))
+      .map((schema) => parse(undefined, schema, { name: resolvedName, typeName, description, keysToOmit, optionalType, enumType, mapper }))
       .filter(Boolean)
       .at(0) as ts.TypeNode) || typeKeywordMapper.undefined()
 

--- a/packages/swagger-ts/src/plugin.ts
+++ b/packages/swagger-ts/src/plugin.ts
@@ -28,6 +28,7 @@ export const pluginTs = createPlugin<PluginTs>((options) => {
     optionalType = 'questionToken',
     transformers = {},
     oasType = false,
+    mapper = {},
   } = options
   const template = group?.output ? group.output : `${output.path}/{{tag}}Controller`
 
@@ -44,6 +45,7 @@ export const pluginTs = createPlugin<PluginTs>((options) => {
       usedEnumNames: {},
       unknownType,
       override,
+      mapper,
     },
     pre: [pluginOasName],
     resolvePath(baseName, pathMode, options) {

--- a/packages/swagger-ts/src/types.ts
+++ b/packages/swagger-ts/src/types.ts
@@ -117,7 +117,7 @@ type ResolvedOptions = {
   transformers: NonNullable<Options['transformers']>
   oasType: NonNullable<Options['oasType']>
   usedEnumNames: Record<string, number>
-  mapper: NonNullable<Options['mapper']>
+  mapper:Record<string, any>
 }
 
 export type FileMeta = {

--- a/packages/swagger-ts/src/types.ts
+++ b/packages/swagger-ts/src/types.ts
@@ -1,6 +1,7 @@
 import type { Plugin, PluginFactoryOptions, ResolveNameParams } from '@kubb/core'
 import type * as KubbFile from '@kubb/fs/types'
 import type { Exclude, Include, Override, ResolvePathOptions } from '@kubb/plugin-oas'
+import type { ts } from '@kubb/parser-ts'
 
 export type Options = {
   output?: {
@@ -93,6 +94,17 @@ export type Options = {
    * Export an Oas object as Oas type with `import type { Infer } from '@kubb/swagger-ts/oas'`
    */
   oasType?: 'infer' | false
+  /**
+   * @example
+   * Use https://ts-ast-viewer.com to generate factory code(see createPropertySignature)
+   * category: factory.createPropertySignature(
+   *   undefined,
+   *   factory.createIdentifier("category"),
+   *   factory.createToken(ts.SyntaxKind.QuestionToken),
+   *   factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword)
+   * )
+   */
+  mapper?: Record<string, ts.PropertySignature>
 }
 
 type ResolvedOptions = {
@@ -105,6 +117,7 @@ type ResolvedOptions = {
   transformers: NonNullable<Options['transformers']>
   oasType: NonNullable<Options['oasType']>
   usedEnumNames: Record<string, number>
+  mapper: NonNullable<Options['mapper']>
 }
 
 export type FileMeta = {

--- a/packages/swagger-zod/src/types.ts
+++ b/packages/swagger-zod/src/types.ts
@@ -131,7 +131,7 @@ type ResolvedOptions = {
   typed: NonNullable<Options['typed']>
   typedSchema: NonNullable<Options['typedSchema']>
   templates: NonNullable<Templates>
-  mapper: Record<string, string>
+  mapper: NonNullable<Options['mapper']>
   importPath: NonNullable<Options['importPath']>
   coercion: NonNullable<Options['coercion']>
 }


### PR DESCRIPTION
Defining a custom mapper for TypeScript cannot work with strings(behind the scenes we are using the TypeScript factory, see https://www.kubb.dev/plugins/parser-ts/).

Most of the time, the OpenAPI file is incorrect and needs a change(manually or the provider made a mistake and needs to update the OpenAPI file) but in some cases, you want to override the generated type. 

To make that possible I added the `mapper` functionality like we have been using for `zod` and `faker` with one change: you need to return a `PropertySignature`(see `factory.createPropertySignature`).

> Use https://ts-ast-viewer.com/#code/C4TwDgpgBAKhDOwoF4oG8BQVtQMYENgIBzAewCcQB+ALikXIEsA7YjAXyA as an example of how to return the factory code from a TypeScript file.


```
import { defineConfig } from '@kubb/core'
import { pluginOas } from '@kubb/plugin-oas'
import { pluginTs } from '@kubb/swagger-ts'
import ts, { factory } from 'typescript'

export default defineConfig({
  root: '.',
  input: {
    path: './petStore.yaml',
  },
  output: {
    path: './src/gen',
    clean: true,
  },
  plugins: [
    pluginOas({ validate: false }),
    pluginTs({
      output: {
        path: 'ts/models',
      },
      mapper: {
        category: factory.createPropertySignature(
          undefined,
          factory.createIdentifier('category'),
          factory.createToken(ts.SyntaxKind.QuestionToken),
          factory.createKeywordTypeNode(ts.SyntaxKind.StringKeyword),
        ),
      },
    }),
  ],
})
```