### PR TITLE
fix: Loosen up ws dependency version constraint

### DIFF
--- a/.changeset/good-zebras-know.md
+++ b/.changeset/good-zebras-know.md
@@ -1,0 +1,5 @@
+---
+"@kubb/react": patch
+---
+
+fix: Loosen up ws dependency version constraint

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -91,7 +91,7 @@
     "react-devtools-core": "^5.3.2",
     "react-reconciler": "^0.29.2",
     "signal-exit": "^4.1.0",
-    "ws": "8.15.0"
+    "ws": "^8.15.0"
   },
   "devDependencies": {
     "@kubb/config-ts": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1718,8 +1718,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0
       ws:
-        specifier: 8.15.0
-        version: 8.15.0(bufferutil@4.0.8)
+        specifier: ^8.15.0
+        version: 8.18.0(bufferutil@4.0.8)
     devDependencies:
       '@kubb/config-ts':
         specifier: workspace:*


### PR DESCRIPTION
`ws` has a high severity CVE (https://github.com/advisories/GHSA-3h5v-q93c-6h6q), but kubb pins to a vulnerable version. So this loosens up the version constraint to allow patched versions.