### PR TITLE
test: use toMatchInlineSnapshot to reduce complexity in test cases

### DIFF
--- a/packages/adapter-oas/src/resolvers.test.ts
+++ b/packages/adapter-oas/src/resolvers.test.ts
@@ -125,18 +125,20 @@ describe('buildSchemaNode', () => {
     }
     const node = buildSchemaNode(schema, 'myName', true, 'defaultVal')
 
-    expect(node).toEqual({
-      name: 'myName',
-      nullable: true,
-      title: 'My Schema',
-      description: 'A description',
-      deprecated: true,
-      readOnly: true,
-      writeOnly: false,
-      default: 'defaultVal',
-      example: 42,
-      format: 'email',
-    })
+    expect(node).toMatchInlineSnapshot(`
+      {
+        "default": "defaultVal",
+        "deprecated": true,
+        "description": "A description",
+        "example": 42,
+        "format": "email",
+        "name": "myName",
+        "nullable": true,
+        "readOnly": true,
+        "title": "My Schema",
+        "writeOnly": false,
+      }
+    `)
   })
 
   it('passes through undefined fields as undefined', () => {

--- a/packages/ast/src/refs.test.ts
+++ b/packages/ast/src/refs.test.ts
@@ -64,71 +64,115 @@ describe('refMapToObject', () => {
 
     expect(Object.keys(obj).sort()).toEqual(['Error', 'FullPet', 'NewPet', 'Pet', 'PetList', 'PetOrError'])
 
-    expect(obj['Pet']).toEqual({
-      kind: 'Schema',
-      name: 'Pet',
-      type: 'object',
-      primitive: 'object',
-      properties: [
-        {
-          kind: 'Property',
-          name: 'id',
-          required: true,
-          schema: { kind: 'Schema', type: 'integer', primitive: 'integer' },
-        },
-        {
-          kind: 'Property',
-          name: 'name',
-          required: true,
-          schema: { kind: 'Schema', type: 'string', primitive: 'string' },
-        },
-      ],
-    })
-
-    expect(obj['PetList']).toEqual({
-      kind: 'Schema',
-      name: 'PetList',
-      type: 'array',
-      primitive: 'array',
-      items: [{ kind: 'Schema', type: 'ref', ref: 'Pet' }],
-    })
-
-    expect(obj['PetOrError']).toEqual({
-      kind: 'Schema',
-      name: 'PetOrError',
-      type: 'union',
-      members: [
-        { kind: 'Schema', type: 'ref', ref: 'Pet' },
-        { kind: 'Schema', type: 'ref', ref: 'Error' },
-      ],
-    })
-
-    expect(obj['FullPet']).toEqual({
-      kind: 'Schema',
-      name: 'FullPet',
-      type: 'intersection',
-      members: [
-        { kind: 'Schema', type: 'ref', ref: 'Pet' },
-        {
-          kind: 'Schema',
-          type: 'object',
-          primitive: 'object',
-          properties: [
-            {
-              kind: 'Property',
-              name: 'createdAt',
-              required: false,
-              schema: {
-                kind: 'Schema',
-                type: 'datetime',
-                primitive: 'string',
-                optional: true,
-                nullish: undefined,
-              },
+    expect(obj['Pet']).toMatchInlineSnapshot(`
+      {
+        "kind": "Schema",
+        "name": "Pet",
+        "primitive": "object",
+        "properties": [
+          {
+            "kind": "Property",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "kind": "Schema",
+              "nullish": undefined,
+              "optional": undefined,
+              "primitive": "integer",
+              "type": "integer",
             },
-          ],
-        },
-      ],
-    })
+          },
+          {
+            "kind": "Property",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "kind": "Schema",
+              "nullish": undefined,
+              "optional": undefined,
+              "primitive": "string",
+              "type": "string",
+            },
+          },
+        ],
+        "type": "object",
+      }
+    `)
+
+    expect(obj['PetList']).toMatchInlineSnapshot(`
+      {
+        "items": [
+          {
+            "kind": "Schema",
+            "primitive": undefined,
+            "ref": "Pet",
+            "type": "ref",
+          },
+        ],
+        "kind": "Schema",
+        "name": "PetList",
+        "primitive": "array",
+        "type": "array",
+      }
+    `)
+
+    expect(obj['PetOrError']).toMatchInlineSnapshot(`
+      {
+        "kind": "Schema",
+        "members": [
+          {
+            "kind": "Schema",
+            "primitive": undefined,
+            "ref": "Pet",
+            "type": "ref",
+          },
+          {
+            "kind": "Schema",
+            "primitive": undefined,
+            "ref": "Error",
+            "type": "ref",
+          },
+        ],
+        "name": "PetOrError",
+        "primitive": undefined,
+        "type": "union",
+      }
+    `)
+
+    expect(obj['FullPet']).toMatchInlineSnapshot(`
+      {
+        "kind": "Schema",
+        "members": [
+          {
+            "kind": "Schema",
+            "primitive": undefined,
+            "ref": "Pet",
+            "type": "ref",
+          },
+          {
+            "kind": "Schema",
+            "primitive": "object",
+            "properties": [
+              {
+                "kind": "Property",
+                "name": "createdAt",
+                "required": false,
+                "schema": {
+                  "kind": "Schema",
+                  "nullish": undefined,
+                  "optional": true,
+                  "primitive": "string",
+                  "type": "datetime",
+                },
+              },
+            ],
+            "type": "object",
+          },
+        ],
+        "name": "FullPet",
+        "primitive": undefined,
+        "type": "intersection",
+      }
+    `)
   })
 })


### PR DESCRIPTION
## Summary

Replaces verbose, hand-written nested object literals in `toEqual` assertions with self-maintaining `toMatchInlineSnapshot()` blocks, matching the established style already used in `adapter.test.ts`. This reduces noise and maintenance burden in test cases.

Scope is intentionally **targeted** — only genuinely verbose, deeply-nested static literals were converted. Small/intentful assertions (`toBe`, short `toEqual({...})`, `toMatchObject` partial matches) were left as-is.

### Changes

- `packages/ast/src/refs.test.ts` — converted the 4 large nested schema literals (`Pet`, `PetList`, `PetOrError`, `FullPet`) in `refMapToObject`.
- `packages/adapter-oas/src/resolvers.test.ts` — converted the verbose flat metadata literal in `buildSchemaNode`.

The inline snapshots were generated by Vitest (`-u`), so they capture the exact runtime shape (including `undefined`-valued keys that `toEqual` previously ignored).

## Test plan

- [x] `pnpm test` — affected packages green (ast: 322, adapter-oas: 455)
- [x] `pnpm typecheck` — passes
- [x] `pnpm format && pnpm lint` — clean
- [ ] Reviewer spot-checks generated snapshots match the original asserted shapes

No changeset: changes are test-only with no shipped code or public API impact.

https://claude.ai/code/session_01TEsVs7KWf4TAzb6QcyVdo7

---
_Generated by [Claude Code](https://claude.ai/code/session_01TEsVs7KWf4TAzb6QcyVdo7)_