### PR TITLE
fix(plugin-react-query): align infinite query generics with tanstack

### DIFF
--- a/packages/plugin-react-query/src/components/InfiniteQuery.tsx
+++ b/packages/plugin-react-query/src/components/InfiniteQuery.tsx
@@ -3,7 +3,7 @@ import type { OperationSchemas } from '@kubb/plugin-oas'
 import { getComments, getPathParams } from '@kubb/plugin-oas/utils'
 import { File, Function, FunctionParams } from '@kubb/react'
 import type { ReactNode } from 'react'
-import type { PluginReactQuery } from '../types.ts'
+import type { Infinite, PluginReactQuery } from '../types.ts'
 import { QueryKey } from './QueryKey.tsx'
 import { QueryOptions } from './QueryOptions.tsx'
 
@@ -21,20 +21,18 @@ type Props = {
   paramsType: PluginReactQuery['resolvedOptions']['paramsType']
   pathParamsType: PluginReactQuery['resolvedOptions']['pathParamsType']
   dataReturnType: PluginReactQuery['resolvedOptions']['client']['dataReturnType']
+  queryParam?: Infinite['queryParam']
 }
 
 type GetParamsProps = {
   paramsType: PluginReactQuery['resolvedOptions']['paramsType']
   paramsCasing: PluginReactQuery['resolvedOptions']['paramsCasing']
   pathParamsType: PluginReactQuery['resolvedOptions']['pathParamsType']
-  dataReturnType: PluginReactQuery['resolvedOptions']['client']['dataReturnType']
   typeSchemas: OperationSchemas
+  pageParamGeneric: string
 }
 
-function getParams({ paramsType, paramsCasing, pathParamsType, dataReturnType, typeSchemas }: GetParamsProps) {
-  const TData = dataReturnType === 'data' ? typeSchemas.response.name : `ResponseConfig<${typeSchemas.response.name}>`
-  const TError = `ResponseErrorConfig<${typeSchemas.errors?.map((item) => item.name).join(' | ') || 'Error'}>`
-
+function getParams({ paramsType, paramsCasing, pathParamsType, typeSchemas, pageParamGeneric }: GetParamsProps) {
   if (paramsType === 'object') {
     return FunctionParams.factory({
       data: {
@@ -67,7 +65,7 @@ function getParams({ paramsType, paramsCasing, pathParamsType, dataReturnType, t
       options: {
         type: `
 {
-  query?: Partial<InfiniteQueryObserverOptions<${[TData, TError, 'TQueryData', 'TQueryKey', 'TQueryData'].join(', ')}>> & { client?: QueryClient },
+  query?: Partial<InfiniteQueryObserverOptions<TQueryFnData, TError, TData, TQueryKey, ${pageParamGeneric}>> & { client?: QueryClient },
   client?: ${typeSchemas.request?.name ? `Partial<RequestConfig<${typeSchemas.request?.name}>> & { client?: typeof fetch }` : 'Partial<RequestConfig> & { client?: typeof fetch }'}
 }
 `,
@@ -108,7 +106,7 @@ function getParams({ paramsType, paramsCasing, pathParamsType, dataReturnType, t
     options: {
       type: `
 {
-  query?: Partial<InfiniteQueryObserverOptions<${[TData, TError, 'TQueryData', 'TQueryKey', 'TQueryData'].join(', ')}>> & { client?: QueryClient },
+  query?: Partial<InfiniteQueryObserverOptions<TQueryFnData, TError, TData, TQueryKey, ${pageParamGeneric}>> & { client?: QueryClient },
   client?: ${typeSchemas.request?.name ? `Partial<RequestConfig<${typeSchemas.request?.name}>> & { client?: typeof fetch }` : 'Partial<RequestConfig> & { client?: typeof fetch }'}
 }
 `,
@@ -128,11 +126,20 @@ export function InfiniteQuery({
   dataReturnType,
   typeSchemas,
   operation,
+  queryParam,
 }: Props): ReactNode {
-  const TData = dataReturnType === 'data' ? typeSchemas.response.name : `ResponseConfig<${typeSchemas.response.name}>`
-  const TError = `ResponseErrorConfig<${typeSchemas.errors?.map((item) => item.name).join(' | ') || 'Error'}>`
-  const returnType = `UseInfiniteQueryResult<${['TData', TError].join(', ')}> & { queryKey: TQueryKey }`
-  const generics = [`TData = InfiniteData<${TData}>`, `TQueryData = ${TData}`, `TQueryKey extends QueryKey = ${queryKeyTypeName}`]
+  const responseType = dataReturnType === 'data' ? typeSchemas.response.name : `ResponseConfig<${typeSchemas.response.name}>`
+  const errorType = `ResponseErrorConfig<${typeSchemas.errors?.map((item) => item.name).join(' | ') || 'Error'}>`
+  const explicitPageParamType = queryParam && typeSchemas.queryParams?.name ? `${typeSchemas.queryParams?.name}['${queryParam}']` : undefined
+  const pageParamType = explicitPageParamType ?? 'number'
+  const returnType = 'UseInfiniteQueryResult<TData, TError> & { queryKey: TQueryKey }'
+  const generics = [
+    `TQueryFnData = ${responseType}`,
+    `TError = ${errorType}`,
+    'TData = InfiniteData<TQueryFnData>',
+    `TQueryKey extends QueryKey = ${queryKeyTypeName}`,
+    `TPageParam = ${pageParamType}`,
+  ]
 
   const queryKeyParams = QueryKey.getParams({
     pathParamsType,
@@ -149,8 +156,8 @@ export function InfiniteQuery({
     paramsCasing,
     paramsType,
     pathParamsType,
-    dataReturnType,
     typeSchemas,
+    pageParamGeneric: 'TPageParam',
   })
 
   const queryOptions = `${queryOptionsName}(${queryOptionsParams.toCall()})`
@@ -175,7 +182,7 @@ export function InfiniteQuery({
         ...${queryOptions},
         queryKey,
         ...queryOptions
-       } as unknown as InfiniteQueryObserverOptions, queryClient) as ${returnType}
+       } as unknown as InfiniteQueryObserverOptions<TQueryFnData, TError, TData, TQueryKey, TPageParam>, queryClient) as ${returnType}
 
        query.queryKey = queryKey as TQueryKey
 

--- a/packages/plugin-react-query/src/components/InfiniteQueryOptions.tsx
+++ b/packages/plugin-react-query/src/components/InfiniteQueryOptions.tsx
@@ -112,8 +112,9 @@ export function InfiniteQueryOptions({
   queryParam,
   queryKeyName,
 }: Props): ReactNode {
-  const TData = dataReturnType === 'data' ? typeSchemas.response.name : `ResponseConfig<${typeSchemas.response.name}>`
-  const TError = `ResponseErrorConfig<${typeSchemas.errors?.map((item) => item.name).join(' | ') || 'Error'}>`
+  const queryFnDataType = dataReturnType === 'data' ? typeSchemas.response.name : `ResponseConfig<${typeSchemas.response.name}>`
+  const errorType = `ResponseErrorConfig<${typeSchemas.errors?.map((item) => item.name).join(' | ') || 'Error'}>`
+  const pageParamType = queryParam && typeSchemas.queryParams?.name ? `${typeSchemas.queryParams?.name}['${queryParam}']` : 'number'
 
   const params = getParams({ paramsType, paramsCasing, pathParamsType, typeSchemas })
   const clientParams = Client.getParams({
@@ -164,7 +165,7 @@ export function InfiniteQueryOptions({
         <Function name={name} export params={params.toConstructor()}>
           {`
       const queryKey = ${queryKeyName}(${queryKeyParams.toCall()})
-      return infiniteQueryOptions<${TData}, ${TError}, ${TData}, typeof queryKey, number>({
+      return infiniteQueryOptions<${queryFnDataType}, ${errorType}, InfiniteData<${queryFnDataType}>, typeof queryKey, ${pageParamType}>({
        ${enabledText}
        queryKey,
        queryFn: async ({ signal, pageParam }) => {
@@ -185,7 +186,7 @@ export function InfiniteQueryOptions({
       <Function name={name} export params={params.toConstructor()}>
         {`
       const queryKey = ${queryKeyName}(${queryKeyParams.toCall()})
-      return infiniteQueryOptions<${TData}, ${TError}, ${TData}, typeof queryKey>({
+      return infiniteQueryOptions<${queryFnDataType}, ${errorType}, InfiniteData<${queryFnDataType}>, typeof queryKey, ${pageParamType}>({
        ${enabledText}
        queryKey,
        queryFn: async ({ signal }) => {

--- a/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-react-query/src/generators/infiniteQueryGenerator.tsx
@@ -159,6 +159,7 @@ export const infiniteQueryGenerator = createReactGenerator<PluginReactQuery>({
               dataReturnType={options.client.dataReturnType}
               queryKeyName={queryKey.name}
               queryKeyTypeName={queryKey.typeName}
+              queryParam={options.infinite.queryParam}
             />
           </>
         )}


### PR DESCRIPTION
  ## Summary

  Official builds of `@kubb/plugin-react-query` still emit infinite-query hooks that target the old TanStack overloads where
  `TQueryData` doubles as `TPageParam`. With TanStack Query v5 (and the current `@tanstack/react-query` types), those signatures now require a distinct `TPageParam`, so consumers hit `TS2769` when `pageParam` isn’t a `number`.

  This change updates the plugin to:

  - Emit `InfiniteQuery` hooks with explicit `TQueryFnData`, `TError`, `TData`, `TQueryKey`, and `TPageParam` generics (defaulting
  `TPageParam` to the configured query param type or `number`).
  - Mirror the same generics in `InfiniteQueryOptions`, so the builder returns options keyed by the correct page-param type.
  - Pass the configured `queryParam` from the generator into `InfiniteQuery`, letting the emitter pick the right cursor/offset type.

  Generated consumers (tested in our project against TanStack Query v5.89.0) typecheck without custom patching.