### PR TITLE
fix(plugin-oas): matchers check for any tag

### DIFF
--- a/.changeset/wicked-ligers-repair.md
+++ b/.changeset/wicked-ligers-repair.md
@@ -1,0 +1,28 @@
+---
+"@kubb/cli": patch
+"@kubb/config-biome": patch
+"@kubb/config-ts": patch
+"@kubb/config-tsup": patch
+"@kubb/core": patch
+"@kubb/fs": patch
+"kubb": patch
+"@kubb/oas": patch
+"@kubb/parser-ts": patch
+"@kubb/plugin-client": patch
+"@kubb/plugin-faker": patch
+"@kubb/plugin-msw": patch
+"@kubb/plugin-oas": patch
+"@kubb/plugin-react-query": patch
+"@kubb/plugin-redoc": patch
+"@kubb/plugin-solid-query": patch
+"@kubb/plugin-svelte-query": patch
+"@kubb/plugin-swr": patch
+"@kubb/plugin-ts": patch
+"@kubb/plugin-vue-query": patch
+"@kubb/plugin-zod": patch
+"@kubb/react": patch
+"@kubb/types": patch
+"unplugin-kubb": patch
+---
+
+Including and excluding tags now matches any tag, instead of just the first one.

--- a/packages/plugin-oas/src/OperationGenerator.ts
+++ b/packages/plugin-oas/src/OperationGenerator.ts
@@ -44,7 +44,7 @@ export class OperationGenerator<
     return (
       override.find(({ pattern, type }) => {
         if (type === 'tag') {
-          return !!operation.getTags()[0]?.name.match(pattern)
+          return !!operation.getTags().some((tag) => tag.name.match(pattern))
         }
 
         if (type === 'operationId') {
@@ -70,7 +70,7 @@ export class OperationGenerator<
 
     exclude.forEach(({ pattern, type }) => {
       if (type === 'tag' && !matched) {
-        matched = !!operation.getTags()[0]?.name.match(pattern)
+        matched = !!operation.getTags().some((tag) => tag.name.match(pattern))
       }
 
       if (type === 'operationId' && !matched) {
@@ -95,7 +95,7 @@ export class OperationGenerator<
 
     include.forEach(({ pattern, type }) => {
       if (type === 'tag' && !matched) {
-        matched = !!operation.getTags()[0]?.name.match(pattern)
+        matched = !!operation.getTags().some((tag) => tag.name.match(pattern))
       }
 
       if (type === 'operationId' && !matched) {


### PR DESCRIPTION
This patch fixes an issue where the `include` and `exclude` options only check for the first tag on a path. Instead, we should match on any tag.

Ex: Including the "public" tag will now include any path that has the "public" tag, even if it has other tags.

Ex: Excluding the "public" tag will now exclude any path that has the "public" tag, even if it has other tags.