### PR TITLE
fix: returnType for faker functions

### DIFF
--- a/.changeset/chatty-rats-warn.md
+++ b/.changeset/chatty-rats-warn.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-faker": patch
+---
+
+updating return-type to be non-partial of entering type

--- a/packages/plugin-faker/src/components/Faker.tsx
+++ b/packages/plugin-faker/src/components/Faker.tsx
@@ -71,7 +71,7 @@ export function Faker({ tree, description, name, typeName, seed, regexGenerator,
         name={name}
         JSDoc={{ comments: [description ? `@description ${transformers.jsStringEscape(description)}` : undefined].filter(Boolean) }}
         params={canOverride ? params.toConstructor() : undefined}
-        returnType={canOverride ? `Partial<${typeName}>` : undefined}
+        returnType={canOverride ? typeName : undefined}
       >
         {seed ? `faker.seed(${JSON.stringify(seed)})` : undefined}
         <br />

--- a/packages/plugin-faker/src/generators/__snapshots__/createPet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/createPet.ts
@@ -14,13 +14,13 @@ export function createPetsError() {
   return error()
 }
 
-export function createPetsMutationRequest(data?: Partial<CreatePetsMutationRequest>): Partial<CreatePetsMutationRequest> {
+export function createPetsMutationRequest(data?: Partial<CreatePetsMutationRequest>): CreatePetsMutationRequest {
   return {
     ...{ name: faker.string.alpha(), tag: faker.string.alpha() },
     ...(data || {}),
   }
 }
 
-export function createPetsMutationResponse(data?: Partial<CreatePetsMutationResponse>): Partial<CreatePetsMutationResponse> {
+export function createPetsMutationResponse(data?: Partial<CreatePetsMutationResponse>): CreatePetsMutationResponse {
   return data || faker.helpers.arrayElement<any>([createPets201()])
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/createPetSeed.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/createPetSeed.ts
@@ -16,7 +16,7 @@ export function createPetsError() {
   return error()
 }
 
-export function createPetsMutationRequest(data?: Partial<CreatePetsMutationRequest>): Partial<CreatePetsMutationRequest> {
+export function createPetsMutationRequest(data?: Partial<CreatePetsMutationRequest>): CreatePetsMutationRequest {
   faker.seed([222])
   return {
     ...{ name: faker.string.alpha(), tag: faker.string.alpha() },
@@ -24,7 +24,7 @@ export function createPetsMutationRequest(data?: Partial<CreatePetsMutationReque
   }
 }
 
-export function createPetsMutationResponse(data?: Partial<CreatePetsMutationResponse>): Partial<CreatePetsMutationResponse> {
+export function createPetsMutationResponse(data?: Partial<CreatePetsMutationResponse>): CreatePetsMutationResponse {
   faker.seed([222])
   return data || faker.helpers.arrayElement<any>([createPets201()])
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/createPetUnknownTypeAny.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/createPetUnknownTypeAny.ts
@@ -14,13 +14,13 @@ export function createPetsError() {
   return error()
 }
 
-export function createPetsMutationRequest(data?: Partial<CreatePetsMutationRequest>): Partial<CreatePetsMutationRequest> {
+export function createPetsMutationRequest(data?: Partial<CreatePetsMutationRequest>): CreatePetsMutationRequest {
   return {
     ...{ name: faker.string.alpha(), tag: faker.string.alpha() },
     ...(data || {}),
   }
 }
 
-export function createPetsMutationResponse(data?: Partial<CreatePetsMutationResponse>): Partial<CreatePetsMutationResponse> {
+export function createPetsMutationResponse(data?: Partial<CreatePetsMutationResponse>): CreatePetsMutationResponse {
   return data || faker.helpers.arrayElement<any>([createPets201()])
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/getPets.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/getPets.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker'
 
-export function listPetsQueryParams(data?: Partial<ListPetsQueryParams>): Partial<ListPetsQueryParams> {
+export function listPetsQueryParams(data?: Partial<ListPetsQueryParams>): ListPetsQueryParams {
   return {
     ...{ limit: faker.string.alpha() },
     ...(data || {}),
@@ -21,6 +21,6 @@ export function listPetsError() {
   return error()
 }
 
-export function listPetsQueryResponse(data?: Partial<ListPetsQueryResponse>): Partial<ListPetsQueryResponse> {
+export function listPetsQueryResponse(data?: Partial<ListPetsQueryResponse>): ListPetsQueryResponse {
   return data || faker.helpers.arrayElement<any>([listPets200()])
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/pet.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/pet.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Partial<Pet> {
+export function pet(data?: Partial<Pet>): Pet {
   return {
     ...{
       id: faker.number.int(),

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithDateString.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithDateString.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Partial<Pet> {
+export function pet(data?: Partial<Pet>): Pet {
   return {
     ...{
       id: faker.number.int(),

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithDayjs.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Partial<Pet> {
+export function pet(data?: Partial<Pet>): Pet {
   return {
     ...{
       id: faker.number.int(),

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithMapper.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithMapper.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Partial<Pet> {
+export function pet(data?: Partial<Pet>): Pet {
   return {
     ...{
       id: faker.string.fromCharacters('abc'),

--- a/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/petWithRandExp.ts
@@ -1,7 +1,7 @@
 import RandExp from 'randexp'
 import { faker } from '@faker-js/faker'
 
-export function pet(data?: Partial<Pet>): Partial<Pet> {
+export function pet(data?: Partial<Pet>): Pet {
   return {
     ...{
       id: faker.number.int(),

--- a/packages/plugin-faker/src/generators/__snapshots__/pets.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/pets.ts
@@ -1,5 +1,5 @@
 import { faker } from '@faker-js/faker'
 
-export function pets(data?: Partial<Pets>): Partial<Pets> {
+export function pets(data?: Partial<Pets>): Pets {
   return [...(faker.helpers.multiple(() => pet()) as any), ...(data || [])]
 }

--- a/packages/plugin-faker/src/generators/__snapshots__/showPetById.ts
+++ b/packages/plugin-faker/src/generators/__snapshots__/showPetById.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker'
 
-export function showPetByIdPathParams(data?: Partial<ShowPetByIdPathParams>): Partial<ShowPetByIdPathParams> {
+export function showPetByIdPathParams(data?: Partial<ShowPetByIdPathParams>): ShowPetByIdPathParams {
   return {
     ...{ petId: faker.string.alpha(), testId: faker.string.alpha() },
     ...(data || {}),
@@ -21,6 +21,6 @@ export function showPetByIdError() {
   return error()
 }
 
-export function showPetByIdQueryResponse(data?: Partial<ShowPetByIdQueryResponse>): Partial<ShowPetByIdQueryResponse> {
+export function showPetByIdQueryResponse(data?: Partial<ShowPetByIdQueryResponse>): ShowPetByIdQueryResponse {
   return data || faker.helpers.arrayElement<any>([showPetById200()])
 }


### PR DESCRIPTION
Following #1548 to update the return type from `Partial<T>` to `T`.