### PR TITLE
fix: add missing freeform object definition to plugin-oas schema generator

### DIFF
--- a/.changeset/poor-candles-wash.md
+++ b/.changeset/poor-candles-wash.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-oas": patch
+---
+
+Take care of turning `additionalProperties: {}` to a correct freeform object type (#1232)

--- a/packages/plugin-oas/src/SchemaGenerator.ts
+++ b/packages/plugin-oas/src/SchemaGenerator.ts
@@ -302,7 +302,7 @@ export class SchemaGenerator<
 
     if (additionalProperties) {
       additionalPropertiesSchemas =
-        additionalProperties === true
+        additionalProperties === true || !Object.keys(additionalProperties).length
           ? [{ keyword: this.#getUnknownReturn({ schema, name }) }]
           : this.parse({ schema: additionalProperties as SchemaObject, parentName: name })
     }


### PR DESCRIPTION
closes #1232 