### PR TITLE
Correct order for null field - Fixes #1584

### DIFF
--- a/packages/plugin-zod/src/parser.ts
+++ b/packages/plugin-zod/src/parser.ts
@@ -155,6 +155,7 @@ export function sort(items?: Schema[]): Schema[] {
     schemaKeywords.password,
     schemaKeywords.matches,
     schemaKeywords.uuid,
+    schemaKeywords.null,
     schemaKeywords.min,
     schemaKeywords.max,
     schemaKeywords.default,
@@ -162,7 +163,6 @@ export function sort(items?: Schema[]): Schema[] {
     schemaKeywords.optional,
     schemaKeywords.nullable,
     schemaKeywords.nullish,
-    schemaKeywords.null,
   ]
 
   if (!items) {


### PR DESCRIPTION
Hi 👋
I've experienced the bug #1584 as well, and had quick glance at the code.
It seems that `null` has the lowest sort order, and thus always comes last. But this seems to be an issue, since keywords that generates methods should always come after keywords that generate objects. Since `null` produces an object and `optional` produces a method, the current result is `.optional()z.null()`.
The fix seems to be to move `null` above the method keywords.

Feel free to merge this pull request, perform the fix yourselves or reject it if I have misunderstood something.

I really appreciate this project a lot and I'm very grateful for its existence. Feel free to reach out to me, if I can help with anything further.