### PR TITLE
Potential fix for code scanning alert no. 39: Incomplete string escaping or encoding

### DIFF
--- a/packages/fs/src/read.ts
+++ b/packages/fs/src/read.ts
@@ -8,11 +8,11 @@ function slash(path: string, platform: 'windows' | 'mac' | 'linux' = 'linux') {
 
   if (['linux', 'mac'].includes(platform) && !isWindowsPath) {
     // linux and mac
-    return path.replaceAll(/\\/g, '/').replace('../', '').trimEnd()
+    return path.replaceAll(/\\/g, '/').replace(/\.{2}\//g, '').trimEnd()
   }
 
   // windows
-  return path.replaceAll(/\\/g, '/').replace('../', '').trimEnd()
+  return path.replaceAll(/\\/g, '/').replace(/\.{2}\//g, '').trimEnd()
 }
 
 export function getRelativePath(rootDir?: string | null, filePath?: string | null, platform: 'windows' | 'mac' | 'linux' = 'linux'): string {


### PR DESCRIPTION
Potential fix for [https://github.com/kubb-labs/kubb/security/code-scanning/39](https://github.com/kubb-labs/kubb/security/code-scanning/39)

To fix the issue, the second `replace` call should be updated to replace all occurrences of `'../'` in the string. This can be achieved by using a regular expression with the global (`g`) flag instead of a string literal. This ensures that all instances of `'../'` are replaced, not just the first one.

The change should be made on line 15 (and line 11, as the same issue exists there). The updated code will use `.replace(/\.{2}\//g, '')` instead of `.replace('../', '')`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
