### PR TITLE
Fix typing issue in generated code

### DIFF
--- a/.changeset/large-socks-stare.md
+++ b/.changeset/large-socks-stare.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-client": patch
+---
+
+Fix typescript strict checking issue regarding FormData values

--- a/packages/plugin-client/src/components/Client.tsx
+++ b/packages/plugin-client/src/components/Client.tsx
@@ -193,7 +193,7 @@ export function Client({
    if(data) {
     Object.keys(data).forEach((key) => {
       const value = data[key as keyof typeof data];
-      if (typeof key === "string" && (typeof value === "string" || (value as Blob) instanceof Blob)) {
+      if (typeof key === "string" && (typeof value === "string" || (value as unknown as Blob) instanceof Blob)) {
         formData.append(key, value as unknown as string);
       }
     })


### PR DESCRIPTION
In strict mode the generated client code doesn't properly cast value to unknown first, which makes typescript fails. 

![image](https://github.com/user-attachments/assets/3374bdee-ece3-4a57-88d7-fd04491931af)


```
TS2352: Conversion of type
number | {
    pkDimProduct: number;
    retailerCode: string;
    countryCode: string;
    productEan: string;
    productName: string;
    productDescription: string;
    brandName: string;
    brandTypeId: number;
    brandTypeName: string;
    ... 16 more ...;
    hierarchyLevel3Name: string;
} | { ...; } | undefined
to type Blob may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to unknown first.
```


