### PR TITLE
Fix sponsor button shadow behind navbar.

### DIFF
--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -345,6 +345,7 @@ a.fancy-sponsor {
   background-clip: padding-box, border-box, border-box;
   background-size: 200%;
   animation: spin 2s infinite linear;
+  z-index: 0;
 }
 
 a.fancy-sponsor::before {


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/d3ca92e9-15fe-4c8c-854a-bc7e736b5e9d)

After:
![image](https://github.com/user-attachments/assets/543548da-618c-45c2-bef7-df8711b9f03b)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the `.fancy-sponsor` class to include a stacking order adjustment, which may affect how these elements appear in relation to others on the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->