### PR TITLE
make setConfig method in fetch.ts client non-required with Partial type

### DIFF
--- a/.changeset/dirty-games-unite.md
+++ b/.changeset/dirty-games-unite.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-client": path
+---
+
+Making setConfig method types non required with Partial

--- a/packages/plugin-client/clients/fetch.ts
+++ b/packages/plugin-client/clients/fetch.ts
@@ -32,7 +32,7 @@ let _config: Partial<RequestConfig> = {}
 
 export const getConfig = () => _config
 
-export const setConfig = (config: RequestConfig) => {
+export const setConfig = (config: Partial<RequestConfig>) => {
   _config = config
   return getConfig()
 }


### PR DESCRIPTION
Improving the last PR even more with Partial type for setConfig method