### PR TITLE
It is possible for discriminated unions to have no properties. This c…

### DIFF
--- a/.changeset/icy-shrimps-find.md
+++ b/.changeset/icy-shrimps-find.md
@@ -1,0 +1,5 @@
+---
+"@kubb/oas": patch
+---
+
+It is possible for discriminated unions to have no properties. This change checks whether the current childSchema has "properties" before continuing execution.

--- a/packages/oas/src/Oas.ts
+++ b/packages/oas/src/Oas.ts
@@ -82,14 +82,16 @@ export class Oas<const TOAS = unknown> extends BaseOas {
             const childSchema = this.get(mappingValue)
             const property = childSchema.properties?.[propertyName] as SchemaObject
 
-            childSchema.properties[propertyName] = {
-              ...childSchema.properties[propertyName],
-              enum: [...(property?.enum?.filter((value) => value !== mappingKey) ?? []), mappingKey],
+            if (childSchema.properties) {
+              childSchema.properties[propertyName] = {
+                ...childSchema.properties[propertyName],
+                enum: [...(property?.enum?.filter((value) => value !== mappingKey) ?? []), mappingKey],
+              }
+
+              childSchema.required = [...(childSchema.required ?? []), propertyName]
+
+              this.set(mappingValue, childSchema)
             }
-
-            childSchema.required = [...(childSchema.required ?? []), propertyName]
-
-            this.set(mappingValue, childSchema)
           }
         })
       }


### PR DESCRIPTION
It is possible for discriminated unions to have no properties. This change checks whether the current childSchema has "properties" before continuing execution.

#1575