### PR TITLE
test(adapter-oas): regression test for operation/schema enum collision (#3364)

### DIFF
--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -2719,6 +2719,94 @@ describe('parseSchema array', () => {
     expect(status?.name).toBe('GetTransfers200DataStatusEnum')
   })
 
+  // Regression for kubb-labs/kubb#3364: an operation response with the same shape as a
+  // top-level component named `<Op><code>` must not produce colliding enum identifiers.
+  // The operation path qualifies with `Status<code>` so its enums stay distinct from the
+  // component's, avoiding the `TS2300: Duplicate identifier` re-export in the barrel.
+  it('does not collide operation-response enums with a same-named component schema (#3364)', async () => {
+    const oas = await parseDocument({
+      openapi: '3.0.3',
+      info: { title: 'Test', version: '1.0.0' },
+      components: {
+        schemas: {
+          GetMaintenance200: {
+            type: 'object',
+            properties: {
+              data: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  properties: {
+                    status: { type: 'string', enum: ['ok', 'failed'] },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      paths: {
+        '/maintenance': {
+          get: {
+            operationId: 'getMaintenance',
+            responses: {
+              '200': {
+                description: 'OK',
+                content: {
+                  'application/json': {
+                    // Inline (structurally equivalent to the component above) so the operation
+                    // file emits its own copy of the nested enum under the response name.
+                    schema: {
+                      type: 'object',
+                      properties: {
+                        data: {
+                          type: 'array',
+                          items: {
+                            type: 'object',
+                            properties: {
+                              status: { type: 'string', enum: ['ok', 'failed'] },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+    const root = parseOas(oas).root
+
+    const collectEnumNames = (node: ast.SchemaNode | null | undefined): Array<string> =>
+      node
+        ? ast
+            .collect(node, {
+              schema(n) {
+                return ast.narrowSchema(n, 'enum') ?? undefined
+              },
+            })
+            .map((e) => e.name)
+            .filter((name): name is string => !!name)
+        : []
+
+    const component = root.schemas.find((s) => s.name === 'GetMaintenance200')
+    const responseSchema = root.operations.find((op) => op.operationId === 'getMaintenance')?.responses.find((r) => r.statusCode === '200')?.schema
+
+    const componentEnums = collectEnumNames(component)
+    const responseEnums = collectEnumNames(responseSchema)
+
+    // Schema path keeps the component-qualified name…
+    expect(componentEnums).toContain('GetMaintenance200DataStatusEnum')
+    // …while the operation response path qualifies with `Status<code>` so it cannot collide.
+    expect(responseEnums).toContain('GetMaintenanceStatus200DataStatusEnum')
+
+    // The core #3364 guarantee: no enum identifier is emitted by both file owners.
+    expect(componentEnums.filter((name) => responseEnums.includes(name))).toEqual([])
+  })
+
   it('preserves nullable on array', () => {
     const node = parseSchema(ctx, {
       schema: { type: 'array', nullable: true },


### PR DESCRIPTION
## Summary

Adds a document-level regression test that locks in the fix for #3364 (operation response and top-level schema emitting duplicate enum declarations into separate files → `TS2300: Duplicate identifier`).

The underlying bug was already fixed on `main` by commit `15009f6` ("fix(adapter-oas): close remaining enum naming collisions"), which landed on PR #3363's branch *after* #3364 was filed and merged with it. That commit switched the operation response parse name from `<Op><code>` to `<Op>Status<code>` (`parser.ts:939`), matching plugin-ts's `resolveResponseStatusName`, so operation-side nested enums no longer collide with component schemas named `<Op><code>`. The issue stayed open only because PR #3363 cross-referenced "Closes #3362", never #3364.

Existing tests covered enum-name qualification at the single-schema level only. This PR adds the missing **document-level** assertion: parse a full OAS where an operation's `200` response is structurally equivalent to a component named `GetMaintenance200`, and verify the two file owners produce **distinct** enum identifiers:

- component schema → `GetMaintenance200DataStatusEnum`
- operation response → `GetMaintenanceStatus200DataStatusEnum`
- and that no enum identifier is emitted by both (the core #3364 guarantee).

This test fails on the pre-`15009f6` code (both would be `GetMaintenance200DataStatusEnum`) and passes now.

## Test plan

- [x] `pnpm --filter @kubb/adapter-oas test` — new test green; full `parser.test.ts` suite passes (the 2 unrelated `#mocks`-import suite failures are a pre-existing environment resolution issue, untouched here)
- [x] `pnpm --filter @kubb/adapter-oas typecheck` — clean
- [x] `pnpm lint` (oxlint) — clean
- [x] `oxfmt` — no formatting churn

Test-only change → no changeset (no package behavior/public API change).

Closes #3364

https://claude.ai/code/session_01B7pxX9Byr1YrHKE1CKE7S9

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7pxX9Byr1YrHKE1CKE7S9)_