### PR TITLE
fix(plugin-mcp): description generation

### DIFF
--- a/packages/plugin-mcp/mocks/petStore.yaml
+++ b/packages/plugin-mcp/mocks/petStore.yaml
@@ -10,6 +10,7 @@ paths:
   /pets:
     get:
       summary: List all pets
+      description: Returns all `pets` from the system \n that the user has access to
       operationId: listPets
       tags:
         - pets
@@ -21,7 +22,7 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: A paged array of pets
           headers:
             x-next:
@@ -31,15 +32,23 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Pets'
+                $ref: "#/components/schemas/Pets"
         default:
           description: unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
     post:
       summary: Create a pet
+      description: >
+        Creates a pet in the store.
+
+        This is an arbitrary description with lots of `strange` but likely formatting
+        from the real world.
+
+        - We like to make lists
+        - And we need to escape: some, type, of `things`
       operationId: createPets
       tags:
         - pets
@@ -50,22 +59,22 @@ paths:
             schema:
               type: object
               required:
-                - 'name'
-                - 'tag'
+                - "name"
+                - "tag"
               properties:
                 name:
                   type: string
                 tag:
                   type: string
       responses:
-        '201':
+        "201":
           description: Null response
         default:
           description: unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
   /pets/{petId}:
     get:
       summary: Info for a specific pet
@@ -86,18 +95,18 @@ paths:
           schema:
             type: string
       responses:
-        '200':
+        "200":
           description: Expected response to a valid request
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Pet'
+                $ref: "#/components/schemas/Pet"
         default:
           description: unexpected error
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: "#/components/schemas/Error"
 components:
   schemas:
     Pet:
@@ -116,7 +125,7 @@ components:
     Pets:
       type: array
       items:
-        $ref: '#/components/schemas/Pet'
+        $ref: "#/components/schemas/Pet"
     Error:
       type: object
       required:

--- a/packages/plugin-mcp/src/components/Server.tsx
+++ b/packages/plugin-mcp/src/components/Server.tsx
@@ -107,14 +107,14 @@ export function Server({ name, serverName, serverVersion, operations }: Props) {
 
             if (zod.schemas.request?.name || zod.schemas.headerParams?.name || zod.schemas.queryParams?.name || zod.schemas.pathParams?.name) {
               return `
-server.tool('${operationId}', '${description}', ${paramsClient.toObjectValue()}, async (${paramsClient.toObject()}) => {
+server.tool('${operationId}', ${JSON.stringify(description)}, ${paramsClient.toObjectValue()}, async (${paramsClient.toObject()}) => {
   return ${mcp.name}(${paramsClient.toObject()})
 })
           `
             }
 
             return `
-server.tool('${operationId}', '${description}', async () => {
+server.tool('${operationId}', ${JSON.stringify(description)}, async () => {
   return ${mcp.name}(${paramsClient.toObject()})
 })
           `

--- a/packages/plugin-mcp/src/generators/__snapshots__/createPet.ts
+++ b/packages/plugin-mcp/src/generators/__snapshots__/createPet.ts
@@ -3,6 +3,7 @@ import type { ResponseErrorConfig } from '@kubb/plugin-client/clients/axios'
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types'
 
 /**
+ * @description Creates a pet in the store.This is an arbitrary description with lots of `strange` but likely formatting from the real world.- We like to make lists - And we need to escape: some, type, of `things`
  * @summary Create a pet
  * {@link /pets}
  */

--- a/packages/plugin-mcp/src/generators/__snapshots__/getPets.ts
+++ b/packages/plugin-mcp/src/generators/__snapshots__/getPets.ts
@@ -3,6 +3,7 @@ import type { ResponseErrorConfig } from '@kubb/plugin-client/clients/axios'
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types'
 
 /**
+ * @description Returns all `pets` from the system \n that the user has access to
  * @summary List all pets
  * {@link /pets}
  */

--- a/packages/plugin-mcp/src/generators/__snapshots__/server.ts
+++ b/packages/plugin-mcp/src/generators/__snapshots__/server.ts
@@ -11,13 +11,18 @@ export const server = new McpServer({
   version: '3.0.0',
 })
 
-server.tool('listPets', '', { params: listPetsQueryParams }, async ({ params }) => {
+server.tool('listPets', 'Returns all `pets` from the system \\n that the user has access to', { params: listPetsQueryParams }, async ({ params }) => {
   return listPetsHandler({ params })
 })
 
-server.tool('createPets', '', { data: createPetsMutationRequest }, async ({ data }) => {
-  return createPetsHandler({ data })
-})
+server.tool(
+  'createPets',
+  'Creates a pet in the store.\nThis is an arbitrary description with lots of `strange` but likely formatting from the real world.\n- We like to make lists - And we need to escape: some, type, of `things`\n',
+  { data: createPetsMutationRequest },
+  async ({ data }) => {
+    return createPetsHandler({ data })
+  },
+)
 
 server.tool('showPetById', '', { petId: showPetByIdPathParams.shape['petId'], testId: showPetByIdPathParams.shape['testId'] }, async ({ petId, testId }) => {
   return showPetByIdHandler({ petId, testId })


### PR DESCRIPTION
**🗒️ ⚠️ Opening this PR just to start a convo. I don't currently have the 'right' answer.**

While attempting to generate the MCP files on an existing spec with descriptions similar to the ones added in the tests, I ran into issues due to not escaping line breaks and such that you'd typically see for more in-depth `description`s on specs.

I'm honestly not sure of the best way to handle this. I've poked around at a few similar projects and they get around this issue by not generating files and instead declaring them like:

```ts
const tool: Tool = {
          name:
            op.operationId || op.summary || `${method.toUpperCase()} ${path}`,
          description:
            op.description ||
            `Make a ${method.toUpperCase()} request to ${path}`,
          inputSchema: {
            type: "object",
            properties: {},
            // Add any additional properties from OpenAPI spec
          },
        };
```

Nice reference for customizing the mcp generated output: https://www.speakeasy.com/docs/model-context-protocol#configuring-generated-tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced and expanded endpoint and function descriptions throughout the pet store API mock, including detailed multi-line explanations and improved formatting.
  - Updated OpenAPI documentation to standardize string quoting style for consistency.
  - Added comprehensive JSDoc descriptions to relevant handler functions and server tool registrations for improved clarity.

- **Style**
  - Standardized string quoting in API documentation and schema references for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->