### PR TITLE
perf(ast): persist schema signatures in a process-wide WeakMap

### DIFF
--- a/.changeset/perf-signature-weakmap-cache.md
+++ b/.changeset/perf-signature-weakmap-cache.md
@@ -1,0 +1,7 @@
+---
+'@kubb/ast': patch
+---
+
+**Performance: persist schema signatures in a process-wide `WeakMap`**
+
+`signatureOf` now memoizes node → digest in a module-level `WeakMap` keyed by node identity, instead of a fresh `Map` per `schemaSignature`/`buildDedupePlan`/`applyDedupe` call. During streaming, each top-level schema tree was hashed twice — once by `schemaSignature` and again by `applyDedupe` — so a node is no longer re-hashed once it has been seen. Entries are released when the node is garbage-collected, and reuse is sound because signatures depend only on a node's (immutable) content.

--- a/packages/ast/src/dedupe.ts
+++ b/packages/ast/src/dedupe.ts
@@ -101,12 +101,11 @@ export function applyDedupe(node: OperationNode, canonicalBySignature: ReadonlyM
 export function applyDedupe(node: Node, canonicalBySignature: ReadonlyMap<string, DedupeCanonical>, skipRootMatch = false): Node {
   if (canonicalBySignature.size === 0) return node
 
-  const signatures = new Map<SchemaNode, string>()
   const root = node
 
   return transform(node, {
     schema(schemaNode) {
-      const signature = signatureOf(schemaNode, signatures)
+      const signature = signatureOf(schemaNode)
       if (skipRootMatch && schemaNode === root) return undefined
 
       const canonical = canonicalBySignature.get(signature)
@@ -145,7 +144,6 @@ function cleanDefinition(node: SchemaNode, name: string): SchemaNode {
 export function buildDedupePlan(roots: ReadonlyArray<Node>, options: BuildDedupePlanOptions): DedupePlan {
   const { isCandidate, nameFor, refFor, minOccurrences = 2 } = options
 
-  const signatures = new Map<SchemaNode, string>()
   const topLevelNodes = new Set<SchemaNode>()
 
   type Group = {
@@ -156,7 +154,7 @@ export function buildDedupePlan(roots: ReadonlyArray<Node>, options: BuildDedupe
   const groups = new Map<string, Group>()
 
   function record(schemaNode: SchemaNode): void {
-    const signature = signatureOf(schemaNode, signatures)
+    const signature = signatureOf(schemaNode)
     if (!isCandidate(schemaNode)) return
 
     const isTopLevel = topLevelNodes.has(schemaNode) && !!schemaNode.name

--- a/packages/ast/src/signature.test.ts
+++ b/packages/ast/src/signature.test.ts
@@ -30,4 +30,19 @@ describe('schemaSignature', () => {
 
     expect(isSchemaEqual(base, renamed)).toBe(false)
   })
+
+  it('returns a stable signature for the same node across repeated calls', () => {
+    const node = createSchema({ type: 'object', properties: [createProperty({ name: 'id', required: true, schema: stringEnum(['a', 'b']) })] })
+
+    expect(schemaSignature(node)).toBe(schemaSignature(node))
+  })
+
+  it('compares distinct nodes by content, not identity', () => {
+    const a = stringEnum(['a', 'b'])
+    const b = stringEnum(['a', 'b'])
+
+    // Hash each independently first so both are cached, then assert content equality still holds.
+    expect(schemaSignature(a)).toBe(schemaSignature(b))
+    expect(schemaSignature(stringEnum(['a', 'c']))).not.toBe(schemaSignature(a))
+  })
 })

--- a/packages/ast/src/signature.ts
+++ b/packages/ast/src/signature.ts
@@ -104,7 +104,7 @@ const SHAPE_KEYS: Partial<Record<SchemaNode['type'], ReadonlyArray<ShapeField>>>
   time: [{ kind: 'scalar', key: 'representation', prefix: 'rep' }],
 }
 
-function serializeShapeField(field: ShapeField, node: SchemaNode, record: Record<string, unknown>, signatures: Map<SchemaNode, string>): string {
+function serializeShapeField(field: ShapeField, node: SchemaNode, record: Record<string, unknown>): string {
   switch (field.kind) {
     case 'scalar':
       return `${field.prefix}:${record[field.key] ?? ''}`
@@ -112,21 +112,21 @@ function serializeShapeField(field: ShapeField, node: SchemaNode, record: Record
       return `${field.prefix}:${record[field.key] ? 1 : 0}`
     case 'child': {
       const child = record[field.key] as SchemaNode | undefined
-      return `${field.prefix}:${child ? signatureOf(child, signatures) : ''}`
+      return `${field.prefix}:${child ? signatureOf(child) : ''}`
     }
     case 'children': {
       const children = (record[field.key] as Array<SchemaNode> | undefined) ?? []
-      return `${field.prefix}[${children.map((c) => signatureOf(c, signatures)).join(',')}]`
+      return `${field.prefix}[${children.map((c) => signatureOf(c)).join(',')}]`
     }
     case 'objectProps': {
       const obj = node as Extract<SchemaNode, { type: 'object' }>
-      const props = (obj.properties ?? []).map((prop) => `${prop.name}${prop.required ? '!' : '?'}${signatureOf(prop.schema, signatures)}`).join(',')
+      const props = (obj.properties ?? []).map((prop) => `${prop.name}${prop.required ? '!' : '?'}${signatureOf(prop.schema)}`).join(',')
       return `p[${props}]`
     }
     case 'additionalProps': {
       const obj = node as Extract<SchemaNode, { type: 'object' }>
       if (typeof obj.additionalProperties === 'boolean') return `ab:${obj.additionalProperties}`
-      if (obj.additionalProperties) return `as:${signatureOf(obj.additionalProperties, signatures)}`
+      if (obj.additionalProperties) return `as:${signatureOf(obj.additionalProperties)}`
       return ''
     }
     case 'patternProps': {
@@ -134,7 +134,7 @@ function serializeShapeField(field: ShapeField, node: SchemaNode, record: Record
       const pattern = obj.patternProperties
         ? Object.keys(obj.patternProperties)
             .sort()
-            .map((key) => `${key}=${signatureOf(obj.patternProperties![key]!, signatures)}`)
+            .map((key) => `${key}=${signatureOf(obj.patternProperties![key]!)}`)
             .join(',')
         : ''
       return `pp[${pattern}]`
@@ -160,7 +160,7 @@ function serializeShapeField(field: ShapeField, node: SchemaNode, record: Record
  * children's signatures. {@link signatureOf} hashes this string; children contribute their
  * fixed-length signature rather than their own full descriptor, which keeps the result bounded.
  */
-function describeShape(node: SchemaNode, signatures: Map<SchemaNode, string>): string {
+function describeShape(node: SchemaNode): string {
   const flags = flagsDescriptor(node)
   const fields = SHAPE_KEYS[node.type]
   if (!fields) return `${node.type}|${flags}`
@@ -168,10 +168,21 @@ function describeShape(node: SchemaNode, signatures: Map<SchemaNode, string>): s
   const record = node as unknown as Record<string, unknown>
   const parts: Array<string> = [`${node.type}|${flags}`]
   for (const field of fields) {
-    parts.push(serializeShapeField(field, node, record, signatures))
+    parts.push(serializeShapeField(field, node, record))
   }
   return parts.join('|')
 }
+
+/**
+ * Persistent hash-consing cache: `SchemaNode` → signature digest, keyed by node identity.
+ *
+ * A `WeakMap` so entries are released once the node is garbage-collected, and so a node hashed
+ * during dedupe planning is not re-hashed when the same tree is rewritten during streaming
+ * (where `schemaSignature` and `applyDedupe` would otherwise each walk it from scratch). Reuse
+ * across calls is sound because a signature depends only on a node's content, and schema nodes
+ * are immutable once created — transforms allocate new objects rather than mutating in place.
+ */
+const signatureCache = new WeakMap<SchemaNode, string>()
 
 /**
  * Hash-consing: each node's signature is a fixed-length digest of its local shape plus its
@@ -179,13 +190,13 @@ function describeShape(node: SchemaNode, signatures: Map<SchemaNode, string>): s
  * full nested descriptor, so a signature stays bounded regardless of subtree depth, and the
  * digest is identical across calls because it depends only on content — never on traversal
  * order. This keeps the keys built during planning consistent with the ones recomputed later
- * during streaming. `signatures` memoizes node → digest within a single computation.
+ * during streaming. {@link signatureCache} memoizes node → digest across every computation.
  */
-export function signatureOf(node: SchemaNode, signatures: Map<SchemaNode, string>): string {
-  const cached = signatures.get(node)
+export function signatureOf(node: SchemaNode): string {
+  const cached = signatureCache.get(node)
   if (cached !== undefined) return cached
-  const signature = createHash('sha256').update(describeShape(node, signatures)).digest('hex')
-  signatures.set(node, signature)
+  const signature = createHash('sha256').update(describeShape(node)).digest('hex')
+  signatureCache.set(node, signature)
   return signature
 }
 
@@ -205,7 +216,7 @@ export function signatureOf(node: SchemaNode, signatures: Map<SchemaNode, string
  * ```
  */
 export function schemaSignature(node: SchemaNode): string {
-  return signatureOf(node, new Map())
+  return signatureOf(node)
 }
 
 /**


### PR DESCRIPTION
## Summary

Improves memory usage and speed of schema deduplication by replacing the per-call `Map` memoization in `signatureOf` with a persistent, process-wide `WeakMap` keyed by node identity.

Previously each top-level call — `schemaSignature`, `buildDedupePlan`, and `applyDedupe` — created a fresh `Map<SchemaNode, string>`. In the streaming path (`adapter-oas`), every top-level schema tree was therefore hashed **twice**: once by `schemaSignature(node)` in `rewriteTopLevelSchema`, then again by `applyDedupe(node)` which re-walks the whole tree. With a shared cache, a node is hashed at most once.

- **Speed**: eliminates the redundant full-tree SHA-256 re-hashing of every top-level schema during streaming.
- **Memory**: `WeakMap` keying lets each entry be garbage-collected with its node, and removes the transient per-call `Map` + duplicate hash/string allocations.

Reuse across calls is sound: a signature depends only on a node's content, and schema nodes are immutable once created (`transform` allocates new objects rather than mutating in place — verified there are no in-place mutations of schema node fields). The cache write happens only after a node's full signature is computed, so recursion/cycle behavior (cycles are broken by name-only `ref` targets) is unchanged.

The internal `signatureOf` helper drops its `signatures` parameter; the public API (`schemaSignature`, `isSchemaEqual`, `applyDedupe`, `buildDedupePlan`) is unchanged.

### Why only a WeakMap change (and not generators)?

The branch name mentions generators too, but the AST layer already traverses lazily via the `collectLazy` / `getChildren` generators and rebuilds immutably with structural sharing in `transform`. The signature cache was the remaining hot path that still recomputed work, so this is the targeted "if needed" improvement rather than a speculative refactor.

## Test plan

- [x] `pnpm vitest run` in `@kubb/ast` — 324 passed (incl. 2 new signature cache-correctness tests: stable repeated hashing, content-based comparison of distinct objects)
- [x] `pnpm vitest run` in `@kubb/adapter-oas` — 455 passed (exercises the dedupe/streaming path)
- [x] `pnpm --filter @kubb/ast typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm format` — applied

https://claude.ai/code/session_012AYhdzZZYHdwkJn83rTqWT

---
_Generated by [Claude Code](https://claude.ai/code/session_012AYhdzZZYHdwkJn83rTqWT)_