### PR TITLE
feat(swagger-zodios): add support for includeOperationIdAsAlias option

### DIFF
--- a/.changeset/popular-tigers-float.md
+++ b/.changeset/popular-tigers-float.md
@@ -1,0 +1,5 @@
+---
+"@kubb/swagger-zodios": minor
+---
+
+Add includeOperationIdAsAlias option to swagger-zodios plugin

--- a/packages/swagger-zodios/src/OperationGenerator.test.tsx
+++ b/packages/swagger-zodios/src/OperationGenerator.test.tsx
@@ -1,0 +1,105 @@
+import { mockedPluginManager } from '@kubb/core/mocks'
+
+import { OperationGenerator } from './OperationGenerator.tsx'
+
+import type { Plugin } from '@kubb/core'
+import type { GetOperationGeneratorOptions } from '@kubb/plugin-oas'
+import { parseFromConfig } from '@kubb/plugin-oas/utils'
+import type { PluginZodios } from './types.ts'
+import { Oas } from '@kubb/plugin-oas/components'
+import { App } from '@kubb/react'
+import { createRootServer } from '@kubb/react/server'
+import { Definitions } from './components/Definitions.tsx'
+
+describe('OperationGenerator', async () => {
+  const oas = await parseFromConfig({
+    root: './',
+    output: {
+      path: 'test',
+      clean: true,
+    },
+    input: { path: 'packages/swagger-zodios/mocks/petStore.yaml' },
+  })
+
+  test('includes an alias property when includeOperationIdAsAlias is true', async () => {
+    const options: GetOperationGeneratorOptions<OperationGenerator> = {
+      baseURL: '',
+      includeOperationIdAsAlias: true,
+      name: 'example',
+    }
+    const plugin = { options } as Plugin<PluginZodios>
+
+    const generator = new OperationGenerator(options, {
+      oas,
+      exclude: [],
+      include: [{ type: 'operationId', pattern: 'listPets' }],
+      pluginManager: mockedPluginManager,
+      plugin,
+      contentType: undefined,
+      override: undefined,
+      mode: 'split',
+    })
+
+    // Need to build to set the operationsByMethod
+    generator.build()
+
+    const operation = oas.operation('/pets', 'get')
+
+    const Component = () => {
+      return (
+        <App plugin={plugin} pluginManager={mockedPluginManager} mode="split">
+          <Oas oas={oas} operations={[operation]} generator={generator}>
+            <Oas.Operation operation={operation}>
+              <Definitions.File operationsByMethod={generator.operationsByMethod} {...options} />
+            </Oas.Operation>
+          </Oas>
+        </App>
+      )
+    }
+    const root = createRootServer({ logger: mockedPluginManager.logger })
+    const output = await root.renderToString(<Component />)
+
+    expect(output).toMatchSnapshot()
+  })
+
+  test('does not include an alias property when includeOperationIdAsAlias is false', async () => {
+    const options: GetOperationGeneratorOptions<OperationGenerator> = {
+      baseURL: '',
+      includeOperationIdAsAlias: false,
+      name: 'example',
+    }
+    const plugin = { options } as Plugin<PluginZodios>
+
+    const generator = new OperationGenerator(options, {
+      oas,
+      exclude: [],
+      include: [{ type: 'operationId', pattern: 'listPets' }],
+      pluginManager: mockedPluginManager,
+      plugin,
+      contentType: undefined,
+      override: undefined,
+      mode: 'split',
+    })
+
+    // Need to build to set the operationsByMethod
+    generator.build()
+
+    const operation = oas.operation('/pets', 'get')
+
+    const Component = () => {
+      return (
+        <App plugin={plugin} pluginManager={mockedPluginManager} mode="split">
+          <Oas oas={oas} operations={[operation]} generator={generator}>
+            <Oas.Operation operation={operation}>
+              <Definitions.File operationsByMethod={generator.operationsByMethod} {...options} />
+            </Oas.Operation>
+          </Oas>
+        </App>
+      )
+    }
+    const root = createRootServer({ logger: mockedPluginManager.logger })
+    const output = await root.renderToString(<Component />)
+
+    expect(output).toMatchSnapshot()
+  })
+})

--- a/packages/swagger-zodios/src/OperationGenerator.tsx
+++ b/packages/swagger-zodios/src/OperationGenerator.tsx
@@ -19,7 +19,12 @@ export class OperationGenerator extends Generator<PluginZodios['resolvedOptions'
     root.render(
       <App pluginManager={pluginManager} plugin={plugin} mode={mode}>
         <Oas oas={oas} operations={operations} generator={this}>
-          <Definitions.File name={this.options.name} baseURL={this.options.baseURL} operationsByMethod={operationsByMethod} />
+          <Definitions.File
+            name={this.options.name}
+            baseURL={this.options.baseURL}
+            operationsByMethod={operationsByMethod}
+            includeOperationIdAsAlias={this.options.includeOperationIdAsAlias}
+          />
         </Oas>
       </App>,
     )

--- a/packages/swagger-zodios/src/__snapshots__/OperationGenerator.test.tsx.snap
+++ b/packages/swagger-zodios/src/__snapshots__/OperationGenerator.test.tsx.snap
@@ -1,0 +1,52 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`OperationGenerator > does not include an alias property when includeOperationIdAsAlias is false 1`] = `
+"export const endpoints = makeApi([
+  {
+    method: 'get',
+    path: '/pets',
+    description: \`\`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'limit',
+        description: \`How many items to return at one time (max 100)\`,
+        type: 'Query',
+        schema: ListPetsQueryParams.unwrap().shape['limit'],
+      },
+    ],
+    response: ListPetsQueryResponse,
+    errors: [],
+  },
+])
+export const getAPI = (baseUrl: string) => new Zodios(baseUrl, endpoints)
+export const api = new Zodios(endpoints)
+export default api
+"
+`;
+
+exports[`OperationGenerator > includes an alias property when includeOperationIdAsAlias is true 1`] = `
+"export const endpoints = makeApi([
+  {
+    method: 'get',
+    path: '/pets',
+    alias: 'listPets',
+    description: \`\`,
+    requestFormat: 'json',
+    parameters: [
+      {
+        name: 'limit',
+        description: \`How many items to return at one time (max 100)\`,
+        type: 'Query',
+        schema: ListPetsQueryParams.unwrap().shape['limit'],
+      },
+    ],
+    response: ListPetsQueryResponse,
+    errors: [],
+  },
+])
+export const getAPI = (baseUrl: string) => new Zodios(baseUrl, endpoints)
+export const api = new Zodios(endpoints)
+export default api
+"
+`;

--- a/packages/swagger-zodios/src/components/Definitions.tsx
+++ b/packages/swagger-zodios/src/components/Definitions.tsx
@@ -36,6 +36,7 @@ const defaultTemplates = { default: Template } as const
 
 type Props = {
   baseURL: string | undefined
+  includeOperationIdAsAlias: boolean
   /**
    * @deprecated
    */
@@ -46,7 +47,7 @@ type Props = {
   Template?: React.ComponentType<React.ComponentProps<typeof Template>>
 }
 
-export function Definitions({ baseURL, operationsByMethod, Template = defaultTemplates.default }: Props): ReactNode {
+export function Definitions({ baseURL, operationsByMethod, Template = defaultTemplates.default, includeOperationIdAsAlias }: Props): ReactNode {
   const { pluginManager } = useApp<PluginZodios>()
   const definitions = getDefinitions(operationsByMethod, {
     resolveName: pluginManager.resolveName,
@@ -58,21 +59,24 @@ export function Definitions({ baseURL, operationsByMethod, Template = defaultTem
       name={'api'}
       baseURL={baseURL}
       definitions={definitions.map(({ errors, response, operation, parameters }) => {
-        return `
-        {
-          method: "${operation.method}",
-          path: "${new URLPath(operation.path).URL}",
-          description: \`${transformers.escape(operation.getDescription())}\`,
-          requestFormat: "json",
-          parameters: [
-              ${parameters.join(',')}
-          ],
-          response: ${response},
-          errors: [
-              ${errors.join(',')}
-          ],
-      }
-      `
+        const template = `
+    {
+      method: "${operation.method}",
+      path: "${new URLPath(operation.path).URL}",
+      ${includeOperationIdAsAlias ? `alias: "${operation.getOperationId()}",\n` : ''}
+      description: \`${transformers.escape(operation.getDescription())}\`,
+      requestFormat: "json",
+      parameters: [
+          ${parameters.join(',')}
+      ],
+      response: ${response},
+      errors: [
+          ${errors.join(',')}
+      ],
+    }
+    `
+        // remove empty lines from conditional property rendering
+        return template.replace(/^\s*[\r\n]/gm, '').trim()
       })}
     />
   )
@@ -81,6 +85,7 @@ export function Definitions({ baseURL, operationsByMethod, Template = defaultTem
 type FileProps = {
   name: string
   baseURL: string | undefined
+  includeOperationIdAsAlias: boolean | undefined
   /**
    * @deprecated
    */
@@ -91,12 +96,11 @@ type FileProps = {
   templates?: typeof defaultTemplates
 }
 
-Definitions.File = function ({ name, baseURL, operationsByMethod, templates = defaultTemplates }: FileProps): ReactNode {
+Definitions.File = function ({ name, baseURL, operationsByMethod, templates = defaultTemplates, includeOperationIdAsAlias = false }: FileProps): ReactNode {
   const {
     pluginManager,
     plugin: { key: pluginKey },
   } = useApp<PluginZodios>()
-
   const file = pluginManager.getFile({ name, extName: '.ts', pluginKey })
 
   const definitionsImports = getDefinitionsImports(operationsByMethod, {
@@ -123,7 +127,7 @@ Definitions.File = function ({ name, baseURL, operationsByMethod, templates = de
         <File.Import name={['makeApi', 'Zodios']} path="@zodios/core" />
         {imports}
         <File.Source>
-          <Definitions Template={Template} operationsByMethod={operationsByMethod} baseURL={baseURL} />
+          <Definitions Template={Template} operationsByMethod={operationsByMethod} baseURL={baseURL} includeOperationIdAsAlias={includeOperationIdAsAlias} />
         </File.Source>
       </File>
     </Parser>

--- a/packages/swagger-zodios/src/plugin.ts
+++ b/packages/swagger-zodios/src/plugin.ts
@@ -54,7 +54,7 @@ export const pluginZodios = createPlugin<PluginZodios>((options) => {
         {
           name: trimExtName(output.path),
           baseURL,
-          includeOperationIdAsAlias: this.plugin.options.includeOperationIdAsAlias ?? false,
+          includeOperationIdAsAlias: options.output?.includeOperationIdAsAlias ?? false,
         },
         {
           oas,

--- a/packages/swagger-zodios/src/plugin.ts
+++ b/packages/swagger-zodios/src/plugin.ts
@@ -22,6 +22,7 @@ export const pluginZodios = createPlugin<PluginZodios>((options) => {
     options: {
       name: trimExtName(output.path),
       baseURL: undefined,
+      includeOperationIdAsAlias: false,
     },
     pre: [pluginOasName, pluginZodName],
     resolvePath(baseName) {
@@ -53,6 +54,7 @@ export const pluginZodios = createPlugin<PluginZodios>((options) => {
         {
           name: trimExtName(output.path),
           baseURL,
+          includeOperationIdAsAlias: this.plugin.options.includeOperationIdAsAlias ?? false,
         },
         {
           oas,

--- a/packages/swagger-zodios/src/types.ts
+++ b/packages/swagger-zodios/src/types.ts
@@ -22,18 +22,19 @@ export type Options = {
      * @default `'barrel'`
      */
     exportType?: 'barrel' | 'barrelNamed' | false
+    /**
+     * Include `alias` in the generated endpoints, allowing for usage such as `apiClient.getUserById()`
+     *
+     * Defaults to the `operationId` in the OpenAPI file document for a given route. If no `operationId` is defined, it will be generated.
+     * @default `false`
+     */
+    includeOperationIdAsAlias: boolean | undefined
   }
 }
 
 type ResolveOptions = {
   baseURL: string | undefined
   name: string
-  /**
-   * Include `alias` in the generated endpoints, allowing for usage such as `apiClient.getUserById()`
-   *
-   * Defaults to the `operationId` in the OpenAPI file document for a given route. If no `operationId` is defined, it will be generated.
-   * @default `false`
-   */
   includeOperationIdAsAlias: boolean | undefined
 }
 

--- a/packages/swagger-zodios/src/types.ts
+++ b/packages/swagger-zodios/src/types.ts
@@ -28,6 +28,13 @@ export type Options = {
 type ResolveOptions = {
   baseURL: string | undefined
   name: string
+  /**
+   * Include `alias` in the generated endpoints, allowing for usage such as `apiClient.getUserById()`
+   *
+   * Defaults to the `operationId` in the OpenAPI file document for a given route. If no `operationId` is defined, it will be generated.
+   * @default `false`
+   */
+  includeOperationIdAsAlias: boolean | undefined
 }
 
 export type FileMeta = {

--- a/packages/swagger-zodios/src/types.ts
+++ b/packages/swagger-zodios/src/types.ts
@@ -28,7 +28,7 @@ export type Options = {
      * Defaults to the `operationId` in the OpenAPI file document for a given route. If no `operationId` is defined, it will be generated.
      * @default `false`
      */
-    includeOperationIdAsAlias: boolean | undefined
+    includeOperationIdAsAlias?: boolean | undefined
   }
 }
 


### PR DESCRIPTION
Just a quick idea backwards compatible idea to make zodios slightly more friendly. This allows for `apiClient.someOperationId()` instead of `apiClient.path("/something/:id/nested/path/thing", {})`.