### PR TITLE
Make 'Mutation' configs optional

### DIFF
--- a/packages/plugin-react-query/src/types.ts
+++ b/packages/plugin-react-query/src/types.ts
@@ -110,7 +110,7 @@ export type Options = {
   /**
    * Override some useMutation behaviours.
    */
-  mutation?: Mutation | false
+  mutation?: Partial<Mutation> | false
   /**
    * Which parser should be used before returning the data to `@tanstack/query`.
    * `'zod'` will use `@kubb/plugin-zod` to parse the data.


### PR DESCRIPTION
This is the same as for `Query` etc, since otherwise users always have to specify `key` (which is not the case when specifying `Query` options, and users should not have to)