### PR TITLE
test: use toMatchInlineSnapshot to reduce complexity in test cases

### DIFF
--- a/packages/adapter-oas/src/refs.test.ts
+++ b/packages/adapter-oas/src/refs.test.ts
@@ -21,10 +21,16 @@ describe('resolveRef', () => {
   it('resolves a local $ref to its schema', () => {
     const result = resolveRef<SchemaObject>(document, '#/components/schemas/Pet')
 
-    expect(result).toEqual({
-      type: 'object',
-      properties: { name: { type: 'string' } },
-    })
+    expect(result).toMatchInlineSnapshot(`
+      {
+        "properties": {
+          "name": {
+            "type": "string",
+          },
+        },
+        "type": "object",
+      }
+    `)
   })
 
   it('returns null for an empty ref', () => {

--- a/packages/adapter-oas/src/resolvers.test.ts
+++ b/packages/adapter-oas/src/resolvers.test.ts
@@ -68,17 +68,21 @@ describe('getDateType', () => {
   })
 
   it('resolves date-time with dateType string to datetime without offset', () => {
-    expect(getDateType({ ...base, dateType: 'string' }, 'date-time')).toEqual({
-      type: 'datetime',
-      offset: false,
-    })
+    expect(getDateType({ ...base, dateType: 'string' }, 'date-time')).toMatchInlineSnapshot(`
+      {
+        "offset": false,
+        "type": "datetime",
+      }
+    `)
   })
 
   it('resolves date-time with dateType date', () => {
-    expect(getDateType({ ...base, dateType: 'date' }, 'date-time')).toEqual({
-      type: 'date',
-      representation: 'date',
-    })
+    expect(getDateType({ ...base, dateType: 'date' }, 'date-time')).toMatchInlineSnapshot(`
+      {
+        "representation": "date",
+        "type": "date",
+      }
+    `)
   })
 
   it('resolves date-time with dateType stringOffset', () => {
@@ -90,25 +94,33 @@ describe('getDateType', () => {
   })
 
   it('resolves date format', () => {
-    expect(getDateType({ ...base, dateType: 'string' }, 'date')).toEqual({
-      type: 'date',
-      representation: 'string',
-    })
-    expect(getDateType({ ...base, dateType: 'date' }, 'date')).toEqual({
-      type: 'date',
-      representation: 'date',
-    })
+    expect(getDateType({ ...base, dateType: 'string' }, 'date')).toMatchInlineSnapshot(`
+      {
+        "representation": "string",
+        "type": "date",
+      }
+    `)
+    expect(getDateType({ ...base, dateType: 'date' }, 'date')).toMatchInlineSnapshot(`
+      {
+        "representation": "date",
+        "type": "date",
+      }
+    `)
   })
 
   it('resolves time format', () => {
-    expect(getDateType({ ...base, dateType: 'string' }, 'time')).toEqual({
-      type: 'time',
-      representation: 'string',
-    })
-    expect(getDateType({ ...base, dateType: 'date' }, 'time')).toEqual({
-      type: 'time',
-      representation: 'date',
-    })
+    expect(getDateType({ ...base, dateType: 'string' }, 'time')).toMatchInlineSnapshot(`
+      {
+        "representation": "string",
+        "type": "time",
+      }
+    `)
+    expect(getDateType({ ...base, dateType: 'date' }, 'time')).toMatchInlineSnapshot(`
+      {
+        "representation": "date",
+        "type": "time",
+      }
+    `)
   })
 })
 

--- a/packages/ast/src/factory.test.ts
+++ b/packages/ast/src/factory.test.ts
@@ -248,11 +248,13 @@ describe('createFunctionParameter', () => {
 
     expect(node.kind).toBe('FunctionParameter')
     expect(node.name).toBe('petId')
-    expect(node.type).toEqual({
-      kind: 'ParamsType',
-      variant: 'reference',
-      name: 'string',
-    })
+    expect(node.type).toMatchInlineSnapshot(`
+      {
+        "kind": "ParamsType",
+        "name": "string",
+        "variant": "reference",
+      }
+    `)
     expect(node.optional).toBe(false)
   })
 
@@ -429,10 +431,12 @@ describe('createSource', () => {
 
     expect(node.kind).toBe('Source')
     expect(node.name).toBe('Pet')
-    expect(node.nodes?.[0]).toEqual({
-      kind: 'Text',
-      value: 'export type Pet = { id: number }',
-    })
+    expect(node.nodes?.[0]).toMatchInlineSnapshot(`
+      {
+        "kind": "Text",
+        "value": "export type Pet = { id: number }",
+      }
+    `)
   })
 
   it('supports isExportable flag', () => {


### PR DESCRIPTION
## Summary

Follow-up to #3394. Converts multi-line whole-value object assertions to `toMatchInlineSnapshot()`, matching the inline-snapshot style already used elsewhere in the same files (e.g. `buildSchemaNode` in `resolvers.test.ts`).

Converted (whole-value, multi-line, deterministic results only):
- `packages/adapter-oas/src/resolvers.test.ts` — the multi-line `getDateType` result objects (single-line ones left as-is).
- `packages/adapter-oas/src/refs.test.ts` — the nested `resolveRef` result object.
- `packages/ast/src/factory.test.ts` — the `createFunctionParameter` `type` (`ParamsType`) object and the `createSource` `Text` node.

Deliberately left as-is (conservative scope):
- The many focused field probes in `parser.test.ts` / `factory.test.ts` (intentional, often commented behavioral checks).
- Partial `toMatchObject` matches (e.g. `refs.test.ts` dereference, `loadConfig`/`unpluginFactory`).
- Intent-carrying literals (e.g. `studio.test.ts` serialization round-trips that mirror their input).
- `ast/utils.test.ts`, which is already heavily inline-snapshot based.

Snapshots were generated by Vitest (`-u`), so each captures the exact previous value — behavior is unchanged.

## Test plan
- [x] `vitest run` on the three changed files (137 tests pass; snapshots stable on re-run without `-u`)
- [x] `oxfmt` formatting applied
- [x] `oxlint ./packages` clean
- [x] `tsc --noEmit` clean for `adapter-oas` and `ast`
- Note: full local suite shows 4 pre-existing `@internals/utils` module-resolution failures in `packages/agent` (needs `pnpm build`; confirmed identical on the unmodified baseline — unrelated to this change)
- No changeset (test-only change, no public behavior change)

https://claude.ai/code/session_01LCWTRTc4rLP97tk1GxHTKJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCWTRTc4rLP97tk1GxHTKJ)_