### PR TITLE
fix: support version alias -v

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -11,7 +11,7 @@ body:
   - type: input
     attributes:
       label: What version of `kubb` is running?
-      description: Copy the output of `kubb -v`
+      description: Copy the output of `npx kubb -v`
   - type: dropdown
     attributes:
       label: What kind of platform do you use?

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,7 +13,18 @@ const main = defineCommand({
     version,
     description: 'Kubb generation',
   },
-  async setup({ rawArgs }) {
+  args: {
+    version: {
+      type: 'boolean',
+      alias: 'v',
+      description: 'Show version number'
+    }
+  },
+  async setup({ rawArgs, args }) {
+    if (args.version) {
+      console.log(version);
+      process.exit(0);
+    }
     try {
       consola.log(gradientString(['#F58517', '#F5A217', '#F55A17'])('Kubb CLI:'))
 


### PR DESCRIPTION
Fixed a minor issue found when submitting an issue. Currently unable to print version using `npx kubb -v`, can only use `npx kubb --version`. This appears to be an upstream issue as well. According to issue https://github.com/unjs/citty/issues/66, it should have been supported. However, I will quickly fix this error in the project first, then wait for upstream feedback gradually.

Before

```sh
➜  cli git:(main) node bin/kubb.cjs -v
Kubb CLI:                                                                     8:35:27 AM
-v

[8:35:28 AM]  ERROR  Cannot find module '/Users/rxliuli/code/web/kubb/packages/cli/node_modules/@kubb/core/dist/index.js' imported from /Users/rxliuli/code/web/kubb/packages/cli/dist/generate-jMDBjxTU.js

    at finalizeResolution (node:internal/modules/esm/resolve:275:11)
    at moduleResolve (node:internal/modules/esm/resolve:860:10)
    at defaultResolve (node:internal/modules/esm/resolve:984:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:685:12)
    at ModuleLoader.#cachedDefaultResolve (node:internal/modules/esm/loader:634:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:617:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:273:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:135:49)



[8:35:28 AM]  ERROR  Cannot find module '/Users/rxliuli/code/web/kubb/packages/cli/node_modules/@kubb/core/dist/index.js' imported from /Users/rxliuli/code/web/kubb/packages/cli/dist/generate-jMDBjxTU.js
```

After

```sh
➜  cli git:(main) ✗ node bin/kubb.cjs -v
3.18.1
```

Since using `kubb -v` in the command line results in `zsh: command not found: kubb`, I have also modified `.github/ISSUE_TEMPLATE/bug.yml`.
