### PR TITLE
chore: update `plugin-oas` examples to use empty generators

### DIFF
--- a/e2e/kubb.config.js
+++ b/e2e/kubb.config.js
@@ -45,7 +45,7 @@ const baseConfig = {
   },
   plugins: [
     pluginOas({
-      output: false,
+      generators: [],
       validate: false,
       docs: false,
     }),

--- a/examples/msw/kubb.config.js
+++ b/examples/msw/kubb.config.js
@@ -18,7 +18,7 @@ export default defineConfig(() => {
       done: ['npm run typecheck', 'biome format --write ./', 'biome lint --apply-unsafe ./src'],
     },
     plugins: [
-      pluginOas({ output: false }),
+      pluginOas({ generators: [] }),
       pluginTs({
         output: {
           path: 'models',

--- a/examples/solid-query/kubb.config.js
+++ b/examples/solid-query/kubb.config.js
@@ -17,7 +17,7 @@ export default defineConfig({
   },
   plugins: [
     pluginOas({
-      output: false,
+      generators: [],
     }),
     pluginTs({
       output: { path: 'models' },

--- a/examples/svelte-query/kubb.config.js
+++ b/examples/svelte-query/kubb.config.js
@@ -17,7 +17,7 @@ export default defineConfig({
   },
   plugins: [
     pluginOas({
-      output: false,
+      generators: [],
     }),
     pluginTs({
       output: { path: 'models' },

--- a/examples/swr/kubb.config.js
+++ b/examples/swr/kubb.config.js
@@ -17,7 +17,7 @@ export default defineConfig({
     done: ['npm run typecheck', 'biome format --write ./', 'biome lint --apply-unsafe ./src'],
   },
   plugins: [
-    pluginOas({ output: false }),
+    pluginOas({ generators: [] }),
     pluginTs({
       output: {
         path: 'models',

--- a/examples/zod/kubb.config.js
+++ b/examples/zod/kubb.config.js
@@ -22,7 +22,7 @@ export default defineConfig(async () => {
       // done: ['npm run typecheck', 'biome format --write ./', 'biome lint --apply-unsafe ./src'],
     },
     plugins: [
-      pluginOas({ output: false }),
+      pluginOas({ generators: [] }),
       pluginTs({
         output: {
           path: './ts',


### PR DESCRIPTION
Replace `output: false` with `generators: []` in `plugin-oas` options for all examples that use it.