### PR TITLE
fix: update faker.image.imageUrl to faker.image.url

### DIFF
--- a/examples/advanced/src/gen/mocks/petController/createUploadFile.ts
+++ b/examples/advanced/src/gen/mocks/petController/createUploadFile.ts
@@ -24,7 +24,7 @@ export function createUploadFile200() {
 }
 
 export function createUploadFileMutationRequest() {
-  return faker.image.imageUrl() as unknown as Blob
+  return faker.image.url() as unknown as Blob
 }
 
 /**

--- a/examples/msw/src/gen/mocks/petMocks/createUploadFile.ts
+++ b/examples/msw/src/gen/mocks/petMocks/createUploadFile.ts
@@ -28,7 +28,7 @@ export function createUploadFile200() {
 
 export function createUploadFileMutationRequest() {
   faker.seed([220])
-  return faker.image.imageUrl() as unknown as Blob
+  return faker.image.url() as unknown as Blob
 }
 
 /**

--- a/packages/plugin-faker/src/parser/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-faker/src/parser/__snapshots__/index.test.ts.snap
@@ -14,7 +14,7 @@ exports[`faker parse > 'arrayRef' 1`] = `"faker.helpers.arrayElements([Pet()]) a
 
 exports[`faker parse > 'arrayRegex' 1`] = `"faker.helpers.arrayElements([faker.helpers.fromRegExp(new RegExp('^[a-zA-Z0-9]{1,13}$')), faker.string.alpha()]) as any"`;
 
-exports[`faker parse > 'blob' 1`] = `"faker.image.imageUrl() as unknown as Blob"`;
+exports[`faker parse > 'blob' 1`] = `"faker.image.url() as unknown as Blob"`;
 
 exports[`faker parse > 'boolean' 1`] = `"faker.datatype.boolean()"`;
 

--- a/packages/plugin-faker/src/parser/index.ts
+++ b/packages/plugin-faker/src/parser/index.ts
@@ -117,7 +117,7 @@ const fakerKeywordMapper = {
   lastName: () => 'faker.person.lastName()',
   password: () => 'faker.internet.password()',
   phone: () => 'faker.phone.number()',
-  blob: () => 'faker.image.imageUrl() as unknown as Blob',
+  blob: () => 'faker.image.url() as unknown as Blob',
   default: undefined,
   describe: undefined,
   const: (value?: string | number) => (value as string) ?? '',


### PR DESCRIPTION
Looks like the [faker image docs](https://fakerjs.dev/api/image#url) indicate the correct call is `url()` instead of `imageUrl()`?