### PR TITLE
fix(ast): keep default import when a used named import shares its path

### DIFF
--- a/.changeset/fix-grouped-default-import-drop.md
+++ b/.changeset/fix-grouped-default-import-drop.md
@@ -1,0 +1,7 @@
+---
+"@kubb/ast": patch
+---
+
+Keep a default import when a used named import from the same module path is retained.
+
+Previously, when operations were grouped into a single file, a used default import (such as a generated `client` runtime) could be dropped during the merge because its binding was not found in the reconstructed source string, producing references to an undefined value. `combineImports` now retains a default import whenever a used named/type import from the same path survives.

--- a/packages/ast/src/utils.test.ts
+++ b/packages/ast/src/utils.test.ts
@@ -1778,6 +1778,24 @@ describe('combineImports', () => {
     expect(result).toHaveLength(1)
     expect(result[0]!.name).toHaveLength(1)
   })
+
+  it('keeps a default import when a used named import from the same path is retained', () => {
+    const client = createImport({ name: 'client', path: '@kubb/plugin-client/clients/axios' })
+    const types = createImport({ name: ['Client', 'RequestConfig'], path: '@kubb/plugin-client/clients/axios', isTypeOnly: true })
+    // The merged grouped source omits the function body, so `client` is absent — but `Client` is referenced.
+    const result = combineImports([client, types], [], 'Partial<RequestConfig> & { client?: Client }')
+
+    expect(result.some((i) => i.name === 'client')).toBe(true)
+    expect(result.some((i) => Array.isArray(i.name) && i.name.includes('Client'))).toBe(true)
+  })
+
+  it('still drops a default import when no named import from the same path is used', () => {
+    const client = createImport({ name: 'client', path: '@kubb/plugin-client/clients/axios' })
+    const types = createImport({ name: ['Client'], path: '@kubb/plugin-client/clients/axios', isTypeOnly: true })
+    const result = combineImports([client, types], [], 'const x = 1')
+
+    expect(result).toHaveLength(0)
+  })
 })
 
 describe('findCircularSchemas', () => {

--- a/packages/ast/src/utils.ts
+++ b/packages/ast/src/utils.ts
@@ -664,6 +664,17 @@ export function combineImports(imports: Array<ImportNode>, exports: Array<Export
     return importNameMemo.get(key)!
   }
 
+  // Paths that keep at least one used named import. A default import from such a path is retained
+  // even when its binding can't be found in `source` — e.g. a generated `client` default import
+  // alongside `import type { Client } from <same path>`, where merged grouped output omits the body.
+  const pathsWithUsedNamedImport = new Set<string>()
+  for (const node of imports) {
+    if (!Array.isArray(node.name)) continue
+    if (node.name.some((item) => (typeof item === 'string' ? isUsed(item) : isUsed(item.name ?? item.propertyName)))) {
+      pathsWithUsedNamedImport.add(node.path)
+    }
+  }
+
   const result: Array<ImportNode> = []
   // Accumulates array-named imports keyed by `path:isTypeOnly` for name-merging
   const namedByPath = new Map<string, ImportNode>()
@@ -697,7 +708,7 @@ export function combineImports(imports: Array<ImportNode>, exports: Array<Export
         namedByPath.set(key, newItem)
       }
     } else {
-      if (name && !isUsed(name)) continue
+      if (name && !isUsed(name) && !pathsWithUsedNamedImport.has(path)) continue
 
       const key = importKey(path, name, isTypeOnly)
       if (!seen.has(key)) {

--- a/packages/core/src/FileManager.test.ts
+++ b/packages/core/src/FileManager.test.ts
@@ -1,4 +1,4 @@
-import { createFile, createSource, createText } from '@kubb/ast'
+import { createFile, createImport, createSource, createText } from '@kubb/ast'
 import { describe, expect, it } from 'vitest'
 import { FileManager } from './FileManager.ts'
 
@@ -32,6 +32,24 @@ describe('FileManager', () => {
       manager.add(makeFile('/src/foo.ts', 'const a = 1'), makeFile('/src/foo.ts', 'const b = 2'))
       expect(manager.files).toHaveLength(1)
       expect(manager.files[0]?.sources).toHaveLength(2)
+    })
+
+    it('keeps a default client import when grouped sources omit its body usage', () => {
+      const manager = new FileManager()
+      const clientPath = '@kubb/plugin-client/clients/axios'
+      // Source references the type imports (Client/RequestConfig) but not the lowercase `client`
+      // binding — mirroring grouped output where the function body that uses `client` is omitted.
+      const make = (op: string) =>
+        makeFile(`/src/clients/pet.ts`, `export declare function ${op}(): RequestConfig<Client>`, {
+          imports: [
+            createImport({ name: 'client', path: clientPath }),
+            createImport({ name: ['Client', 'RequestConfig'], path: clientPath, isTypeOnly: true }),
+          ],
+        })
+      manager.add(make('getOrderById'), make('getPetById'))
+
+      const imports = manager.files[0]?.imports ?? []
+      expect(imports.some((i) => i.name === 'client')).toBe(true)
     })
 
     it('stores multiple distinct files', () => {


### PR DESCRIPTION
## Summary

When operations are grouped into a single output file (e.g. `group: { type: 'tag' }`), a **used default import** could be dropped during the file merge, leaving the generated code referencing an undefined binding (`TS2304`).

Root cause: `mergeFile` → `createFile` → `combineImports` filters default (string-name) imports via `isUsed(name) = source.includes(name)`. At merge time the reconstructed `source` string (built by `extractStringsFromNodes`) does not reliably contain the function-body usage of the binding, so a used default import like a generated `client` runtime is dropped — while named/type imports from the same path survive.

Fix: in `combineImports`, retain a default import whenever a **used named/type import from the same module path** is retained. Generated client code always imports its types (`Client`, `RequestConfig`, `ResponseErrorConfig`) from the same path as the default `client` import, so this reliably keeps the runtime import. Genuinely-unused default imports (no surviving sibling from the same path) are still pruned.

This unblocks the downstream `@kubb/plugin-client` / query plugins effort to standardize the generated request runtime symbol on `client`, where grouped output + a custom `importPath` triggered the drop.

## Changes
- `packages/ast/src/utils.ts` — `combineImports` precomputes paths with a used named import and keeps default imports from those paths.
- `packages/ast/src/utils.test.ts` — unit coverage for keep/drop cases.
- `packages/core/src/FileManager.test.ts` — merged-file regression test (fails without the fix).
- changeset (`@kubb/ast` patch).

## Test plan
- [x] `pnpm --filter @kubb/ast test` (303 passing)
- [x] `pnpm --filter @kubb/core test` (133 passing)
- [x] Confirmed the new FileManager test fails when the `utils.ts` fix is reverted

https://claude.ai/code/session_017mMSe7SXrdLC3CF6SnPNPM

---
_Generated by [Claude Code](https://claude.ai/code/session_017mMSe7SXrdLC3CF6SnPNPM)_