### PR TITLE
fix: Enums should use `z.literal` when format is set to number, string, boolean

### DIFF
--- a/.changeset/thirty-tomatoes-change.md
+++ b/.changeset/thirty-tomatoes-change.md
@@ -1,0 +1,6 @@
+---
+"@kubb/plugin-oas": patch
+"@kubb/plugin-zod": patch
+---
+
+Enums should use `z.literal` when format is set to number, string or boolean

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,22 @@ title: Changelog
 
 ## 3.0.0-alpha.21
 - [`plugin-faker`](/plugins/plugin-faker): use of `faker.image.url()` instead of `faker.image.imageUrl()`
+- [`plugin-zod`](/plugins/plugin-zod): Enums should use `z.literal` when format is set to number, string or boolean
+::: code-group
+
+``` [input]
+enum:
+  type: boolean
+  enum:
+    - true
+    - false
+```
+``` [output]
+z.enum(["true", "false"]) // [!code --]
+z.union([z.literal(true), z.literal(false)]) // [!code ++]
+```
+:::
+
 
 ## 3.0.0-alpha.20
 

--- a/packages/core/src/transformers/stringify.ts
+++ b/packages/core/src/transformers/stringify.ts
@@ -1,6 +1,6 @@
 import { trimQuotes } from './trim'
 
-export function stringify(value: string | number | undefined): string {
+export function stringify(value: string | number | boolean | undefined): string {
   if (value === undefined || value === null) {
     return '""'
   }

--- a/packages/parser-ts/src/factory.ts
+++ b/packages/parser-ts/src/factory.ts
@@ -553,3 +553,5 @@ export const createNull = factory.createNull
 export const createIdentifier = factory.createIdentifier
 
 export const createTupleTypeNode = factory.createTupleTypeNode
+export const createTrue = factory.createTrue
+export const createFalse = factory.createFalse

--- a/packages/plugin-faker/src/parser/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-faker/src/parser/__snapshots__/index.test.ts.snap
@@ -30,6 +30,8 @@ exports[`faker parse > 'default' 2`] = `undefined`;
 
 exports[`faker parse > 'enum' 1`] = `"faker.helpers.arrayElement<any>(["A", "B", "C", 2])"`;
 
+exports[`faker parse > 'enumLiteralBoolean' 1`] = `"faker.helpers.arrayElement<any>(["true", "false"])"`;
+
 exports[`faker parse > 'integer' 1`] = `"faker.number.int()"`;
 
 exports[`faker parse > 'matches' 1`] = `"faker.helpers.fromRegExp(new RegExp('^[A-Z]{2}$'))"`;

--- a/packages/plugin-oas/mocks/petStore.yaml
+++ b/packages/plugin-oas/mocks/petStore.yaml
@@ -118,6 +118,11 @@ components:
           additionalProperties:
             x-nullable: true
             type: string
+        enumLiteral:
+          type: boolean
+          enum:
+            - true
+            - false
     Pets:
       type: array
       items:

--- a/packages/plugin-oas/mocks/schemas.ts
+++ b/packages/plugin-oas/mocks/schemas.ts
@@ -158,7 +158,29 @@ const basic: Array<{ name: string; schema: Schema }> = [
       },
     },
   },
-
+  {
+    name: 'enumLiteralBoolean',
+    schema: {
+      keyword: schemaKeywords.enum,
+      args: {
+        asConst: true,
+        items: [
+          {
+            format: 'boolean',
+            name: 'true',
+            value: true,
+          },
+          {
+            format: 'boolean',
+            name: 'false',
+            value: false,
+          },
+        ],
+        name: 'PetEnumLiteral',
+        typeName: 'PetEnumLiteral',
+      },
+    },
+  },
   {
     name: 'tuple',
     schema: {

--- a/packages/plugin-oas/src/SchemaGenerator.ts
+++ b/packages/plugin-oas/src/SchemaGenerator.ts
@@ -618,6 +618,35 @@ export class SchemaGenerator<
         ]
       }
 
+      if (schema.type === 'boolean') {
+        // we cannot use z.enum when enum type is boolean
+        const enumNames = extensionEnums[0]?.find((item) => isKeyword(item, schemaKeywords.enum)) as unknown as SchemaKeywordMapper['enum']
+        return [
+          {
+            keyword: schemaKeywords.enum,
+            args: {
+              name: enumName,
+              typeName,
+              asConst: true,
+              items: enumNames?.args?.items
+                ? [...new Set(enumNames.args.items)].map(({ name, value }) => ({
+                    name,
+                    value,
+                    format: 'boolean',
+                  }))
+                : [...new Set(filteredValues)].map((value: string) => {
+                    return {
+                      name: value,
+                      value,
+                      format: 'boolean',
+                    }
+                  }),
+            },
+          },
+          ...baseItems.filter((item) => item.keyword !== schemaKeywords.matches),
+        ]
+      }
+
       if (extensionEnums.length > 0 && extensionEnums[0]) {
         return extensionEnums[0]
       }

--- a/packages/plugin-oas/src/SchemaMapper.ts
+++ b/packages/plugin-oas/src/SchemaMapper.ts
@@ -34,8 +34,8 @@ export type SchemaKeywordMapper = {
       asConst: boolean
       items: Array<{
         name: string | number
-        format: 'string' | 'number'
-        value?: string | number
+        format: 'string' | 'number' | 'boolean'
+        value?: string | number | boolean
       }>
     }
   }
@@ -44,8 +44,8 @@ export type SchemaKeywordMapper = {
     keyword: 'const'
     args: {
       name: string | number
-      format: 'string' | 'number'
-      value?: string | number
+      format: 'string' | 'number' | 'boolean'
+      value?: string | number | boolean
     }
   }
   union: { keyword: 'union'; args: Schema[] }

--- a/packages/plugin-oas/src/__snapshots__/SchemaGenerator.test.ts.snap
+++ b/packages/plugin-oas/src/__snapshots__/SchemaGenerator.test.ts.snap
@@ -33,6 +33,42 @@ exports[`SchemaGenerator core > 'Pet' 1`] = `
     "args": {
       "additionalProperties": [],
       "properties": {
+        "enumLiteral": [
+          {
+            "args": {
+              "asConst": true,
+              "items": [
+                {
+                  "format": "boolean",
+                  "name": true,
+                  "value": true,
+                },
+                {
+                  "format": "boolean",
+                  "name": false,
+                  "value": false,
+                },
+              ],
+              "name": "PetEnumLiteral",
+              "typeName": "PetEnumLiteral",
+            },
+            "keyword": "enum",
+          },
+          {
+            "args": {
+              "format": undefined,
+              "type": "boolean",
+            },
+            "keyword": "schema",
+          },
+          {
+            "args": "enumLiteral",
+            "keyword": "name",
+          },
+          {
+            "keyword": "optional",
+          },
+        ],
         "id": [
           {
             "keyword": "integer",

--- a/packages/plugin-ts/src/parser/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-ts/src/parser/__snapshots__/index.test.ts.snap
@@ -444,6 +444,36 @@ NodeObject {
 }
 `;
 
+exports[`type parse > 'enumLiteralBoolean' 1`] = `
+NodeObject {
+  "emitNode": undefined,
+  "end": -1,
+  "flags": 16,
+  "id": 0,
+  "kind": 183,
+  "modifierFlagsCache": 0,
+  "original": undefined,
+  "parent": undefined,
+  "pos": -1,
+  "transformFlags": 1,
+  "typeArguments": undefined,
+  "typeName": IdentifierObject {
+    "emitNode": undefined,
+    "end": -1,
+    "escapedText": "PetEnumLiteral",
+    "flags": 16,
+    "flowNode": undefined,
+    "id": 0,
+    "jsDoc": undefined,
+    "kind": 80,
+    "parent": undefined,
+    "pos": -1,
+    "symbol": undefined,
+    "transformFlags": 0,
+  },
+}
+`;
+
 exports[`type parse > 'integer' 1`] = `
 TokenObject {
   "emitNode": undefined,

--- a/packages/plugin-ts/src/parser/index.ts
+++ b/packages/plugin-ts/src/parser/index.ts
@@ -54,12 +54,20 @@ export const typeKeywordMapper = {
       nodes,
     })
   },
-  const: (name?: string | number, format?: 'string' | 'number') => {
+  const: (name?: string | number | boolean, format?: 'string' | 'number' | 'boolean') => {
     if (!name) {
       return undefined
     }
 
-    if (format === 'number') {
+    if (format === 'boolean') {
+      if (name === true) {
+        return factory.createLiteralTypeNode(factory.createTrue())
+      }
+
+      return factory.createLiteralTypeNode(factory.createFalse())
+    }
+
+    if (format === 'number' && typeof name === 'number') {
       return factory.createLiteralTypeNode(factory.createNumericLiteral(name))
     }
 

--- a/packages/plugin-zod/mocks/enums3_1.yaml
+++ b/packages/plugin-zod/mocks/enums3_1.yaml
@@ -13,6 +13,15 @@ components:
       - Pending
       - Received
       - null
+    enumBooleanLiteral:
+      type: boolean
+      enum:
+        - true
+        - false
+    enumSingleLiteral:
+      type: number
+      enum:
+        - 0
 
 paths:
   /var-names:

--- a/packages/plugin-zod/src/generators/__snapshots__/enumBooleanLiteral.ts
+++ b/packages/plugin-zod/src/generators/__snapshots__/enumBooleanLiteral.ts
@@ -1,0 +1,3 @@
+import { z } from "zod";
+
+ export const enumBooleanLiteral = z.union([z.literal(true), z.literal(false)]);

--- a/packages/plugin-zod/src/generators/__snapshots__/enumSingleLiteral.ts
+++ b/packages/plugin-zod/src/generators/__snapshots__/enumSingleLiteral.ts
@@ -1,0 +1,3 @@
+import { z } from "zod";
+
+ export const enumSingleLiteral = z.literal(0);

--- a/packages/plugin-zod/src/generators/zodGenerator.test.tsx
+++ b/packages/plugin-zod/src/generators/zodGenerator.test.tsx
@@ -154,6 +154,18 @@ describe('zodGenerator schema', async () => {
       options: {},
     },
     {
+      name: 'enumBooleanLiteral',
+      path: 'enumBooleanLiteral',
+      input: '../../mocks/enums3_1.yaml',
+      options: {},
+    },
+    {
+      name: 'enumSingleLiteral',
+      path: 'enumSingleLiteral',
+      input: '../../mocks/enums3_1.yaml',
+      options: {},
+    },
+    {
       name: 'Recursive',
       path: 'Example',
       input: '../../mocks/recursive.yaml',

--- a/packages/plugin-zod/src/parser/__snapshots__/index.test.ts.snap
+++ b/packages/plugin-zod/src/parser/__snapshots__/index.test.ts.snap
@@ -30,6 +30,8 @@ exports[`zod parse > 'default' 2`] = `".default(default)"`;
 
 exports[`zod parse > 'enum' 1`] = `"z.enum(["A", "B", "C", "2"])"`;
 
+exports[`zod parse > 'enumLiteralBoolean' 1`] = `"z.union([z.literal(true), z.literal(false)])"`;
+
 exports[`zod parse > 'integer' 1`] = `"z.number().int()"`;
 
 exports[`zod parse > 'matches' 1`] = `".regex(new RegExp('^[A-Z]{2}$'))"`;


### PR DESCRIPTION
``` [input]
enum:
  type: boolean
  enum:
    - true
    - false
```
becomes
``` [output]
z.enum(["true", "false"]) // [!code --]
z.union([z.literal(true), z.literal(false)]) // [!code ++]
```