### PR TITLE
refactor(ast,adapter-oas): table-driven dispatch, structural-sharing transform, OAS dialect

### DIFF
--- a/.changeset/adapter-oas-schema-dialect.md
+++ b/.changeset/adapter-oas-schema-dialect.md
@@ -1,0 +1,5 @@
+---
+'@kubb/adapter-oas': patch
+---
+
+Isolate the OpenAPI-specific schema decisions (nullability, `$ref` detection and resolution, discriminator, binary) behind a single `SchemaDialect` passed into `createSchemaParser`. The converter pipeline and dispatch rules are now dialect-driven with the OAS dialect as the default, so the spec-specific surface lives in one documented place — the seam a future adapter (e.g. AsyncAPI) targets. No change to generated output.

--- a/.changeset/add-ast-dispatch-helper.md
+++ b/.changeset/add-ast-dispatch-helper.md
@@ -1,0 +1,6 @@
+---
+'@kubb/ast': minor
+'@kubb/adapter-oas': patch
+---
+
+Add a generic `dispatch` helper and `DispatchRule` type to `@kubb/ast`: an ordered match/convert table that maps source-spec shapes onto Kubb AST nodes. `@kubb/adapter-oas` now builds its OAS schema parser on top of it, replacing the long `parseSchema` if/else chain with a declarative `schemaRules` table. The mechanism is spec-agnostic, so future adapters (e.g. AsyncAPI) can reuse the same traversal by defining their own context type and rules. No change to generated output.

--- a/.changeset/ast-define-dialect.md
+++ b/.changeset/ast-define-dialect.md
@@ -3,4 +3,4 @@
 '@kubb/adapter-oas': patch
 ---
 
-Promote the schema dialect to `@kubb/ast` as a first-class, spec-agnostic contract: add a generic, guard-preserving `SchemaDialect<TSchema, TRef, TDiscriminated, TDocument>` type and a `defineDialect` helper, alongside `dispatch`. `@kubb/adapter-oas` now builds `oasDialect` with `ast.defineDialect`, so the JSON-Schema-family seam (nullability, `$ref`, discriminator, binary, ref resolution) is shared across adapters — an AsyncAPI adapter supplies its own dialect and reuses the converter pipeline and dispatch rules. No change to generated output.
+Promote the schema dialect to `@kubb/ast` as a first-class, spec-agnostic contract: add a generic, guard-preserving `SchemaDialect<TSchema, TRef, TDiscriminated, TDocument>` type and a `defineSchemaDialect` helper, alongside `dispatch`. `@kubb/adapter-oas` now builds `oasDialect` with `ast.defineSchemaDialect`, so the JSON-Schema-family seam (nullability, `$ref`, discriminator, binary, ref resolution) is shared across adapters — an AsyncAPI adapter supplies its own dialect and reuses the converter pipeline and dispatch rules. No change to generated output.

--- a/.changeset/ast-define-dialect.md
+++ b/.changeset/ast-define-dialect.md
@@ -1,0 +1,6 @@
+---
+'@kubb/ast': minor
+'@kubb/adapter-oas': patch
+---
+
+Promote the schema dialect to `@kubb/ast` as a first-class, spec-agnostic contract: add a generic, guard-preserving `SchemaDialect<TSchema, TRef, TDiscriminated, TDocument>` type and a `defineDialect` helper, alongside `dispatch`. `@kubb/adapter-oas` now builds `oasDialect` with `ast.defineDialect`, so the JSON-Schema-family seam (nullability, `$ref`, discriminator, binary, ref resolution) is shared across adapters — an AsyncAPI adapter supplies its own dialect and reuses the converter pipeline and dispatch rules. No change to generated output.

--- a/.changeset/ast-structural-sharing-transform.md
+++ b/.changeset/ast-structural-sharing-transform.md
@@ -1,0 +1,5 @@
+---
+'@kubb/ast': minor
+---
+
+`transform` now preserves identity (structural sharing): when a pass leaves a node and all its descendants unchanged it returns the same reference instead of reallocating the subtree. No-op rewrites become free and callers can detect "nothing changed" by reference, which keeps caches valid and cuts allocations on large specs. Adds an `update(node, changes)` factory — an identity-preserving shallow update, the analogue of the TypeScript compiler's `factory.updateX`.

--- a/packages/adapter-oas/src/dialect.ts
+++ b/packages/adapter-oas/src/dialect.ts
@@ -1,0 +1,50 @@
+import { isDiscriminator, isNullable, isReference } from './guards.ts'
+import { resolveRef } from './refs.ts'
+import type { SchemaObject } from './types.ts'
+
+/**
+ * The spec-specific decisions a schema parser makes while converting a source
+ * document's schemas into Kubb AST nodes.
+ *
+ * Everything else in `createSchemaParser` is generic JSON Schema shared across
+ * adapters; this object is the one seam where a spec differs. A future adapter
+ * (e.g. AsyncAPI) supplies its own dialect — nullability via `type: ['null', …]`
+ * only, no discriminator object, binary via `contentEncoding` — and reuses the
+ * converter pipeline and dispatch rules unchanged.
+ *
+ * Formats (`uuid`, `email`, dates, …) are intentionally NOT here: they are shared
+ * JSON Schema vocabulary, so keeping them in the converters avoids duplicating
+ * the common case across adapters.
+ */
+export type SchemaDialect = {
+  /** Identifies the dialect in logs and while debugging dispatch. */
+  name: string
+  /** Whether a schema should be treated as nullable. */
+  isNullable: typeof isNullable
+  /** Whether a value is a `$ref` pointer object. */
+  isReference: typeof isReference
+  /** Whether a schema carries a structured discriminator (polymorphism). */
+  isDiscriminator: typeof isDiscriminator
+  /** Whether a schema represents binary data (converted to a `blob` node). */
+  isBinary: (schema: SchemaObject) => boolean
+  /** Resolves a local `$ref` pointer against the document. */
+  resolveRef: typeof resolveRef
+}
+
+/**
+ * The OpenAPI / Swagger dialect — the default used by `@kubb/adapter-oas`.
+ *
+ * @example
+ * ```ts
+ * const parser = createSchemaParser(context)            // uses oasDialect
+ * const parser = createSchemaParser(context, oasDialect) // explicit
+ * ```
+ */
+export const oasDialect: SchemaDialect = {
+  name: 'oas',
+  isNullable,
+  isReference,
+  isDiscriminator,
+  isBinary: (schema) => schema.type === 'string' && schema.contentMediaType === 'application/octet-stream',
+  resolveRef,
+}

--- a/packages/adapter-oas/src/dialect.ts
+++ b/packages/adapter-oas/src/dialect.ts
@@ -1,50 +1,38 @@
+import { ast } from '@kubb/core'
 import { isDiscriminator, isNullable, isReference } from './guards.ts'
 import { resolveRef } from './refs.ts'
 import type { SchemaObject } from './types.ts'
 
 /**
- * The spec-specific decisions a schema parser makes while converting a source
- * document's schemas into Kubb AST nodes.
+ * The OpenAPI / Swagger dialect — the default used by `@kubb/adapter-oas`.
  *
- * Everything else in `createSchemaParser` is generic JSON Schema shared across
- * adapters; this object is the one seam where a spec differs. A future adapter
- * (e.g. AsyncAPI) supplies its own dialect — nullability via `type: ['null', …]`
- * only, no discriminator object, binary via `contentEncoding` — and reuses the
- * converter pipeline and dispatch rules unchanged.
+ * Implements the spec-agnostic {@link ast.SchemaDialect} contract: it isolates the
+ * decisions that differ between specs (nullability, `$ref`, discriminator, binary,
+ * ref resolution) so the converter pipeline and dispatch rules stay shared. A
+ * future adapter (e.g. AsyncAPI) ships its own dialect — `type: ['null', …]`
+ * nullability, no discriminator object, binary via `contentEncoding` — and reuses
+ * the rest unchanged.
  *
  * Formats (`uuid`, `email`, dates, …) are intentionally NOT here: they are shared
- * JSON Schema vocabulary, so keeping them in the converters avoids duplicating
- * the common case across adapters.
- */
-export type SchemaDialect = {
-  /** Identifies the dialect in logs and while debugging dispatch. */
-  name: string
-  /** Whether a schema should be treated as nullable. */
-  isNullable: typeof isNullable
-  /** Whether a value is a `$ref` pointer object. */
-  isReference: typeof isReference
-  /** Whether a schema carries a structured discriminator (polymorphism). */
-  isDiscriminator: typeof isDiscriminator
-  /** Whether a schema represents binary data (converted to a `blob` node). */
-  isBinary: (schema: SchemaObject) => boolean
-  /** Resolves a local `$ref` pointer against the document. */
-  resolveRef: typeof resolveRef
-}
-
-/**
- * The OpenAPI / Swagger dialect — the default used by `@kubb/adapter-oas`.
+ * JSON Schema vocabulary, so the converters keep that common case.
  *
  * @example
  * ```ts
- * const parser = createSchemaParser(context)            // uses oasDialect
+ * const parser = createSchemaParser(context)             // uses oasDialect
  * const parser = createSchemaParser(context, oasDialect) // explicit
  * ```
  */
-export const oasDialect: SchemaDialect = {
+export const oasDialect = ast.defineDialect({
   name: 'oas',
   isNullable,
   isReference,
   isDiscriminator,
-  isBinary: (schema) => schema.type === 'string' && schema.contentMediaType === 'application/octet-stream',
+  isBinary: (schema: SchemaObject) => schema.type === 'string' && schema.contentMediaType === 'application/octet-stream',
   resolveRef,
-}
+})
+
+/**
+ * The concrete dialect type for `@kubb/adapter-oas`. Keeps the OAS guard predicates
+ * (`isReference`, `isDiscriminator`) intact so converters narrow schemas after a check.
+ */
+export type OasDialect = typeof oasDialect

--- a/packages/adapter-oas/src/dialect.ts
+++ b/packages/adapter-oas/src/dialect.ts
@@ -22,7 +22,7 @@ import type { SchemaObject } from './types.ts'
  * const parser = createSchemaParser(context, oasDialect) // explicit
  * ```
  */
-export const oasDialect = ast.defineDialect({
+export const oasDialect = ast.defineSchemaDialect({
   name: 'oas',
   isNullable,
   isReference,

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -1,8 +1,9 @@
 import { ast } from '@kubb/core'
 import { describe, expect, it } from 'vitest'
 import { buildMinimalOas } from '../mocks/oas.ts'
+import { oasDialect, type SchemaDialect } from './dialect.ts'
 import { parseDocument } from './factory.ts'
-import { parseOas, parseSchema } from './parser.ts'
+import { createSchemaParser, parseOas, parseSchema } from './parser.ts'
 import type { Document, SchemaObject } from './types.ts'
 
 const emptyDocument: Document = {
@@ -4149,5 +4150,33 @@ describe('enum naming', () => {
     const enumNode = ast.narrowSchema(arrayNode?.items?.[0], 'enum')
 
     expect(enumNode?.name).toBe('ItemTagsEnum')
+  })
+})
+
+describe('SchemaDialect seam', () => {
+  const ctx = { document: emptyDocument }
+
+  it('routes nullability through the dialect', () => {
+    const schema: SchemaObject = { type: 'string', nullable: true }
+
+    // The default OAS dialect honors `nullable: true`.
+    expect(parseSchema(ctx, { schema }).nullable).toBe(true)
+
+    // A dialect that never treats schemas as nullable drops the flag.
+    const nonNullable: SchemaDialect = { ...oasDialect, name: 'test', isNullable: () => false }
+    const node = createSchemaParser(ctx, nonNullable).parseSchema({ schema })
+    expect(node.nullable).toBeUndefined()
+  })
+
+  it('routes binary detection through the dialect', () => {
+    const schema: SchemaObject = { type: 'string', contentMediaType: 'application/octet-stream' }
+
+    // The default OAS dialect maps octet-stream strings to `blob`.
+    expect(parseSchema(ctx, { schema }).type).toBe('blob')
+
+    // A dialect that reports nothing as binary falls through to `string`.
+    const noBinary: SchemaDialect = { ...oasDialect, name: 'test', isBinary: () => false }
+    const node = createSchemaParser(ctx, noBinary).parseSchema({ schema })
+    expect(node.type).toBe('string')
   })
 })

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -1,7 +1,7 @@
 import { ast } from '@kubb/core'
 import { describe, expect, it } from 'vitest'
 import { buildMinimalOas } from '../mocks/oas.ts'
-import { oasDialect, type SchemaDialect } from './dialect.ts'
+import { oasDialect, type OasDialect } from './dialect.ts'
 import { parseDocument } from './factory.ts'
 import { createSchemaParser, parseOas, parseSchema } from './parser.ts'
 import type { Document, SchemaObject } from './types.ts'
@@ -4163,7 +4163,7 @@ describe('SchemaDialect seam', () => {
     expect(parseSchema(ctx, { schema }).nullable).toBe(true)
 
     // A dialect that never treats schemas as nullable drops the flag.
-    const nonNullable: SchemaDialect = { ...oasDialect, name: 'test', isNullable: () => false }
+    const nonNullable: OasDialect = { ...oasDialect, name: 'test', isNullable: () => false }
     const node = createSchemaParser(ctx, nonNullable).parseSchema({ schema })
     expect(node.nullable).toBeUndefined()
   })
@@ -4175,7 +4175,7 @@ describe('SchemaDialect seam', () => {
     expect(parseSchema(ctx, { schema }).type).toBe('blob')
 
     // A dialect that reports nothing as binary falls through to `string`.
-    const noBinary: SchemaDialect = { ...oasDialect, name: 'test', isBinary: () => false }
+    const noBinary: OasDialect = { ...oasDialect, name: 'test', isBinary: () => false }
     const node = createSchemaParser(ctx, noBinary).parseSchema({ schema })
     expect(node.type).toBe('string')
   })

--- a/packages/adapter-oas/src/parser.ts
+++ b/packages/adapter-oas/src/parser.ts
@@ -61,6 +61,13 @@ type SchemaContext = {
 }
 
 /**
+ * One entry in this adapter's schema-dispatch table — a {@link ast.DispatchRule} specialized
+ * to OAS schema context and Kubb `SchemaNode` output. See {@link ast.dispatch} for the contract
+ * a future adapter (e.g. AsyncAPI) follows: define a context type and an ordered rules table.
+ */
+type SchemaRule = ast.DispatchRule<SchemaContext, ast.SchemaNode>
+
+/**
  * Normalizes malformed `{ type: 'array', enum: [...] }` schemas by moving enum values into items.
  *
  * This pattern violates the OpenAPI spec but appears in real specs. The fix moves enum values
@@ -722,11 +729,85 @@ export function createSchemaParser(ctx: OasParserContext) {
   }
 
   /**
+   * Converts a binary string schema (`type: 'string'`, `contentMediaType: 'application/octet-stream'`)
+   * into a `blob` node.
+   */
+  function convertBlob({ schema, name, nullable, defaultValue }: SchemaContext): ast.SchemaNode {
+    return ast.createSchema({
+      type: 'blob',
+      primitive: 'string',
+      ...buildSchemaNode(schema, name, nullable, defaultValue),
+    })
+  }
+
+  /**
+   * Converts an OAS 3.1 multi-type array (e.g. `type: ['string', 'number']`) into a `UnionSchemaNode`.
+   *
+   * Returns `null` when only one non-`null` type remains (e.g. `['string', 'null']`), so `parseSchema`
+   * falls through and handles it as that single type with nullability already folded in.
+   */
+  function convertMultiType({ schema, name, nullable, defaultValue, rawOptions }: SchemaContext): ast.SchemaNode | null {
+    const types = schema.type as Array<string>
+    const nonNullTypes = types.filter((t) => t !== 'null')
+    if (nonNullTypes.length <= 1) return null
+
+    const arrayNullable = types.includes('null') || nullable || undefined
+    return ast.createSchema({
+      type: 'union',
+      members: nonNullTypes.map((t) => parseSchema({ schema: { ...schema, type: t } as SchemaObject, name }, rawOptions)),
+      ...buildSchemaNode(schema, name, arrayNullable, defaultValue),
+    })
+  }
+
+  /**
+   * Ordered schema-dispatch table. Order is significant: composition keywords (`$ref`, `allOf`,
+   * `oneOf`/`anyOf`) take precedence over `const`/`format`, which take precedence over the plain
+   * `type`. The first matching rule that produces a node wins; see {@link SchemaRule} for the
+   * match/convert/fall-through contract.
+   */
+  const schemaRules: Array<SchemaRule> = [
+    { name: 'ref', match: ({ schema }) => isReference(schema), convert: convertRef },
+    { name: 'allOf', match: ({ schema }) => !!schema.allOf?.length, convert: convertAllOf },
+    { name: 'union', match: ({ schema }) => !!(schema.oneOf?.length || schema.anyOf?.length), convert: convertUnion },
+    { name: 'const', match: ({ schema }) => 'const' in schema && schema.const !== undefined, convert: convertConst },
+    { name: 'format', match: ({ schema }) => !!schema.format, convert: convertFormat },
+    {
+      name: 'blob',
+      match: ({ schema }) => schema.type === 'string' && schema.contentMediaType === 'application/octet-stream',
+      convert: convertBlob,
+    },
+    { name: 'multi-type', match: ({ schema }) => Array.isArray(schema.type) && schema.type.length > 1, convert: convertMultiType },
+    {
+      name: 'constrained-string',
+      match: ({ schema, type }) => !type && (schema.minLength !== undefined || schema.maxLength !== undefined || schema.pattern !== undefined),
+      convert: convertString,
+    },
+    {
+      name: 'constrained-number',
+      match: ({ schema, type }) => !type && (schema.minimum !== undefined || schema.maximum !== undefined),
+      convert: (ctx) => convertNumeric(ctx, 'number'),
+    },
+    { name: 'enum', match: ({ schema }) => !!schema.enum?.length, convert: convertEnum },
+    {
+      name: 'object',
+      match: ({ schema, type }) => type === 'object' || !!schema.properties || !!schema.additionalProperties || 'patternProperties' in schema,
+      convert: convertObject,
+    },
+    { name: 'tuple', match: ({ schema }) => 'prefixItems' in schema, convert: convertTuple },
+    { name: 'array', match: ({ schema, type }) => type === 'array' || 'items' in schema, convert: convertArray },
+    { name: 'string', match: ({ type }) => type === 'string', convert: convertString },
+    { name: 'number', match: ({ type }) => type === 'number', convert: (ctx) => convertNumeric(ctx, 'number') },
+    { name: 'integer', match: ({ type }) => type === 'integer', convert: (ctx) => convertNumeric(ctx, 'integer') },
+    { name: 'boolean', match: ({ type }) => type === 'boolean', convert: convertBoolean },
+    { name: 'null', match: ({ type }) => type === 'null', convert: convertNull },
+  ]
+
+  /**
    * Central dispatcher that converts an OAS `SchemaObject` into a `SchemaNode`.
    *
-   * Dispatch order (first match wins): `$ref` → `allOf` → `oneOf`/`anyOf` → `const` → `format`
-   * → octet-stream blob → multi-type array → constraint-inferred type → `enum` → object/array/tuple/scalar
-   * → empty-schema fallback (`emptySchemaType` option).
+   * Builds the per-schema context, then runs it through the ordered {@link schemaRules} table
+   * via {@link ast.dispatch}. When no rule produces a node, falls back to the configured
+   * `emptySchemaType`.
    */
   function parseSchema({ schema, name }: { schema: SchemaObject; name?: string | null }, rawOptions?: Partial<ast.ParserOptions>): ast.SchemaNode {
     const options: ast.ParserOptions = {
@@ -742,7 +823,7 @@ export function createSchemaParser(ctx: OasParserContext) {
     const defaultValue = schema.default === null && nullable ? undefined : schema.default
     const type = Array.isArray(schema.type) ? schema.type[0] : schema.type
 
-    const ctx: SchemaContext = {
+    const schemaCtx: SchemaContext = {
       schema,
       name,
       nullable,
@@ -752,58 +833,8 @@ export function createSchemaParser(ctx: OasParserContext) {
       options,
     }
 
-    if (isReference(schema)) return convertRef(ctx)
-
-    if (schema.allOf?.length) return convertAllOf(ctx)
-    const unionMembers = [...(schema.oneOf ?? []), ...(schema.anyOf ?? [])]
-    if (unionMembers.length) return convertUnion(ctx)
-
-    if ('const' in schema && schema.const !== undefined) return convertConst(ctx)
-
-    if (schema.format) {
-      const formatResult = convertFormat(ctx)
-      if (formatResult) return formatResult
-    }
-
-    if (schema.type === 'string' && schema.contentMediaType === 'application/octet-stream') {
-      return ast.createSchema({
-        type: 'blob',
-        primitive: 'string',
-        ...buildSchemaNode(schema, name, nullable, defaultValue),
-      })
-    }
-
-    if (Array.isArray(schema.type) && schema.type.length > 1) {
-      const nonNullTypes = schema.type.filter((t) => t !== 'null') as Array<string>
-      const arrayNullable = schema.type.includes('null') || nullable || undefined
-
-      if (nonNullTypes.length > 1) {
-        return ast.createSchema({
-          type: 'union',
-          members: nonNullTypes.map((t) => parseSchema({ schema: { ...schema, type: t } as SchemaObject, name }, rawOptions)),
-          ...buildSchemaNode(schema, name, arrayNullable, defaultValue),
-        })
-      }
-    }
-
-    if (!type) {
-      if (schema.minLength !== undefined || schema.maxLength !== undefined || schema.pattern !== undefined) {
-        return convertString(ctx)
-      }
-      if (schema.minimum !== undefined || schema.maximum !== undefined) {
-        return convertNumeric(ctx, 'number')
-      }
-    }
-
-    if (schema.enum?.length) return convertEnum(ctx)
-    if (type === 'object' || schema.properties || schema.additionalProperties || 'patternProperties' in schema) return convertObject(ctx)
-    if ('prefixItems' in schema) return convertTuple(ctx)
-    if (type === 'array' || 'items' in schema) return convertArray(ctx)
-    if (type === 'string') return convertString(ctx)
-    if (type === 'number') return convertNumeric(ctx, 'number')
-    if (type === 'integer') return convertNumeric(ctx, 'integer')
-    if (type === 'boolean') return convertBoolean(ctx)
-    if (type === 'null') return convertNull(ctx)
+    const node = ast.dispatch(schemaRules, schemaCtx)
+    if (node) return node
 
     const emptyType = typeOptionMap.get(options.emptySchemaType)!
     return ast.createSchema({

--- a/packages/adapter-oas/src/parser.ts
+++ b/packages/adapter-oas/src/parser.ts
@@ -2,7 +2,7 @@ import { pascalCase, URLPath } from '@internals/utils'
 import { ast } from '@kubb/core'
 import BaseOas from 'oas'
 import { DEFAULT_PARSER_OPTIONS, enumExtensionKeys, SCHEMA_REF_PREFIX, typeOptionMap } from './constants.ts'
-import { oasDialect, type SchemaDialect } from './dialect.ts'
+import { oasDialect, type OasDialect } from './dialect.ts'
 import {
   buildSchemaNode,
   flattenSchema,
@@ -94,7 +94,7 @@ function normalizeArrayEnum(schema: SchemaObject): SchemaObject {
  *
  * @internal
  */
-export function createSchemaParser(ctx: OasParserContext, dialect: SchemaDialect = oasDialect) {
+export function createSchemaParser(ctx: OasParserContext, dialect: OasDialect = oasDialect) {
   const document = ctx.document
 
   // Branch handlers — each converts one OAS schema pattern to a SchemaNode.

--- a/packages/adapter-oas/src/parser.ts
+++ b/packages/adapter-oas/src/parser.ts
@@ -2,8 +2,7 @@ import { pascalCase, URLPath } from '@internals/utils'
 import { ast } from '@kubb/core'
 import BaseOas from 'oas'
 import { DEFAULT_PARSER_OPTIONS, enumExtensionKeys, SCHEMA_REF_PREFIX, typeOptionMap } from './constants.ts'
-import { isDiscriminator, isNullable, isReference } from './guards.ts'
-import { resolveRef } from './refs.ts'
+import { oasDialect, type SchemaDialect } from './dialect.ts'
 import {
   buildSchemaNode,
   flattenSchema,
@@ -95,7 +94,7 @@ function normalizeArrayEnum(schema: SchemaObject): SchemaObject {
  *
  * @internal
  */
-export function createSchemaParser(ctx: OasParserContext) {
+export function createSchemaParser(ctx: OasParserContext, dialect: SchemaDialect = oasDialect) {
   const document = ctx.document
 
   // Branch handlers — each converts one OAS schema pattern to a SchemaNode.
@@ -134,7 +133,7 @@ export function createSchemaParser(ctx: OasParserContext) {
     if (refPath && !resolvingRefs.has(refPath)) {
       if (!resolvedRefCache.has(refPath)) {
         try {
-          const referenced = resolveRef<SchemaObject>(document, refPath)
+          const referenced = dialect.resolveRef<SchemaObject>(document, refPath)
           if (referenced) {
             resolvingRefs.add(refPath)
             resolvedSchema = parseSchema({ schema: referenced }, rawOptions)
@@ -195,13 +194,13 @@ export function createSchemaParser(ctx: OasParserContext) {
     }> = []
     const allOfMembers: Array<ast.SchemaNode> = (schema.allOf as Array<SchemaObject | ReferenceObject>)
       .filter((item) => {
-        if (!isReference(item) || !name) return true
-        const deref = resolveRef<SchemaObject>(document, item.$ref)
-        if (!deref || !isDiscriminator(deref)) return true
+        if (!dialect.isReference(item) || !name) return true
+        const deref = dialect.resolveRef<SchemaObject>(document, item.$ref)
+        if (!deref || !dialect.isDiscriminator(deref)) return true
         const parentUnion = deref.oneOf ?? deref.anyOf
         if (!parentUnion) return true
         const childRef = `${SCHEMA_REF_PREFIX}${name}`
-        const inOneOf = parentUnion.some((oneOfItem) => isReference(oneOfItem) && oneOfItem.$ref === childRef)
+        const inOneOf = parentUnion.some((oneOfItem) => dialect.isReference(oneOfItem) && oneOfItem.$ref === childRef)
         const inMapping = Object.values(deref.discriminator.mapping ?? {}).some((v) => v === childRef)
         if (inOneOf || inMapping) {
           const discriminatorValue = ast.findDiscriminator(deref.discriminator.mapping, childRef)
@@ -225,9 +224,9 @@ export function createSchemaParser(ctx: OasParserContext) {
 
       if (missingRequired.length) {
         const resolvedMembers = (schema.allOf as Array<SchemaObject | ReferenceObject>).flatMap((item) => {
-          if (!isReference(item)) return [item as SchemaObject]
-          const deref = resolveRef<SchemaObject>(document, item.$ref)
-          return deref && !isReference(deref) ? [deref] : []
+          if (!dialect.isReference(item)) return [item as SchemaObject]
+          const deref = dialect.resolveRef<SchemaObject>(document, item.$ref)
+          return deref && !dialect.isReference(deref) ? [deref] : []
         })
 
         for (const key of missingRequired) {
@@ -294,10 +293,10 @@ export function createSchemaParser(ctx: OasParserContext) {
     const strategy: 'one' | 'any' = schema.oneOf ? 'one' : 'any'
     const unionBase = {
       ...buildSchemaNode(schema, name, nullable, defaultValue),
-      discriminatorPropertyName: isDiscriminator(schema) ? schema.discriminator.propertyName : undefined,
+      discriminatorPropertyName: dialect.isDiscriminator(schema) ? schema.discriminator.propertyName : undefined,
       strategy,
     }
-    const discriminator = isDiscriminator(schema) ? schema.discriminator : undefined
+    const discriminator = dialect.isDiscriminator(schema) ? schema.discriminator : undefined
     const sharedPropertiesNode = schema.properties
       ? (() => {
           const { oneOf: _oneOf, anyOf: _anyOf, ...schemaWithoutUnion } = schema
@@ -310,7 +309,7 @@ export function createSchemaParser(ctx: OasParserContext) {
 
     if (sharedPropertiesNode || discriminator?.mapping) {
       const members = unionMembers.map((s) => {
-        const ref = isReference(s) ? s.$ref : undefined
+        const ref = dialect.isReference(s) ? s.$ref : undefined
         const discriminatorValue = ast.findDiscriminator(discriminator?.mapping, ref)
         const memberNode = parseSchema({ schema: s as SchemaObject, name }, rawOptions)
 
@@ -555,7 +554,7 @@ export function createSchemaParser(ctx: OasParserContext) {
       ? Object.entries(schema.properties).map(([propName, propSchema]) => {
           const required = Array.isArray(schema.required) ? schema.required.includes(propName) : !!schema.required
           const resolvedPropSchema = propSchema as SchemaObject
-          const propNullable = isNullable(resolvedPropSchema)
+          const propNullable = dialect.isNullable(resolvedPropSchema)
 
           const resolvedChildName = ast.childName(name, propName)
           const propNode = parseSchema({ schema: resolvedPropSchema, name: resolvedChildName }, rawOptions)
@@ -619,7 +618,7 @@ export function createSchemaParser(ctx: OasParserContext) {
       ...buildSchemaNode(schema, name, nullable, defaultValue),
     })
 
-    if (isDiscriminator(schema) && schema.discriminator.mapping) {
+    if (dialect.isDiscriminator(schema) && schema.discriminator.mapping) {
       const discPropName = schema.discriminator.propertyName
       const values = Object.keys(schema.discriminator.mapping)
       const enumName = name ? ast.enumPropName(name, discPropName, options.enumSuffix) : undefined
@@ -766,14 +765,14 @@ export function createSchemaParser(ctx: OasParserContext) {
    * match/convert/fall-through contract.
    */
   const schemaRules: Array<SchemaRule> = [
-    { name: 'ref', match: ({ schema }) => isReference(schema), convert: convertRef },
+    { name: 'ref', match: ({ schema }) => dialect.isReference(schema), convert: convertRef },
     { name: 'allOf', match: ({ schema }) => !!schema.allOf?.length, convert: convertAllOf },
     { name: 'union', match: ({ schema }) => !!(schema.oneOf?.length || schema.anyOf?.length), convert: convertUnion },
     { name: 'const', match: ({ schema }) => 'const' in schema && schema.const !== undefined, convert: convertConst },
     { name: 'format', match: ({ schema }) => !!schema.format, convert: convertFormat },
     {
       name: 'blob',
-      match: ({ schema }) => schema.type === 'string' && schema.contentMediaType === 'application/octet-stream',
+      match: ({ schema }) => dialect.isBinary(schema),
       convert: convertBlob,
     },
     { name: 'multi-type', match: ({ schema }) => Array.isArray(schema.type) && schema.type.length > 1, convert: convertMultiType },
@@ -819,7 +818,7 @@ export function createSchemaParser(ctx: OasParserContext) {
       return parseSchema({ schema: flattenedSchema, name }, rawOptions)
     }
 
-    const nullable = isNullable(schema) || undefined
+    const nullable = dialect.isNullable(schema) || undefined
     const defaultValue = schema.default === null && nullable ? undefined : schema.default
     const type = Array.isArray(schema.type) ? schema.type[0] : schema.type
 
@@ -914,7 +913,7 @@ export function createSchemaParser(ctx: OasParserContext) {
     const keys: Array<string> = []
     for (const key in schema.properties) {
       const prop = schema.properties[key]
-      if (prop && !isReference(prop) && (prop as Record<string, unknown>)[flag]) {
+      if (prop && !dialect.isReference(prop) && (prop as Record<string, unknown>)[flag]) {
         keys.push(key)
       }
     }

--- a/packages/ast/src/dialect.ts
+++ b/packages/ast/src/dialect.ts
@@ -12,6 +12,14 @@
  * converters narrow the schema after a check; the type parameters carry those
  * narrowed types through.
  *
+ * Scope: this is the seam for the **JSON Schema family** — OpenAPI, AsyncAPI, and
+ * plain JSON Schema all share `$ref`, `allOf`/`oneOf`, `enum`, and `format`, and
+ * differ only in these few decisions. A spec built on a different type system
+ * (e.g. GraphQL, with non-null wrappers, interfaces, and named-type references
+ * instead of `$ref`) does not implement a `SchemaDialect`; it reuses the universal
+ * layer directly — the `Adapter` port, the AST factories, and {@link dispatch}
+ * with its own rule table — to emit the same nodes.
+ *
  * @typeParam TSchema - The adapter's schema object type (e.g. an OpenAPI `SchemaObject`).
  * @typeParam TRef - The narrowed `$ref` pointer type `isReference` proves.
  * @typeParam TDiscriminated - The narrowed discriminated-schema type `isDiscriminator` proves.

--- a/packages/ast/src/dialect.ts
+++ b/packages/ast/src/dialect.ts
@@ -1,0 +1,56 @@
+/**
+ * The spec-specific decisions a schema parser makes while converting a source
+ * document's schemas into Kubb AST nodes.
+ *
+ * Everything else in an adapter's schema pipeline is generic JSON Schema shared
+ * across specs; the dialect is the one seam where a spec differs — the
+ * "dialect layer" analogue of a database driver targeting Postgres vs MySQL.
+ * Pair it with {@link dispatch}: the rule table decides *which* converter runs,
+ * the dialect answers the spec-specific questions inside them.
+ *
+ * The guard methods (`isReference`, `isDiscriminator`) are type predicates so
+ * converters narrow the schema after a check; the type parameters carry those
+ * narrowed types through.
+ *
+ * @typeParam TSchema - The adapter's schema object type (e.g. an OpenAPI `SchemaObject`).
+ * @typeParam TRef - The narrowed `$ref` pointer type `isReference` proves.
+ * @typeParam TDiscriminated - The narrowed discriminated-schema type `isDiscriminator` proves.
+ * @typeParam TDocument - The source document `resolveRef` resolves against.
+ */
+export type SchemaDialect<TSchema = unknown, TRef = TSchema, TDiscriminated = TSchema, TDocument = unknown> = {
+  /** Identifies the dialect in logs and while debugging dispatch. */
+  name: string
+  /** Whether a schema should be treated as nullable. */
+  isNullable: (schema?: TSchema) => boolean
+  /** Whether a value is a `$ref` pointer object. */
+  isReference: (value?: unknown) => value is TRef
+  /** Whether a schema carries a structured discriminator (polymorphism). */
+  isDiscriminator: (value?: unknown) => value is TDiscriminated
+  /** Whether a schema represents binary data (converted to a `blob` node). */
+  isBinary: (schema: TSchema) => boolean
+  /** Resolves a local `$ref` pointer against the document, or nullish when it cannot. */
+  resolveRef: <TResolved>(document: TDocument, ref: string) => TResolved | null | undefined
+}
+
+/**
+ * Identity helper that types a {@link SchemaDialect} for an adapter. Like
+ * `defineParser`, it adds no runtime behavior — it pins the dialect's type for
+ * inference and gives adapter authors a discoverable anchor.
+ *
+ * @example
+ * ```ts
+ * export const oasDialect = defineDialect<OasDialect>({
+ *   name: 'oas',
+ *   isNullable,
+ *   isReference,
+ *   isDiscriminator,
+ *   isBinary: (schema) => schema.type === 'string' && schema.contentMediaType === 'application/octet-stream',
+ *   resolveRef,
+ * })
+ * ```
+ */
+export function defineDialect<TSchema, TRef, TDiscriminated, TDocument>(
+  dialect: SchemaDialect<TSchema, TRef, TDiscriminated, TDocument>,
+): SchemaDialect<TSchema, TRef, TDiscriminated, TDocument> {
+  return dialect
+}

--- a/packages/ast/src/dialect.ts
+++ b/packages/ast/src/dialect.ts
@@ -47,7 +47,7 @@ export type SchemaDialect<TSchema = unknown, TRef = TSchema, TDiscriminated = TS
  *
  * @example
  * ```ts
- * export const oasDialect = defineDialect<OasDialect>({
+ * export const oasDialect = defineSchemaDialect({
  *   name: 'oas',
  *   isNullable,
  *   isReference,
@@ -57,7 +57,7 @@ export type SchemaDialect<TSchema = unknown, TRef = TSchema, TDiscriminated = TS
  * })
  * ```
  */
-export function defineDialect<TSchema, TRef, TDiscriminated, TDocument>(
+export function defineSchemaDialect<TSchema, TRef, TDiscriminated, TDocument>(
   dialect: SchemaDialect<TSchema, TRef, TDiscriminated, TDocument>,
 ): SchemaDialect<TSchema, TRef, TDiscriminated, TDocument> {
   return dialect

--- a/packages/ast/src/dispatch.ts
+++ b/packages/ast/src/dispatch.ts
@@ -1,0 +1,53 @@
+/**
+ * One entry in an ordered dispatch table: a predicate paired with a converter.
+ *
+ * @typeParam TContext - Per-input context handed to every rule. A spec adapter typically
+ *   pre-computes this once per node (the source spec node plus derived fields like a
+ *   normalized type or resolved options) so individual rules stay cheap predicates.
+ * @typeParam TNode - The node a rule produces, e.g. a Kubb AST `SchemaNode`.
+ */
+export type DispatchRule<TContext, TNode> = {
+  /** Identifies the rule when reading the table or debugging which branch ran. */
+  name: string
+  /** Returns `true` when this rule is responsible for the given context. */
+  match: (context: TContext) => boolean
+  /**
+   * Produces a node for the context, or `null` to fall through to the next rule.
+   *
+   * Returning `null` lets a broad `match` defer: e.g. "has a `format`" matches many schemas,
+   * but only some formats are convertible — the rest fall through to plain `type` handling.
+   */
+  convert: (context: TContext) => TNode | null
+}
+
+/**
+ * Walks an ordered list of {@link DispatchRule}s and returns the first node produced.
+ *
+ * This is the shared backbone for spec adapters (OpenAPI today, AsyncAPI and others later).
+ * The contract an adapter follows is intentionally minimal:
+ *
+ *     context → [rule.match → rule.convert] → node
+ *
+ * An adapter derives a context from a source spec node, then declares an ordered table of
+ * rules mapping spec shapes onto Kubb AST nodes. To add support for a new spec, write a new
+ * context type and a new rules table — the traversal here is reused unchanged.
+ *
+ * Order is significant: earlier rules win, so list higher-precedence or more specific shapes
+ * first (e.g. composition keywords before plain `type`). A rule whose `match` returns `true`
+ * may still `convert` to `null` to defer to later rules. When no rule produces a node this
+ * returns `null`, leaving the caller to apply its own fallback.
+ *
+ * @example
+ * ```ts
+ * const node = dispatch(schemaRules, schemaContext) ?? createSchema({ type: fallbackType })
+ * ```
+ */
+export function dispatch<TContext, TNode>(rules: ReadonlyArray<DispatchRule<TContext, TNode>>, context: TContext): TNode | null {
+  for (const rule of rules) {
+    if (!rule.match(context)) continue
+    const node = rule.convert(context)
+    if (node !== null && node !== undefined) return node
+  }
+
+  return null
+}

--- a/packages/ast/src/factory.ts
+++ b/packages/ast/src/factory.ts
@@ -17,6 +17,7 @@ import type {
   InputNode,
   InputStreamNode,
   JsxNode,
+  Node,
   ObjectSchemaNode,
   OperationNode,
   OutputNode,
@@ -65,6 +66,32 @@ export function syncOptionality(schema: SchemaNode, required: boolean): SchemaNo
  * ```
  */
 export type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never
+
+/**
+ * Identity-preserving node update: returns `node` unchanged when every field in
+ * `changes` already equals (by reference) the current value, otherwise a new node
+ * with the changes applied.
+ *
+ * Mirrors the TypeScript compiler's `factory.updateX` contract — pair it with the
+ * structural sharing in {@link transform} so a no-op rewrite doesn't allocate and
+ * downstream passes can detect "nothing changed" by identity. Comparison is
+ * shallow: a structurally-equal but newly-allocated array/object counts as a change.
+ *
+ * @example
+ * ```ts
+ * update(node, { name: node.name })        // -> same `node` reference
+ * update(node, { name: 'renamed' })        // -> new node, `name` replaced
+ * ```
+ */
+export function update<T extends Node>(node: T, changes: Partial<T>): T {
+  for (const key in changes) {
+    if (changes[key] !== node[key as keyof T]) {
+      return { ...node, ...changes }
+    }
+  }
+
+  return node
+}
 
 type CreateSchemaObjectInput = Omit<ObjectSchemaNode, 'kind' | 'properties' | 'primitive'> & { properties?: Array<PropertyNode>; primitive?: 'object' }
 type CreateSchemaInput = CreateSchemaObjectInput | DistributiveOmit<Exclude<SchemaNode, ObjectSchemaNode>, 'kind'>

--- a/packages/ast/src/index.ts
+++ b/packages/ast/src/index.ts
@@ -1,4 +1,6 @@
 export { httpMethods, isScalarPrimitive, mediaTypes, nodeKinds, schemaTypes } from './constants.ts'
+export { dispatch } from './dispatch.ts'
+export type { DispatchRule } from './dispatch.ts'
 export {
   createArrowFunction,
   createBreak,

--- a/packages/ast/src/index.ts
+++ b/packages/ast/src/index.ts
@@ -1,5 +1,5 @@
 export { httpMethods, isScalarPrimitive, mediaTypes, nodeKinds, schemaTypes } from './constants.ts'
-export { defineDialect } from './dialect.ts'
+export { defineSchemaDialect } from './dialect.ts'
 export { dispatch } from './dispatch.ts'
 export {
   createArrowFunction,

--- a/packages/ast/src/index.ts
+++ b/packages/ast/src/index.ts
@@ -1,4 +1,5 @@
 export { httpMethods, isScalarPrimitive, mediaTypes, nodeKinds, schemaTypes } from './constants.ts'
+export { defineDialect } from './dialect.ts'
 export { dispatch } from './dispatch.ts'
 export {
   createArrowFunction,

--- a/packages/ast/src/index.ts
+++ b/packages/ast/src/index.ts
@@ -1,6 +1,5 @@
 export { httpMethods, isScalarPrimitive, mediaTypes, nodeKinds, schemaTypes } from './constants.ts'
 export { dispatch } from './dispatch.ts'
-export type { DispatchRule } from './dispatch.ts'
 export {
   createArrowFunction,
   createBreak,

--- a/packages/ast/src/index.ts
+++ b/packages/ast/src/index.ts
@@ -27,6 +27,7 @@ export {
   createText,
   createType,
   syncOptionality,
+  update,
 } from './factory.ts'
 export { isInputNode, isOperationNode, isOutputNode, isSchemaNode, narrowSchema } from './guards.ts'
 export { createPrinterFactory, definePrinter } from './printer.ts'

--- a/packages/ast/src/types.ts
+++ b/packages/ast/src/types.ts
@@ -1,4 +1,5 @@
 export type { VisitorDepth } from './constants.ts'
+export type { DispatchRule } from './dispatch.ts'
 export type { DistributiveOmit } from './factory.ts'
 export type { InferSchema, InferSchemaNode, ParserOptions } from './infer.ts'
 export type {

--- a/packages/ast/src/types.ts
+++ b/packages/ast/src/types.ts
@@ -1,4 +1,5 @@
 export type { VisitorDepth } from './constants.ts'
+export type { SchemaDialect } from './dialect.ts'
 export type { DispatchRule } from './dispatch.ts'
 export type { DistributiveOmit } from './factory.ts'
 export type { InferSchema, InferSchemaNode, ParserOptions } from './infer.ts'

--- a/packages/ast/src/visitor.test.ts
+++ b/packages/ast/src/visitor.test.ts
@@ -125,12 +125,30 @@ describe('walk', () => {
 })
 
 describe('transform', () => {
-  it('returns a new tree without mutating the original', () => {
+  it('preserves identity when nothing changes (structural sharing)', () => {
     const root = buildSampleTree()
-    const result = transform(root, {})
 
+    // A no-op transform returns the exact same reference.
+    expect(transform(root, {})).toBe(root)
+    // Visitors that return their input unchanged are also no-ops.
+    expect(transform(root, { schema: (schema) => schema, operation: (operation) => operation })).toBe(root)
+  })
+
+  it('reuses untouched subtrees when only one branch changes', () => {
+    const root = buildSampleTree()
+    const result = transform(root, {
+      operation(op): OperationNode {
+        return { ...op, operationId: `api_${op.operationId}` }
+      },
+    })
+
+    // The root and the operations branch are rebuilt...
     expect(result).not.toBe(root)
-    expect(result.kind).toBe('Input')
+    expect(result.operations).not.toBe(root.operations)
+    expect(result.operations[0]?.operationId).toBe('api_getPetById')
+    // ...but the untouched schemas branch keeps its references.
+    expect(result.schemas).toBe(root.schemas)
+    expect(result.schemas[0]).toBe(root.schemas[0])
   })
 
   it('return type matches input type via overloads', () => {

--- a/packages/ast/src/visitor.ts
+++ b/packages/ast/src/visitor.ts
@@ -443,8 +443,13 @@ export function transform(node: Node, options: TransformOptions): Node {
   const { depth, parent, ...visitor } = options
   const recurse = (depth ?? visitorDepths.deep) === visitorDepths.deep
 
-  const next = applyVisitor<Node>(node, visitor, parent) ?? node
-  const rebuilt = transformChildren(next, options, recurse)
+  const visited = applyVisitor<Node>(node, visitor, parent) ?? node
+  const rebuilt = transformChildren(visited, options, recurse)
+
+  // Structural sharing: when the visitor and child rebuild both left this node
+  // untouched, return the original reference so callers can detect "nothing
+  // changed" by identity and ancestors can avoid reallocating.
+  if (rebuilt === node) return node
 
   const finalize = nodeFinalizers[rebuilt.kind]
   return finalize ? finalize(rebuilt) : rebuilt
@@ -473,19 +478,27 @@ function transformChildren(node: Node, options: TransformOptions, recurse: boole
 
   const record = node as unknown as Record<string, unknown>
   const childOptions = { ...options, parent: node }
-  const updates: Record<string, unknown> = {}
+  let updates: Record<string, unknown> | undefined
 
   for (const key of keys) {
     if (!(key in record)) continue
     const value = record[key]
     if (Array.isArray(value)) {
-      updates[key] = value.map((item) => (isNode(item) ? transform(item, childOptions) : item))
+      let changed = false
+      const mapped = value.map((item) => {
+        if (!isNode(item)) return item
+        const next = transform(item, childOptions)
+        if (next !== item) changed = true
+        return next
+      })
+      if (changed) (updates ??= {})[key] = mapped
     } else if (isNode(value)) {
-      updates[key] = transform(value, childOptions)
+      const next = transform(value, childOptions)
+      if (next !== value) (updates ??= {})[key] = next
     }
   }
 
-  return { ...node, ...updates } as Node
+  return updates ? ({ ...node, ...updates } as Node) : node
 }
 /**
  * Lazy depth-first collection pass. Yields every non-null value returned by


### PR DESCRIPTION
## Summary

Reduces complexity and improves performance in the AST and OAS adapter, and isolates the spec-specific surface so a future `@kubb/adapter-asyncapi` can reuse the schema core. Three cohesive changes:

### 1. `@kubb/ast` — table-driven schema dispatch (foundation)
A generic `dispatch(rules, context)` helper + `DispatchRule<TContext, TNode>` type: an ordered match/convert table mapping source-spec shapes onto Kubb AST nodes, with documented `null` fall-through. `@kubb/adapter-oas` builds its `parseSchema` on it (`schemaRules`) instead of a long if/else chain.

### 2. `@kubb/ast` — structural sharing in `transform` (memory/speed)
`transform` now returns the **same** node/array references when a pass changes nothing: `transformChildren` only rebuilds a child slot when a child actually changes and reuses the original array otherwise; `transform` returns the original node (and skips the Property/Parameter finalizer) when nothing changed. No-op rewrites become free and callers can detect "unchanged" by reference — fewer allocations on large specs (Stripe-scale). Adds an identity-preserving `update(node, changes)` factory (the `factory.updateX` analogue).

### 3. `@kubb/adapter-oas` — `SchemaDialect` strategy (prep for AsyncAPI)
The schema parser is ~90% generic JSON Schema. The OAS-specific decisions — nullability (`nullable`/`x-nullable`/`type:null`), `$ref` detection/resolution, discriminator, binary (`contentMediaType`) — now route through one documented `SchemaDialect` passed into `createSchemaParser` (OAS dialect is the default). The converter pipeline + dispatch rules are dialect-driven, so a future AsyncAPI adapter supplies its own dialect and reuses the rest unchanged. **Output-neutral.**

## Architecture concepts

Structural sharing (persistent data structures) · Chain-of-Responsibility / rule registry (`dispatch`) · Strategy/Dialect (`SchemaDialect`) · Ports & Adapters (the `Adapter` port). Each behavior lives behind a single named seam so humans and AI agents have one place to change it.

## Test plan

- [x] `@kubb/ast` typecheck + tests (305) incl. new structural-sharing identity tests
- [x] `@kubb/adapter-oas` typecheck + `parser.test.ts` (334) — 332 unchanged + 2 new dialect-seam tests; generated output identical
- [x] `@kubb/core` typecheck + tests (137) — consumes `transform`
- [x] format + lint clean on changed files
- [ ] Full CI green

> `discriminator.test.ts` / `resolvers.test.ts` fail locally only due to an unrelated `#mocks` subpath-resolution issue in this sandbox (no `imports` field); they're unchanged by this PR.

Changesets: `@kubb/ast` minor (dispatch + `update`), `@kubb/adapter-oas` patch (dispatch table + dialect).
