### PR TITLE
feat(ast): spec-neutral node vocabulary (operation + workflow/step)

### DIFF
--- a/.changeset/ast-multi-spec-vocabulary.md
+++ b/.changeset/ast-multi-spec-vocabulary.md
@@ -1,0 +1,11 @@
+---
+'@kubb/ast': minor
+'@kubb/core': patch
+---
+
+Make the AST node vocabulary spec-neutral so adapters for non-OpenAPI specs (AsyncAPI, GraphQL, Prisma, Arazzo) map onto built-in nodes — the model stays closed and fully typed, no adapter-defined kinds.
+
+- `OperationNode`: `method` and `path` are now **optional** (HTTP/REST only), plus new optional `protocol` (`'http'`/`'graphql'`/`'kafka'`/…), `action` (`'send'`/`'receive'`/`'query'`/`'mutation'`/`'subscription'`/…), and `channel` fields for non-HTTP specs. `@kubb/adapter-oas` still sets `method`/`path`, so OpenAPI output is unchanged.
+- New `Workflow` and `Step` node kinds (Arazzo) with `createWorkflow`/`createStep` factories, `isWorkflowNode`/`isStepNode` guards, `workflow`/`step` visitor callbacks, and an optional `workflows` collection on the root.
+
+**Breaking (types):** code reading `OperationNode.method`/`path` must handle `undefined` (an OpenAPI operation always carries them — guard or assert).

--- a/cspell.json
+++ b/cspell.json
@@ -27,6 +27,7 @@
   ],
   "ignoreRegExpList": ["https?://github\\.com/[a-zA-Z0-9-_]+(/[a-zA-Z0-9-_]+)?", "\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Z|a-z]{2,}\\b", "\\[kub[ːˑ]+\\]"],
   "words": [
+    "Arazzo",
     "upserts",
     "footgun",
     "PETID",

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -198,7 +198,7 @@ describe('buildAst', () => {
       const oas = await buildMinimalOas()
       const root = parseOas(oas).root
       for (const op of root.operations) {
-        expect(op.method).toBe(op.method.toUpperCase())
+        expect(op.method).toBe(op.method?.toUpperCase())
       }
     })
 

--- a/packages/ast/src/constants.ts
+++ b/packages/ast/src/constants.ts
@@ -20,6 +20,8 @@ export const nodeKinds = {
   input: 'Input',
   output: 'Output',
   operation: 'Operation',
+  workflow: 'Workflow',
+  step: 'Step',
   schema: 'Schema',
   property: 'Property',
   parameter: 'Parameter',

--- a/packages/ast/src/factory.ts
+++ b/packages/ast/src/factory.ts
@@ -30,8 +30,10 @@ import type {
   ResponseNode,
   SchemaNode,
   SourceNode,
+  StepNode,
   TextNode,
   TypeNode,
+  WorkflowNode,
 } from './nodes/index.ts'
 import { combineExports, combineImports, combineSources, extractStringsFromNodes } from './utils.ts'
 
@@ -215,8 +217,8 @@ export function createRequestBody(props: UserRequestBody): RequestBodyNode {
 }
 
 export function createOperation(
-  props: Pick<OperationNode, 'operationId' | 'method' | 'path'> &
-    Partial<Omit<OperationNode, 'kind' | 'operationId' | 'method' | 'path' | 'requestBody'>> & {
+  props: Pick<OperationNode, 'operationId'> &
+    Partial<Omit<OperationNode, 'kind' | 'operationId' | 'requestBody'>> & {
       requestBody?: UserRequestBody
     },
 ): OperationNode {
@@ -230,6 +232,30 @@ export function createOperation(
     kind: 'Operation',
     requestBody: requestBody ? createRequestBody(requestBody) : undefined,
   }
+}
+
+/**
+ * Creates a `StepNode` for a workflow.
+ *
+ * @example
+ * ```ts
+ * const step = createStep({ stepId: 'createPet', operationId: 'addPet' })
+ * ```
+ */
+export function createStep(props: Pick<StepNode, 'stepId'> & Partial<Omit<StepNode, 'kind' | 'stepId'>>): StepNode {
+  return { ...props, kind: 'Step' }
+}
+
+/**
+ * Creates a `WorkflowNode` with a stable default for `steps`.
+ *
+ * @example
+ * ```ts
+ * const workflow = createWorkflow({ workflowId: 'adoptAPet', steps: [createStep({ stepId: 'createPet' })] })
+ * ```
+ */
+export function createWorkflow(props: Pick<WorkflowNode, 'workflowId'> & Partial<Omit<WorkflowNode, 'kind' | 'workflowId'>>): WorkflowNode {
+  return { steps: [], ...props, kind: 'Workflow' }
 }
 
 /**

--- a/packages/ast/src/guards.ts
+++ b/packages/ast/src/guards.ts
@@ -12,6 +12,8 @@ import type {
   ResponseNode,
   SchemaNode,
   SchemaNodeByType,
+  StepNode,
+  WorkflowNode,
 } from './nodes/index.ts'
 
 /**
@@ -66,6 +68,16 @@ export const isOutputNode = isKind<OutputNode>('Output')
  * ```
  */
 export const isOperationNode = isKind<OperationNode>('Operation')
+
+/**
+ * Returns `true` when the input is a `WorkflowNode`.
+ */
+export const isWorkflowNode = isKind<WorkflowNode>('Workflow')
+
+/**
+ * Returns `true` when the input is a `StepNode`.
+ */
+export const isStepNode = isKind<StepNode>('Step')
 
 /**
  * Returns `true` when the input is a `SchemaNode`.

--- a/packages/ast/src/index.ts
+++ b/packages/ast/src/index.ts
@@ -25,12 +25,14 @@ export {
   createResponse,
   createSchema,
   createSource,
+  createStep,
   createText,
   createType,
+  createWorkflow,
   syncOptionality,
   update,
 } from './factory.ts'
-export { isInputNode, isOperationNode, isOutputNode, isSchemaNode, narrowSchema } from './guards.ts'
+export { isInputNode, isOperationNode, isOutputNode, isSchemaNode, isStepNode, isWorkflowNode, narrowSchema } from './guards.ts'
 export { createPrinterFactory, definePrinter } from './printer.ts'
 export { extractRefName } from './refs.ts'
 export { childName, collectImports, enumPropName, findDiscriminator } from './resolvers.ts'

--- a/packages/ast/src/nodes/base.ts
+++ b/packages/ast/src/nodes/base.ts
@@ -10,6 +10,8 @@ export type NodeKind =
   | 'Input'
   | 'Output'
   | 'Operation'
+  | 'Workflow'
+  | 'Step'
   | 'Schema'
   | 'Property'
   | 'Parameter'

--- a/packages/ast/src/nodes/index.ts
+++ b/packages/ast/src/nodes/index.ts
@@ -9,6 +9,7 @@ import type { PropertyNode } from './property.ts'
 import type { ResponseNode } from './response.ts'
 import type { InputNode } from './root.ts'
 import type { SchemaNode } from './schema.ts'
+import type { StepNode, WorkflowNode } from './workflow.ts'
 
 export type { BaseNode, NodeKind } from './base.ts'
 export type { ArrowFunctionNode, BreakNode, CodeNode, ConstNode, FunctionNode, JSDocNode, JsxNode, TextNode, TypeDeclarationNode, TypeNode } from './code.ts'
@@ -16,7 +17,7 @@ export type { ContentNode } from './content.ts'
 export type { ExportNode, FileNode, ImportNode, SourceNode } from './file.ts'
 export type { FunctionNodeType, FunctionParameterNode, FunctionParametersNode, FunctionParamNode, ParameterGroupNode, ParamsTypeNode } from './function.ts'
 export type { HttpStatusCode, MediaType, StatusCode } from './http.ts'
-export type { HttpMethod, OperationNode, RequestBodyNode } from './operation.ts'
+export type { HttpMethod, OperationAction, OperationNode, OperationProtocol, RequestBodyNode } from './operation.ts'
 export type { OutputNode } from './output.ts'
 export type { ParameterLocation, ParameterNode } from './parameter.ts'
 export type { PropertyNode } from './property.ts'
@@ -48,6 +49,7 @@ export type {
   UnionSchemaNode,
   UrlSchemaNode,
 } from './schema.ts'
+export type { StepNode, WorkflowNode } from './workflow.ts'
 
 /**
  * Union of all AST node types.
@@ -72,6 +74,8 @@ export type Node =
   | InputNode
   | OutputNode
   | OperationNode
+  | WorkflowNode
+  | StepNode
   | SchemaNode
   | PropertyNode
   | ParameterNode

--- a/packages/ast/src/nodes/operation.ts
+++ b/packages/ast/src/nodes/operation.ts
@@ -6,6 +6,18 @@ import type { ResponseNode } from './response.ts'
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS' | 'TRACE'
 
 /**
+ * Transport / spec family an operation belongs to. Open-ended so adapters can use
+ * their own value; the listed members cover the common cases.
+ */
+export type OperationProtocol = 'http' | 'ws' | 'kafka' | 'amqp' | 'mqtt' | 'graphql' | (string & {})
+
+/**
+ * Generic operation verb for specs without an HTTP method — AsyncAPI pub/sub
+ * (`send`/`receive`) and GraphQL roots (`query`/`mutation`/`subscription`).
+ */
+export type OperationAction = 'send' | 'receive' | 'query' | 'mutation' | 'subscription' | (string & {})
+
+/**
  * AST node representing an operation request body.
  *
  * Body schemas live exclusively inside the `content` array (one entry per content type),
@@ -71,14 +83,29 @@ export type OperationNode = BaseNode & {
    */
   operationId: string
   /**
-   * HTTP Method like 'GET'
+   * HTTP method like `'GET'`. Optional — only HTTP/REST specs (OpenAPI) set it;
+   * other specs use {@link OperationNode.action} instead.
    */
-  method: HttpMethod
+  method?: HttpMethod
   /**
-   * OpenAPI-style path string, for example `/pets/{petId}`.
-   * Path parameters retain the `{param}` notation from the original spec.
+   * OpenAPI-style path string, for example `/pets/{petId}`, with `{param}` notation
+   * preserved. Optional — only HTTP/REST specs set it.
    */
-  path: string
+  path?: string
+  /**
+   * Transport / spec family (e.g. `'http'`, `'graphql'`, `'kafka'`). Lets a plugin
+   * branch on the source spec without assuming HTTP.
+   */
+  protocol?: OperationProtocol
+  /**
+   * Generic verb for non-HTTP specs — AsyncAPI `send`/`receive`, GraphQL
+   * `query`/`mutation`/`subscription`.
+   */
+  action?: OperationAction
+  /**
+   * Channel address (AsyncAPI) or generic target the operation acts on.
+   */
+  channel?: string
   /**
    * Group labels for the operation.
    * Usually copied from OpenAPI `tags`.

--- a/packages/ast/src/nodes/root.ts
+++ b/packages/ast/src/nodes/root.ts
@@ -1,6 +1,7 @@
 import type { BaseNode } from './base.ts'
 import type { OperationNode } from './operation.ts'
 import type { SchemaNode } from './schema.ts'
+import type { WorkflowNode } from './workflow.ts'
 
 /**
  * Metadata for an API document, populated by the adapter and available to every generator.
@@ -88,6 +89,11 @@ export type InputNode = BaseNode & {
    */
   operations: Array<OperationNode>
   /**
+   * Workflow nodes in the document. Present only for specs that describe workflows
+   * (e.g. Arazzo); absent for plain schema/operation specs.
+   */
+  workflows?: Array<WorkflowNode>
+  /**
    * Document metadata populated by the adapter.
    */
   meta: InputMeta
@@ -119,6 +125,10 @@ export type InputStreamNode = {
    * multiple plugins can iterate independently without sharing state.
    */
   operations: AsyncIterable<OperationNode>
+  /**
+   * Lazily parsed workflow nodes, when the spec describes workflows.
+   */
+  workflows?: AsyncIterable<WorkflowNode>
   /**
    * Document metadata available immediately, before the first yielded node.
    */

--- a/packages/ast/src/nodes/workflow.ts
+++ b/packages/ast/src/nodes/workflow.ts
@@ -1,0 +1,83 @@
+import type { BaseNode } from './base.ts'
+import type { ParameterNode } from './parameter.ts'
+import type { SchemaNode } from './schema.ts'
+
+/**
+ * AST node representing one step in a {@link WorkflowNode} — a single referenced
+ * operation call within a workflow (Arazzo `step`).
+ *
+ * @example
+ * ```ts
+ * const step: StepNode = {
+ *   kind: 'Step',
+ *   stepId: 'createPet',
+ *   operationId: 'addPet',
+ * }
+ * ```
+ */
+export type StepNode = BaseNode & {
+  /**
+   * Node kind.
+   */
+  kind: 'Step'
+  /**
+   * Step identifier, unique within its workflow.
+   */
+  stepId: string
+  /**
+   * Human-readable step description.
+   */
+  description?: string
+  /**
+   * Identifier of the operation this step invokes (when referenced by id).
+   */
+  operationId?: string
+  /**
+   * Reference to the operation this step invokes (when referenced by `$ref`/path).
+   */
+  operationRef?: string
+  /**
+   * Parameters passed to the referenced operation.
+   */
+  parameters?: Array<ParameterNode>
+}
+
+/**
+ * AST node representing a workflow — an ordered sequence of {@link StepNode}s
+ * (Arazzo `workflow`). Spec families without workflows never emit this node.
+ *
+ * @example
+ * ```ts
+ * const workflow: WorkflowNode = {
+ *   kind: 'Workflow',
+ *   workflowId: 'adoptAPet',
+ *   steps: [{ kind: 'Step', stepId: 'createPet', operationId: 'addPet' }],
+ * }
+ * ```
+ */
+export type WorkflowNode = BaseNode & {
+  /**
+   * Node kind.
+   */
+  kind: 'Workflow'
+  /**
+   * Workflow identifier.
+   */
+  workflowId: string
+  /**
+   * Short one-line workflow summary.
+   */
+  summary?: string
+  /**
+   * Full workflow description.
+   */
+  description?: string
+  /**
+   * Schema describing the workflow inputs.
+   */
+  inputs?: SchemaNode
+  /**
+   * Ordered steps that make up the workflow.
+   */
+  steps: Array<StepNode>
+}

--- a/packages/ast/src/types.ts
+++ b/packages/ast/src/types.ts
@@ -39,7 +39,9 @@ export type {
   NodeKind,
   NumberSchemaNode,
   ObjectSchemaNode,
+  OperationAction,
   OperationNode,
+  OperationProtocol,
   OutputNode,
   ParameterGroupNode,
   ParameterLocation,
@@ -57,6 +59,7 @@ export type {
   SourceNode,
   SpecialSchemaType,
   StatusCode,
+  StepNode,
   StringSchemaNode,
   TextNode,
   TimeSchemaNode,
@@ -64,6 +67,7 @@ export type {
   TypeNode,
   UnionSchemaNode,
   UrlSchemaNode,
+  WorkflowNode,
 } from './nodes/index.ts'
 export type { RefMap } from './refs.ts'
 export type { AsyncVisitor, CollectOptions, CollectVisitor, ParentOf, TransformOptions, Visitor, VisitorContext, WalkOptions } from './visitor.ts'

--- a/packages/ast/src/visitor.ts
+++ b/packages/ast/src/visitor.ts
@@ -13,6 +13,8 @@ import type {
   RequestBodyNode,
   ResponseNode,
   SchemaNode,
+  StepNode,
+  WorkflowNode,
 } from './nodes/index.ts'
 
 /**
@@ -159,6 +161,8 @@ export type Visitor = {
   input?(node: InputNode, context: VisitorContext<InputNode>): undefined | null | InputNode
   output?(node: OutputNode, context: VisitorContext<OutputNode>): undefined | null | OutputNode
   operation?(node: OperationNode, context: VisitorContext<OperationNode>): undefined | null | OperationNode
+  workflow?(node: WorkflowNode, context: VisitorContext<WorkflowNode>): undefined | null | WorkflowNode
+  step?(node: StepNode, context: VisitorContext<StepNode>): undefined | null | StepNode
   schema?(node: SchemaNode, context: VisitorContext<SchemaNode>): undefined | null | SchemaNode
   property?(node: PropertyNode, context: VisitorContext<PropertyNode>): undefined | null | PropertyNode
   parameter?(node: ParameterNode, context: VisitorContext<ParameterNode>): undefined | null | ParameterNode
@@ -186,6 +190,8 @@ export type AsyncVisitor = {
   input?(node: InputNode, context: VisitorContext<InputNode>): MaybePromise<undefined | null | InputNode>
   output?(node: OutputNode, context: VisitorContext<OutputNode>): MaybePromise<undefined | null | OutputNode>
   operation?(node: OperationNode, context: VisitorContext<OperationNode>): MaybePromise<undefined | null | OperationNode>
+  workflow?(node: WorkflowNode, context: VisitorContext<WorkflowNode>): MaybePromise<undefined | null | WorkflowNode>
+  step?(node: StepNode, context: VisitorContext<StepNode>): MaybePromise<undefined | null | StepNode>
   schema?(node: SchemaNode, context: VisitorContext<SchemaNode>): MaybePromise<undefined | null | SchemaNode>
   property?(node: PropertyNode, context: VisitorContext<PropertyNode>): MaybePromise<undefined | null | PropertyNode>
   parameter?(node: ParameterNode, context: VisitorContext<ParameterNode>): MaybePromise<undefined | null | ParameterNode>
@@ -208,6 +214,8 @@ export type CollectVisitor<T> = {
   input?(node: InputNode, context: VisitorContext<InputNode>): T | null | undefined
   output?(node: OutputNode, context: VisitorContext<OutputNode>): T | null | undefined
   operation?(node: OperationNode, context: VisitorContext<OperationNode>): T | null | undefined
+  workflow?(node: WorkflowNode, context: VisitorContext<WorkflowNode>): T | null | undefined
+  step?(node: StepNode, context: VisitorContext<StepNode>): T | null | undefined
   schema?(node: SchemaNode, context: VisitorContext<SchemaNode>): T | null | undefined
   property?(node: PropertyNode, context: VisitorContext<PropertyNode>): T | null | undefined
   parameter?(node: ParameterNode, context: VisitorContext<ParameterNode>): T | null | undefined
@@ -289,8 +297,10 @@ export type CollectOptions<T> = CollectVisitor<T> & {
  * in a child slot is a node, so one table drives both `getChildren` and `transform`.
  */
 const VISITOR_KEYS = {
-  Input: ['schemas', 'operations'],
+  Input: ['schemas', 'operations', 'workflows'],
   Operation: ['parameters', 'requestBody', 'responses'],
+  Workflow: ['inputs', 'steps'],
+  Step: ['parameters'],
   RequestBody: ['content'],
   Content: ['schema'],
   Response: ['content'],
@@ -345,6 +355,8 @@ const VISITOR_KEY_BY_KIND: Partial<Record<NodeKind, keyof Visitor>> = {
   Input: 'input',
   Output: 'output',
   Operation: 'operation',
+  Workflow: 'workflow',
+  Step: 'step',
   Schema: 'schema',
   Property: 'property',
   Parameter: 'parameter',

--- a/packages/ast/src/workflow.test.ts
+++ b/packages/ast/src/workflow.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import { createInput, createOperation, createStep, createWorkflow } from './factory.ts'
+import { isStepNode, isWorkflowNode } from './guards.ts'
+import type { StepNode, WorkflowNode } from './nodes/index.ts'
+import { collect, transform, walk } from './visitor.ts'
+
+describe('workflow factories', () => {
+  it('createStep sets the kind', () => {
+    expect(createStep({ stepId: 'createPet', operationId: 'addPet' })).toEqual({
+      kind: 'Step',
+      stepId: 'createPet',
+      operationId: 'addPet',
+    })
+  })
+
+  it('createWorkflow defaults steps to an empty array', () => {
+    expect(createWorkflow({ workflowId: 'adoptAPet' }).steps).toEqual([])
+  })
+})
+
+describe('workflow guards', () => {
+  it('narrows Workflow and Step nodes', () => {
+    const workflow = createWorkflow({ workflowId: 'w', steps: [createStep({ stepId: 's' })] })
+
+    expect(isWorkflowNode(workflow)).toBe(true)
+    expect(isStepNode(workflow.steps[0])).toBe(true)
+    expect(isWorkflowNode(workflow.steps[0])).toBe(false)
+  })
+})
+
+describe('generalized operation', () => {
+  it('builds an operation without HTTP method/path', () => {
+    const op = createOperation({ operationId: 'onPetAdded', protocol: 'kafka', action: 'receive', channel: 'pet.added' })
+
+    expect(op.method).toBeUndefined()
+    expect(op.path).toBeUndefined()
+    expect(op.action).toBe('receive')
+    expect(op.channel).toBe('pet.added')
+  })
+})
+
+describe('workflow traversal', () => {
+  const build = () =>
+    createInput({
+      workflows: [createWorkflow({ workflowId: 'adoptAPet', steps: [createStep({ stepId: 'createPet' }), createStep({ stepId: 'getPet' })] })],
+    })
+
+  it('walks workflows and steps from the root', async () => {
+    const visited = { workflow: 0, step: 0 }
+    await walk(build(), {
+      workflow() {
+        visited.workflow++
+      },
+      step() {
+        visited.step++
+      },
+    })
+
+    expect(visited).toEqual({ workflow: 1, step: 2 })
+  })
+
+  it('collects step ids', () => {
+    const ids = collect<string>(build(), {
+      step(node) {
+        return node.stepId
+      },
+    })
+
+    expect(ids).toEqual(['createPet', 'getPet'])
+  })
+
+  it('transforms a step and preserves identity elsewhere (structural sharing)', () => {
+    const root = build()
+
+    expect(transform(root, {})).toBe(root)
+
+    const result = transform(root, {
+      step(node): StepNode {
+        return node.stepId === 'getPet' ? { ...node, description: 'fetch the pet' } : node
+      },
+    })
+
+    expect(result).not.toBe(root)
+    const workflow = result.workflows?.[0] as WorkflowNode
+    expect(workflow.steps[0]).toBe(root.workflows?.[0]?.steps[0]) // untouched step kept by reference
+    expect(workflow.steps[1]?.description).toBe('fetch the pet')
+  })
+})

--- a/packages/core/src/defineResolver.ts
+++ b/packages/core/src/defineResolver.ts
@@ -271,8 +271,8 @@ function testPattern(value: string, pattern: string | RegExp): boolean {
 function matchesOperationPattern(node: OperationNode, type: string, pattern: string | RegExp): boolean {
   if (type === 'tag') return node.tags.some((tag) => testPattern(tag, pattern))
   if (type === 'operationId') return testPattern(node.operationId, pattern)
-  if (type === 'path') return testPattern(node.path, pattern)
-  if (type === 'method') return testPattern(node.method.toLowerCase(), pattern)
+  if (type === 'path') return node.path !== undefined && testPattern(node.path, pattern)
+  if (type === 'method') return node.method !== undefined && testPattern(node.method.toLowerCase(), pattern)
   if (type === 'contentType') return node.requestBody?.content?.some((c) => testPattern(c.contentType, pattern)) ?? false
   return false
 }


### PR DESCRIPTION
## Summary

Makes the `@kubb/ast` node vocabulary **spec-neutral** so adapters for non-OpenAPI specs (AsyncAPI, GraphQL, Prisma, Arazzo) map onto built-in nodes. The model stays **closed and fully typed** — no adapter-defined kinds, no registry. (Per the design decision: `@kubb/ast` carries all options.)

### Generalized `OperationNode`
- `method` and `path` are now **optional** (HTTP/REST only).
- New optional `protocol` (`'http'`/`'graphql'`/`'kafka'`/`'amqp'`/`'ws'`/…), `action` (`'send'`/`'receive'`/`'query'`/`'mutation'`/`'subscription'`/…), and `channel` fields cover AsyncAPI pub/sub and GraphQL roots.
- `createOperation` no longer requires `method`/`path`.

### New `Workflow` / `Step` kinds (Arazzo)
The only constructs that don't map onto Schema/Operation. Added as first-class closed kinds with `createWorkflow`/`createStep` factories, `isWorkflowNode`/`isStepNode` guards, `workflow`/`step` visitor callbacks, and an optional `workflows` collection on `InputNode`/`InputStreamNode`.

### Spec → vocabulary mapping
| Spec | Maps to |
|---|---|
| OpenAPI | `operations` (method/path) + `schemas` — unchanged |
| AsyncAPI | `operations` (`action`/`channel`) + `schemas` |
| GraphQL | `operations` (`action`) + `schemas` |
| Prisma | `schemas` only (`operations: []`) |
| Arazzo | `workflows`/`steps` + JSON-Schema `inputs` |

## Breaking (types)
`OperationNode.method`/`path` are optional now — code reading them must handle `undefined`. Within this repo only `defineResolver` needed a guard; `@kubb/adapter-oas` still sets `method`/`path`, so **OpenAPI output is byte-identical**. The plugins query/client generators are fixed in a coordinated follow-up PR.

## Test plan

- [x] `@kubb/ast` typecheck + tests (312, incl. new `workflow.test.ts`: factories, guards, walk/transform/collect over a `workflows` root, structural-sharing identity, method-less operation)
- [x] `@kubb/core` typecheck + tests (137) — resolver guards optional method/path
- [x] `@kubb/adapter-oas` typecheck + `parser.test.ts` (334) — OpenAPI output unchanged
- [x] format + lint clean
- [ ] Full CI green

> Stacked on `claude/adapter-oas-rename-schema-ctx` (PR #3377) for a clean diff; retarget to `main` once that merges. Coordinated follow-ups: plugins PR (method/path optionality) and platform-docs PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FMNrXFj7FiJp4nPbUHbqap)_