### PR TITLE
bugfix(msw): including extName when generating operations files

### DIFF
--- a/packages/swagger-msw/src/components/Operations.tsx
+++ b/packages/swagger-msw/src/components/Operations.tsx
@@ -24,7 +24,11 @@ type ParserTemplateProps = {
 function RootTemplate({ children }: ParserTemplateProps) {
   const {
     pluginManager,
-    plugin: { key: pluginKey },
+    plugin: {
+      key: pluginKey,
+      options: { extName },
+    },
+
   } = useApp<PluginMsw>()
 
   const { getName, getFile } = useOperationManager()
@@ -37,7 +41,7 @@ function RootTemplate({ children }: ParserTemplateProps) {
       const operationFile = getFile(operation, { pluginKey })
       const operationName = getName(operation, { pluginKey, type: 'function' })
 
-      return <File.Import key={operationFile.path} name={[operationName]} root={file.path} path={operationFile.path} />
+      return <File.Import extName={extName} key={operationFile.path} name={[operationName]} root={file.path} path={operationFile.path} />
     })
     .filter(Boolean)
 


### PR DESCRIPTION
When the package is of type "module", all imports must have a file extension. The msw plugin currently does not include the `extName` when generating operations files.