### PR TITLE
feat(adapter-oas): support multiple response content types

### DIFF
--- a/.changeset/multi-content-type-response.md
+++ b/.changeset/multi-content-type-response.md
@@ -1,0 +1,8 @@
+---
+'@kubb/ast': minor
+'@kubb/adapter-oas': minor
+---
+
+Add multiple response content type support to the AST and OpenAPI parser.
+
+`ResponseNode` now carries a `content` array (mirroring `requestBody.content`) with one entry per content type declared for a status code. The OpenAPI parser populates every content type instead of keeping only the first. The legacy `schema` and `mediaType` fields stay populated with the primary (JSON-preferred) entry for backward compatibility, so existing consumers are unaffected. When the adapter `contentType` option is set, only that content type is kept.

--- a/.changeset/multi-content-type-response.md
+++ b/.changeset/multi-content-type-response.md
@@ -5,4 +5,12 @@
 
 Add multiple response content type support to the AST and OpenAPI parser.
 
-`ResponseNode` now carries a `content` array (mirroring `requestBody.content`) with one entry per content type declared for a status code. The OpenAPI parser populates every content type instead of keeping only the first. The legacy `schema` and `mediaType` fields stay populated with the primary (JSON-preferred) entry for backward compatibility, so existing consumers are unaffected. When the adapter `contentType` option is set, only that content type is kept.
+`ResponseNode` now mirrors `requestBody`: the response body schemas live exclusively inside a
+`content` array (one entry per content type), instead of a single root-level `schema`/`mediaType`.
+This removes the duplicated schema that previously sat both on the node root and inside `content`.
+The OpenAPI parser populates every content type declared for a status code; body-less responses
+keep a single `content` entry whose schema is the empty/`void` placeholder. When the adapter
+`contentType` option is set, only that content type is kept.
+
+For convenience `createResponse` still accepts a single `schema` (with optional `mediaType`),
+normalizing it into one `content` entry, so existing callers keep working.

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -303,7 +303,7 @@ describe('buildAst', () => {
       const ok = listPets?.responses.find((r) => r.statusCode === '200')
 
       expect(ok?.description).toBe('A list of pets')
-      expect(ok?.schema?.type).toBe('ref')
+      expect(ok?.content?.[0]?.schema?.type).toBe('ref')
     })
 
     it('converts responses without a body schema', async () => {
@@ -321,7 +321,7 @@ describe('buildAst', () => {
       const listPets = root.operations.find((op) => op.operationId === 'listPets')
       const ok = listPets?.responses.find((r) => r.statusCode === '200')
 
-      expect(ok?.mediaType).toBe('application/json')
+      expect(ok?.content?.[0]?.contentType).toBe('application/json')
     })
 
     it('populates requestBody.content with a single entry when operation has one content type', async () => {
@@ -2898,7 +2898,9 @@ describe('parseSchema array', () => {
         : []
 
     const component = root.schemas.find((s) => s.name === 'GetMaintenance200')
-    const responseSchema = root.operations.find((op) => op.operationId === 'getMaintenance')?.responses.find((r) => r.statusCode === '200')?.schema
+    const responseSchema = root.operations
+      .find((op) => op.operationId === 'getMaintenance')
+      ?.responses.find((r) => r.statusCode === '200')?.content?.[0]?.schema
 
     const componentEnums = collectEnumNames(component)
     const responseEnums = collectEnumNames(responseSchema)

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -2898,9 +2898,8 @@ describe('parseSchema array', () => {
         : []
 
     const component = root.schemas.find((s) => s.name === 'GetMaintenance200')
-    const responseSchema = root.operations
-      .find((op) => op.operationId === 'getMaintenance')
-      ?.responses.find((r) => r.statusCode === '200')?.content?.[0]?.schema
+    const responseSchema = root.operations.find((op) => op.operationId === 'getMaintenance')?.responses.find((r) => r.statusCode === '200')
+      ?.content?.[0]?.schema
 
     const componentEnums = collectEnumNames(component)
     const responseEnums = collectEnumNames(responseSchema)

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -427,6 +427,83 @@ describe('buildAst', () => {
       expect(upload?.requestBody?.content).toHaveLength(1)
       expect(upload?.requestBody?.content?.[0]?.contentType).toBe('multipart/form-data')
     })
+
+    it('populates response.content with a single entry when the response has one content type', async () => {
+      const oas = await buildMinimalOas()
+      const root = parseOas(oas).root
+      const listPets = root.operations.find((op) => op.operationId === 'listPets')
+      const ok = listPets?.responses.find((r) => r.statusCode === '200')
+
+      expect(ok?.content).toHaveLength(1)
+      expect(ok?.content?.[0]?.contentType).toBe('application/json')
+    })
+
+    it('populates response.content with all entries when the response has multiple content types', async () => {
+      const oas = await parseDocument({
+        openapi: '3.0.3',
+        info: { title: 'Test', version: '1.0.0' },
+        paths: {
+          '/pets/{petId}': {
+            get: {
+              operationId: 'getPetById',
+              responses: {
+                '200': {
+                  description: 'OK',
+                  content: {
+                    'application/json': {
+                      schema: { type: 'object', properties: { name: { type: 'string' } } },
+                    },
+                    'application/xml': {
+                      schema: { type: 'object', properties: { name: { type: 'string' } } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+      const root = parseOas(oas).root
+      const getPetById = root.operations.find((op) => op.operationId === 'getPetById')
+      const ok = getPetById?.responses.find((r) => r.statusCode === '200')
+
+      expect(ok?.content).toHaveLength(2)
+      expect(ok?.content?.[0]?.contentType).toBe('application/json')
+      expect(ok?.content?.[1]?.contentType).toBe('application/xml')
+    })
+
+    it('when contentType is set, response.content contains only that content type', async () => {
+      const oas = await parseDocument({
+        openapi: '3.0.3',
+        info: { title: 'Test', version: '1.0.0' },
+        paths: {
+          '/pets/{petId}': {
+            get: {
+              operationId: 'getPetById',
+              responses: {
+                '200': {
+                  description: 'OK',
+                  content: {
+                    'application/json': {
+                      schema: { type: 'object', properties: { name: { type: 'string' } } },
+                    },
+                    'application/xml': {
+                      schema: { type: 'object', properties: { name: { type: 'string' } } },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+      const root = parseOas(oas, { contentType: 'application/xml' }).root
+      const getPetById = root.operations.find((op) => op.operationId === 'getPetById')
+      const ok = getPetById?.responses.find((r) => r.statusCode === '200')
+
+      expect(ok?.content).toHaveLength(1)
+      expect(ok?.content?.[0]?.contentType).toBe('application/xml')
+    })
   })
 })
 

--- a/packages/adapter-oas/src/parser.ts
+++ b/packages/adapter-oas/src/parser.ts
@@ -13,6 +13,7 @@ import {
   getPrimitiveType,
   getRequestBodyContentTypes,
   getRequestSchema,
+  getResponseBodyContentTypes,
   getResponseSchema,
   getSchemas,
   getSchemaType,
@@ -947,11 +948,27 @@ export function createSchemaParser(ctx: OasParserContext) {
       const { description, content } = getResponseMeta(responseObj)
       const mediaType = content ? getMediaType(Object.keys(content)[0] ?? '') : getMediaType(operation.contentType ?? '')
 
+      // Build one entry per declared response content type so plugins can union the variants.
+      // When a global contentType is configured, restrict to that single type (mirrors requestBody).
+      const responseContentTypes = ctx.contentType ? [ctx.contentType] : getResponseBodyContentTypes(document, operation, statusCode)
+      const responseContent = responseContentTypes.flatMap((ct) => {
+        const ctSchema = getResponseSchema(document, operation, statusCode, { contentType: ct })
+        if (!ctSchema || Object.keys(ctSchema).length === 0) return []
+        return [
+          {
+            contentType: ct,
+            schema: parseSchema({ schema: ctSchema, name: responseName }, options),
+            keysToOmit: collectPropertyKeysByFlag(ctSchema, 'writeOnly'),
+          },
+        ]
+      })
+
       return ast.createResponse({
         statusCode: statusCode as ast.StatusCode,
         description,
         schema,
         mediaType,
+        content: responseContent.length > 0 ? responseContent : undefined,
         keysToOmit: collectPropertyKeysByFlag(responseSchema, 'writeOnly'),
       })
     })

--- a/packages/adapter-oas/src/parser.ts
+++ b/packages/adapter-oas/src/parser.ts
@@ -8,7 +8,6 @@ import {
   buildSchemaNode,
   flattenSchema,
   getDateType,
-  getMediaType,
   getParameters,
   getPrimitiveType,
   getRequestBodyContentTypes,
@@ -932,44 +931,37 @@ export function createSchemaParser(ctx: OasParserContext) {
 
     const responses: Array<ast.ResponseNode> = operation.getResponseStatusCodes().map((statusCode) => {
       const responseObj = operation.getResponseByStatusCode(statusCode)
-      const responseSchema = getResponseSchema(document, operation, statusCode, { contentType: ctx.contentType })
 
       // Use `Status<code>` (matching plugin-ts's resolveResponseStatusName convention) so the
       // qualified names for nested enums don't collide with top-level component schemas that
       // happen to be named `<operation><statusCode>` (e.g. `GetMaintenance200`).
       const responseName = operationName ? `${operationName}Status${statusCode}` : undefined
-      const schema =
-        responseSchema && Object.keys(responseSchema).length > 0
-          ? parseSchema({ schema: responseSchema, name: responseName }, options)
-          : ast.createSchema({
-              type: typeOptionMap.get(options.emptySchemaType)!,
-            })
+      const { description } = getResponseMeta(responseObj)
 
-      const { description, content } = getResponseMeta(responseObj)
-      const mediaType = content ? getMediaType(Object.keys(content)[0] ?? '') : getMediaType(operation.contentType ?? '')
+      const parseEntrySchema = (contentType?: string) => {
+        const raw = getResponseSchema(document, operation, statusCode, { contentType })
+        const node =
+          raw && Object.keys(raw).length > 0
+            ? parseSchema({ schema: raw, name: responseName }, options)
+            : ast.createSchema({ type: typeOptionMap.get(options.emptySchemaType)! })
+        return { schema: node, keysToOmit: collectPropertyKeysByFlag(raw, 'writeOnly') }
+      }
 
       // Build one entry per declared response content type so plugins can union the variants.
       // When a global contentType is configured, restrict to that single type (mirrors requestBody).
       const responseContentTypes = ctx.contentType ? [ctx.contentType] : getResponseBodyContentTypes(document, operation, statusCode)
-      const responseContent = responseContentTypes.flatMap((ct) => {
-        const ctSchema = getResponseSchema(document, operation, statusCode, { contentType: ct })
-        if (!ctSchema || Object.keys(ctSchema).length === 0) return []
-        return [
-          {
-            contentType: ct,
-            schema: parseSchema({ schema: ctSchema, name: responseName }, options),
-            keysToOmit: collectPropertyKeysByFlag(ctSchema, 'writeOnly'),
-          },
-        ]
-      })
+      const content = responseContentTypes.map((contentType) => ({ contentType, ...parseEntrySchema(contentType) }))
+
+      // Body-less responses keep a single fallback entry so the response still resolves to a
+      // (void/any) schema, matching how `requestBody` only carries schemas inside `content`.
+      if (content.length === 0) {
+        content.push({ contentType: operation.contentType || 'application/json', ...parseEntrySchema(ctx.contentType) })
+      }
 
       return ast.createResponse({
         statusCode: statusCode as ast.StatusCode,
         description,
-        schema,
-        mediaType,
-        content: responseContent.length > 0 ? responseContent : undefined,
-        keysToOmit: collectPropertyKeysByFlag(responseSchema, 'writeOnly'),
+        content,
       })
     })
 

--- a/packages/adapter-oas/src/resolvers.ts
+++ b/packages/adapter-oas/src/resolvers.ts
@@ -541,3 +541,33 @@ export function getRequestBodyContentTypes(document: Document, operation: Operat
   // Do not bail out on isReference — the content is already present on the merged object.
   return body.content ? Object.keys(body.content) : []
 }
+
+/**
+ * Returns all response content type keys for an operation at a given status code.
+ *
+ * Response `$ref`s are resolved in-place first — the same mutation `getResponseSchema` performs —
+ * so the returned list reflects the available content types even for referenced responses.
+ *
+ * @example
+ * ```ts
+ * getResponseBodyContentTypes(document, operation, 200)
+ * // ['application/json', 'application/xml']
+ * ```
+ */
+export function getResponseBodyContentTypes(document: Document, operation: Operation, statusCode: string | number): Array<string> {
+  if (operation.schema.responses) {
+    const responses = operation.schema.responses
+    for (const key in responses) {
+      const schema = responses[key]
+      if (schema && isReference(schema)) {
+        responses[key] = resolveRef<any>(document, schema.$ref)
+      }
+    }
+  }
+
+  const responseObj = operation.getResponseByStatusCode(statusCode)
+  if (!responseObj || typeof responseObj !== 'object' || isReference(responseObj)) return []
+
+  const body = responseObj as { content?: Record<string, unknown> }
+  return body.content ? Object.keys(body.content) : []
+}

--- a/packages/ast/src/factory.test.ts
+++ b/packages/ast/src/factory.test.ts
@@ -188,15 +188,30 @@ describe('createResponse', () => {
     expect(node.statusCode).toBe('200')
   })
 
-  it('accepts a schema and description', () => {
+  it('normalizes a legacy schema into a single content entry', () => {
     const node = createResponse({
       statusCode: '200',
       schema: createSchema({ type: 'object' }),
+      mediaType: 'application/json',
       description: 'Success',
     })
 
-    expect(node.schema?.type).toBe('object')
+    expect(node.content?.[0]?.contentType).toBe('application/json')
+    expect(node.content?.[0]?.schema?.type).toBe('object')
     expect(node.description).toBe('Success')
+  })
+
+  it('accepts an explicit content array', () => {
+    const node = createResponse({
+      statusCode: '200',
+      content: [
+        { contentType: 'application/json', schema: createSchema({ type: 'object' }) },
+        { contentType: 'application/xml', schema: createSchema({ type: 'string' }) },
+      ],
+    })
+
+    expect(node.content).toHaveLength(2)
+    expect(node.content?.[1]?.contentType).toBe('application/xml')
   })
 })
 

--- a/packages/ast/src/factory.ts
+++ b/packages/ast/src/factory.ts
@@ -322,21 +322,32 @@ export function createParameter(
 /**
  * Creates a `ResponseNode`.
  *
+ * Response body schemas live inside `content`. For convenience a single legacy `schema`
+ * (with optional `mediaType`/`keysToOmit`) is normalized into one `content` entry, so the same
+ * schema is never stored both at the node root and inside `content`.
+ *
  * @example
  * ```ts
  * const response = createResponse({
  *   statusCode: '200',
- *   description: 'Success',
- *   schema: createSchema({ type: 'object', properties: [] }),
+ *   content: [{ contentType: 'application/json', schema: createSchema({ type: 'object', properties: [] }) }],
  * })
  * ```
  */
 export function createResponse(
-  props: Pick<ResponseNode, 'statusCode' | 'schema'> & Partial<Omit<ResponseNode, 'kind' | 'statusCode' | 'schema'>>,
+  props: Pick<ResponseNode, 'statusCode'> &
+    Partial<Omit<ResponseNode, 'kind' | 'statusCode'>> & {
+      schema?: SchemaNode
+      mediaType?: string | null
+      keysToOmit?: Array<string> | null
+    },
 ): ResponseNode {
+  const { schema, mediaType, keysToOmit, content, ...rest } = props
+
   return {
-    ...props,
+    ...rest,
     kind: 'Response',
+    content: content ?? (schema ? [{ contentType: mediaType ?? 'application/json', schema, keysToOmit: keysToOmit ?? null }] : undefined),
   }
 }
 

--- a/packages/ast/src/nodes/response.ts
+++ b/packages/ast/src/nodes/response.ts
@@ -29,12 +29,44 @@ export type ResponseNode = BaseNode & {
   description?: string
   /**
    * Response body schema.
+   *
+   * Always populated with the primary (JSON-preferred) content type so existing consumers keep
+   * working. For the full per-content-type breakdown use {@link ResponseNode.content}.
    */
   schema: SchemaNode
   /**
-   * Response media type.
+   * Response media type of the primary content type.
    */
   mediaType?: MediaType | null
+  /**
+   * All available content type entries for this response.
+   *
+   * When the adapter `contentType` option is set, this array contains exactly one entry for that
+   * content type. Otherwise it contains one entry per content type declared in the spec, so that
+   * plugins can generate a union of response types (e.g. `application/json` and `application/xml`).
+   *
+   * @example
+   * ```ts
+   * // spec response declares both application/json and application/xml
+   * response.content[0].contentType // 'application/json'
+   * response.content[1].contentType // 'application/xml'
+   * ```
+   */
+  content?: Array<{
+    /**
+     * The content type for this entry (e.g. `'application/json'`).
+     */
+    contentType: string
+    /**
+     * Response body schema for this content type.
+     */
+    schema?: SchemaNode
+    /**
+     * Property keys to exclude from the generated type via `Omit<Type, Keys>`.
+     * Set when a referenced schema has `writeOnly` fields that should not appear in response types.
+     */
+    keysToOmit?: Array<string> | null
+  }>
   /**
    * Property keys to exclude from the generated type via `Omit<Type, Keys>`.
    * Set when a referenced schema has `writeOnly` fields that should not appear in response types.

--- a/packages/ast/src/nodes/response.ts
+++ b/packages/ast/src/nodes/response.ts
@@ -1,16 +1,20 @@
 import type { BaseNode } from './base.ts'
-import type { MediaType, StatusCode } from './http.ts'
+import type { StatusCode } from './http.ts'
 import type { SchemaNode } from './schema.ts'
 
 /**
  * AST node representing one operation response variant.
+ *
+ * Mirrors {@link OperationNode.requestBody}: the response body schemas live exclusively inside
+ * the `content` array (one entry per content type), so the same schema is never duplicated at the
+ * node root and inside `content`.
  *
  * @example
  * ```ts
  * const response: ResponseNode = {
  *   kind: 'Response',
  *   statusCode: '200',
- *   schema: createSchema({ type: 'string' }),
+ *   content: [{ contentType: 'application/json', schema: createSchema({ type: 'string' }) }],
  * }
  * ```
  */
@@ -28,22 +32,12 @@ export type ResponseNode = BaseNode & {
    */
   description?: string
   /**
-   * Response body schema.
-   *
-   * Always populated with the primary (JSON-preferred) content type so existing consumers keep
-   * working. For the full per-content-type breakdown use {@link ResponseNode.content}.
-   */
-  schema: SchemaNode
-  /**
-   * Response media type of the primary content type.
-   */
-  mediaType?: MediaType | null
-  /**
    * All available content type entries for this response.
    *
    * When the adapter `contentType` option is set, this array contains exactly one entry for that
    * content type. Otherwise it contains one entry per content type declared in the spec, so that
    * plugins can generate a union of response types (e.g. `application/json` and `application/xml`).
+   * Body-less responses keep a single entry whose `schema` is the empty/`void` placeholder.
    *
    * @example
    * ```ts
@@ -67,9 +61,4 @@ export type ResponseNode = BaseNode & {
      */
     keysToOmit?: Array<string> | null
   }>
-  /**
-   * Property keys to exclude from the generated type via `Omit<Type, Keys>`.
-   * Set when a referenced schema has `writeOnly` fields that should not appear in response types.
-   */
-  keysToOmit?: Array<string> | null
 }

--- a/packages/ast/src/visitor.ts
+++ b/packages/ast/src/visitor.ts
@@ -319,7 +319,11 @@ function* getChildren(node: Node, recurse: boolean): Generator<Node, void, undef
     return
   }
   if (node.kind === 'Response') {
-    if (node.schema) yield node.schema
+    if (node.content) {
+      for (const c of node.content) {
+        if (c.schema) yield c.schema
+      }
+    }
     return
   }
 }
@@ -498,7 +502,10 @@ export function transform(node: Node, options: TransformOptions): Node {
 
     return {
       ...response,
-      schema: transform(response.schema, { ...options, parent: response }),
+      content: response.content?.map((entry) => ({
+        ...entry,
+        schema: entry.schema ? transform(entry.schema, { ...options, parent: response }) : entry.schema,
+      })),
     }
   }
 


### PR DESCRIPTION
## Summary

Adds multiple **response** content type support to the AST and OpenAPI parser, the foundation for the plugin-side work in [kubb-labs/plugins#221](https://github.com/kubb-labs/plugins/pull/221). Addresses [discussion #3355](https://github.com/orgs/kubb-labs/discussions/3355).

Previously `ResponseNode` carried a single root-level `schema`/`mediaType` and the parser kept only the **first** content type per status code, silently dropping additional representations (e.g. `application/xml` alongside `application/json`).

## Changes

- **`@kubb/ast`** — `ResponseNode` now mirrors `requestBody`: response body schemas live exclusively inside a `content` array `Array<{ contentType, schema?, keysToOmit? }>`. The duplicated root-level `schema`/`mediaType` is removed, so the same schema is never stored both at the node root and inside `content`.
  - `createResponse` still accepts a single `schema` (with optional `mediaType`) and normalizes it into one `content` entry, so existing callers/fixtures keep working.
  - Visitor traversal (`transform` / child collection) now walks the per-content-type schemas.
- **`@kubb/adapter-oas`** — the parser builds one `content` entry per declared response content type (mirroring the request-body loop) and honours the adapter `contentType` option. Body-less responses keep a single fallback entry whose schema is the empty/`void` placeholder, preserving `StatusXXX = any`/`void` generation. Added `getResponseBodyContentTypes` to `resolvers.ts`.

## Test plan

- [x] `pnpm --filter @kubb/ast exec vitest run` (304 passed) + `pnpm --filter @kubb/adapter-oas exec vitest run src/parser.test.ts` (332 passed, incl. new response-`content` cases)
- [x] `pnpm --filter @kubb/ast --filter @kubb/adapter-oas typecheck`
- [x] `pnpm --filter @kubb/ast --filter @kubb/adapter-oas build`

## Notes

The plugins PR depends on this being released and the plugins catalog bumped to the new `@kubb/adapter-oas`/`@kubb/ast` version.
