### PR TITLE
fix: discard optional if default inside nested objects

### DIFF
--- a/packages/plugin-zod/mocks/petStore.yaml
+++ b/packages/plugin-zod/mocks/petStore.yaml
@@ -20,6 +20,12 @@ paths:
           required: false
           schema:
             type: string
+        - name: offset
+          in: query
+          required: false
+          schema:
+            type: integer
+            default: 0
       responses:
         '200':
           description: A paged array of pets

--- a/packages/plugin-zod/src/generators/__snapshots__/getPets.ts
+++ b/packages/plugin-zod/src/generators/__snapshots__/getPets.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
- export const listPetsQueryParams = z.object({ "limit": z.string().describe("How many items to return at one time (max 100)").optional() }).optional();
+ export const listPetsQueryParams = z.object({ "limit": z.string().describe("How many items to return at one time (max 100)").optional(), "offset": z.number().int().default(0) }).optional();
 
  /**
  * @description A paged array of pets


### PR DESCRIPTION
This is a followup to #1292 as it did not work in nested objects

This PR adds the capability to discard `optional` in nested objects.

I'm not very satisfied with the solution, but i found it hard to find a way to manipulate the AST as it resolves to a string immediately. The issue is that we'd need to make a decision on wether to include the keyword `optional` depending on whether or not `default` shows up before or after. But from the perspective of the `current` keyword there's no way to know about it's siblings.

I didn't want to introduce a refactor, but im open to it if you have some agreement to it.


Two other ways to go about this
1. Introduce a `siblings: Schema[]` to `parse`.
2. Refactor `parse` to output some kind of tree-structure that can then be manipulated after the fact, and before reducing it to a string. Then the tree could be pruned of `optionals` using a Visitor 

