### PR TITLE
Add missing plugin to Zod plugin example

### DIFF
--- a/docs/plugins/plugin-zod/index.md
+++ b/docs/plugins/plugin-zod/index.md
@@ -301,6 +301,7 @@ wrapOutput: ({ output, schema }) => {
 ```typescript twoslash
 import { defineConfig } from '@kubb/core'
 import { pluginOas } from '@kubb/plugin-oas'
+import { pluginTs } from '@kubb/plugin-ts'
 import { pluginZod } from '@kubb/plugin-zod'
 
 export default defineConfig({
@@ -312,6 +313,7 @@ export default defineConfig({
   },
   plugins: [
     pluginOas(),
+    pluginTs(),
     pluginZod({
       output: {
         path: './zod',


### PR DESCRIPTION
Without `pluginTs`, you get the following error running `kubb generate` if you copy/paste the example:
```
 ERROR  This plugin has a pre set that is not valid([               
  "plugin-oas",
  "plugin-ts"
]) (plugin: plugin-oas, hook: buildStart) (plugin: plugin-oas, hook: buildStart)
```