### PR TITLE
Potential fix for code scanning alert no. 38: Incomplete string escaping or encoding

### DIFF
--- a/packages/fs/src/read.ts
+++ b/packages/fs/src/read.ts
@@ -8,11 +8,19 @@ function slash(path: string, platform: 'windows' | 'mac' | 'linux' = 'linux') {
 
   if (['linux', 'mac'].includes(platform) && !isWindowsPath) {
     // linux and mac
-    return path.replaceAll(/\\/g, '/').replace(/\.\.\//g, '').trimEnd()
+    let sanitizedPath = path.replaceAll(/\\/g, '/');
+    while (sanitizedPath.includes('../')) {
+      sanitizedPath = sanitizedPath.replace(/\.\.\//g, '');
+    }
+    return sanitizedPath.trimEnd();
   }
 
   // windows
-  return path.replaceAll(/\\/g, '/').replace(/\.\.\//g, '').trimEnd()
+  let sanitizedPath = path.replaceAll(/\\/g, '/');
+  while (sanitizedPath.includes('../')) {
+    sanitizedPath = sanitizedPath.replace(/\.\.\//g, '');
+  }
+  return sanitizedPath.trimEnd();
 }
 
 export function getRelativePath(rootDir?: string | null, filePath?: string | null, platform: 'windows' | 'mac' | 'linux' = 'linux'): string {

--- a/packages/fs/src/read.ts
+++ b/packages/fs/src/read.ts
@@ -8,11 +8,11 @@ function slash(path: string, platform: 'windows' | 'mac' | 'linux' = 'linux') {
 
   if (['linux', 'mac'].includes(platform) && !isWindowsPath) {
     // linux and mac
-    return path.replaceAll(/\\/g, '/').replace('../', '').trimEnd()
+    return path.replaceAll(/\\/g, '/').replace(/\.\.\//g, '').trimEnd()
   }
 
   // windows
-  return path.replaceAll(/\\/g, '/').replace('../', '').trimEnd()
+  return path.replaceAll(/\\/g, '/').replace(/\.\.\//g, '').trimEnd()
 }
 
 export function getRelativePath(rootDir?: string | null, filePath?: string | null, platform: 'windows' | 'mac' | 'linux' = 'linux'): string {


### PR DESCRIPTION
Potential fix for [https://github.com/kubb-labs/kubb/security/code-scanning/38](https://github.com/kubb-labs/kubb/security/code-scanning/38)

To fix the issue, we need to ensure that all occurrences of `'../'` in the `path` string are replaced. This can be achieved by using a regular expression with the `g` (global) flag instead of a string literal as the first argument to the `replace` method. Specifically, we should replace `replace('../', '')` with `replace(/\.\.\//g, '')`. This change ensures that every occurrence of `'../'` is removed from the string.

The fix will be applied to both instances of `replace('../', '')` in the `slash` function (lines 11 and 15).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
