### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -5,7 +5,11 @@
   },
   "defaultBase": "main",
   "namedInputs": {
-    "sharedGlobals": ["{workspaceRoot}/package.json", "{workspaceRoot}/tsconfig.json", "{workspaceRoot}/nx.json"],
+    "sharedGlobals": [
+      "{workspaceRoot}/package.json",
+      "{workspaceRoot}/tsconfig.json",
+      "{workspaceRoot}/nx.json"
+    ],
     "default": [
       "sharedGlobals",
       "{projectRoot}/**/*",
@@ -26,39 +30,73 @@
   "targetDefaults": {
     "build": {
       "cache": true,
-      "dependsOn": ["^build"],
-      "inputs": ["production", "^production"],
-      "outputs": ["{projectRoot}/dist", "{projectRoot}/assets"]
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "production",
+        "^production"
+      ],
+      "outputs": [
+        "{projectRoot}/dist",
+        "{projectRoot}/assets"
+      ]
     },
     "test": {
       "cache": true,
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^production"],
-      "outputs": ["{projectRoot}/test-results", "{projectRoot}/coverage"]
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "default",
+        "^production"
+      ],
+      "outputs": [
+        "{projectRoot}/test-results",
+        "{projectRoot}/coverage"
+      ]
     },
     "clean": {
-      "dependsOn": ["^clean"],
+      "dependsOn": [
+        "^clean"
+      ],
       "cache": false
     },
     "start": {
-      "dependsOn": ["^start"],
-      "outputs": ["{projectRoot}/dist"],
+      "dependsOn": [
+        "^start"
+      ],
+      "outputs": [
+        "{projectRoot}/dist"
+      ],
       "cache": false
     },
     "typecheck": {
       "cache": true,
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^production"]
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "default",
+        "^production"
+      ]
     },
     "release": {
-      "dependsOn": ["build"]
+      "dependsOn": [
+        "build"
+      ]
     },
     "generate": {
-      "outputs": ["{projectRoot}/src/gen"],
+      "outputs": [
+        "{projectRoot}/src/gen"
+      ],
       "cache": false
     },
     "release:canary": {
-      "dependsOn": ["build"]
+      "dependsOn": [
+        "build"
+      ]
     }
-  }
+  },
+  "nxCloudId": "681131159bdf5d30fad4b2ed"
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/680e9277ed9dce028b267883/workspaces/681131159bdf5d30fad4b2ed

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.