### PR TITLE
test(adapter-oas): add vitest config so #mocks resolves per-package

### DIFF
--- a/packages/adapter-oas/vitest.config.ts
+++ b/packages/adapter-oas/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    dir: './src',
+  },
+  resolve: {
+    tsconfigPaths: true,
+  },
+})


### PR DESCRIPTION
## Summary

`#mocks` is a tsconfig-only alias (`"#mocks": ["./internals/utils/src/mocks.ts"]` in the root `tsconfig.json`) with no `imports` field backing it. The only thing that resolves it at runtime is Vitest's `resolve.tsconfigPaths: true`.

- The root test script (`vitest run --config ./configs/vitest.config.ts`) sets `tsconfigPaths`, so root runs work.
- `packages/adapter-oas` imports `#mocks` (`src/discriminator.test.ts`, `src/resolvers.test.ts`) but had **no `vitest.config.ts`**, so its `pnpm test` (`vitest --passWithNoTests`) ran with defaults and failed to resolve the alias.

This adds `packages/adapter-oas/vitest.config.ts`, mirroring `packages/middleware-barrel/vitest.config.ts` (`test.dir: './src'` + `resolve.tsconfigPaths: true`).

No changeset: `vitest.config.ts` is not part of the published package (`files` is `src`/`dist`/`extension.yaml`), so nothing user-facing ships.

## Test plan

- [x] `cd packages/adapter-oas && pnpm test` — 8 files, 450 tests pass (`#mocks`-importing tests now resolve)
- [ ] Root `pnpm test` stays green in CI

https://claude.ai/code/session_01Stqn82JTs4yKJaSxBr3jfu

---
_Generated by [Claude Code](https://claude.ai/code/session_01Stqn82JTs4yKJaSxBr3jfu)_