### PR TITLE
Include 'null' in list of valid types

### DIFF
--- a/.changeset/sweet-grapes-listen.md
+++ b/.changeset/sweet-grapes-listen.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-oas": patch
+---
+
+Include 'null' in list of valid types

--- a/packages/plugin-oas/src/SchemaGenerator.ts
+++ b/packages/plugin-oas/src/SchemaGenerator.ts
@@ -807,7 +807,7 @@ export abstract class SchemaGenerator<
         ].filter(Boolean)
       }
 
-      if (!['boolean', 'object', 'number', 'string', 'integer'].includes(schema.type)) {
+      if (!['boolean', 'object', 'number', 'string', 'integer', 'null'].includes(schema.type)) {
         this.context.pluginManager.logger.emit('warning', `Schema type '${schema.type}' is not valid for schema ${parentName}.${name}`)
       }
 


### PR DESCRIPTION
`type: "null"` is a valid type in OAS 3.1, but this line will result in a warning if it's used.