### PR TITLE
test: standardize on toStrictEqual

### DIFF
--- a/.skills/testing/SKILL.md
+++ b/.skills/testing/SKILL.md
@@ -25,6 +25,19 @@ pnpm test                 # Run all tests
 pnpm test "<test name>"  # Run a specific test
 ```
 
+## Assertion style
+
+Prefer `toStrictEqual` (or `toEqual`) with an explicit literal for whole-value
+assertions. It states the expected result inline, catches extra or `undefined`
+keys, and never drifts silently when someone runs `vitest -u`.
+
+- Use `toStrictEqual(literal)` to assert a complete returned object/array.
+- Use focused matchers (`toBe`, `toHaveLength`, `toContain`, single-field
+  `toEqual`) for specific behavioral checks — don't snapshot those.
+- Reserve `toMatchInlineSnapshot` / `toMatchFileSnapshot` for large generated
+  output (e.g. generated source files) where hand-maintaining a literal is
+  impractical — not for small/medium structured values.
+
 ## Pre-merge Requirements (Agent should remind)
 
 - All tests must pass

--- a/internals/changelog/index.test.ts
+++ b/internals/changelog/index.test.ts
@@ -9,7 +9,7 @@ describe('getPrimaryPackage', () => {
         '@kubb/middleware-barrel': 'patch',
         'unplugin-kubb': 'patch',
       }),
-    ).toEqual(['@kubb/middleware-barrel', 'patch'])
+    ).toStrictEqual(['@kubb/middleware-barrel', 'patch'])
   })
 
   it('returns undefined when the changeset has no packages', () => {

--- a/internals/utils/src/buildTree.test.ts
+++ b/internals/utils/src/buildTree.test.ts
@@ -7,7 +7,7 @@ describe('buildTree', () => {
 
     expect(tree.path).toBe('/src/gen/types')
     expect(tree.isFile).toBe(false)
-    expect(tree.children).toEqual([])
+    expect(tree.children).toStrictEqual([])
   })
 
   it('creates a direct child for a file at root level', () => {

--- a/internals/utils/src/cli/schema.test.ts
+++ b/internals/utils/src/cli/schema.test.ts
@@ -16,8 +16,8 @@ describe('getCommandSchema', () => {
 
   it('returns empty options and subCommands by default', () => {
     const [schema] = getCommandSchema([{ name: 'build', description: 'Build' }])
-    expect(schema?.options).toEqual([])
-    expect(schema?.subCommands).toEqual([])
+    expect(schema?.options).toStrictEqual([])
+    expect(schema?.subCommands).toStrictEqual([])
   })
 
   describe('option flags', () => {
@@ -86,7 +86,7 @@ describe('getCommandSchema', () => {
         expected: true,
       },
     ])('includes $field when set', ({ option, field, expected }) => {
-      expect(schemaOpt(option)?.[field as keyof ReturnType<typeof schemaOpt>]).toEqual(expected)
+      expect(schemaOpt(option)?.[field as keyof ReturnType<typeof schemaOpt>]).toStrictEqual(expected)
     })
 
     it('omits default when not set', () => {
@@ -96,7 +96,7 @@ describe('getCommandSchema', () => {
 
   it('includes examples when provided', () => {
     const [schema] = getCommandSchema([{ name: 'build', description: 'Build', examples: ['kubb generate', 'kubb generate --watch'] }])
-    expect(schema?.examples).toEqual(['kubb generate', 'kubb generate --watch'])
+    expect(schema?.examples).toStrictEqual(['kubb generate', 'kubb generate --watch'])
   })
 
   it('omits examples when not provided', () => {

--- a/internals/utils/src/cli/types.test.ts
+++ b/internals/utils/src/cli/types.test.ts
@@ -10,7 +10,7 @@ describe('defineCommand', () => {
       subCommands: [sub],
     })
     expect(cmd.run).toBeUndefined()
-    expect(cmd.subCommands).toEqual([sub])
+    expect(cmd.subCommands).toStrictEqual([sub])
   })
 
   it('forwards values to the run callback', async () => {

--- a/internals/utils/src/promise.test.ts
+++ b/internals/utils/src/promise.test.ts
@@ -71,7 +71,7 @@ describe('forBatches', () => {
         { concurrency: 2 },
       )
 
-      expect(batches).toEqual([[1, 2], [3, 4], [5]])
+      expect(batches).toStrictEqual([[1, 2], [3, 4], [5]])
     })
 
     it('passes all items when count is less than concurrency', async () => {
@@ -84,7 +84,7 @@ describe('forBatches', () => {
         { concurrency: 10 },
       )
 
-      expect(batches).toEqual([[1, 2]])
+      expect(batches).toStrictEqual([[1, 2]])
     })
 
     it('does nothing for an empty array', async () => {
@@ -110,7 +110,7 @@ describe('forBatches', () => {
         },
       )
 
-      expect(flushed).toEqual([3, 6, 9, 12])
+      expect(flushed).toStrictEqual([3, 6, 9, 12])
     })
 
     it('does not call flush when source is empty', async () => {
@@ -136,7 +136,7 @@ describe('forBatches', () => {
         { concurrency: 2 },
       )
 
-      expect(batches).toEqual([[1, 2], [3, 4], [5]])
+      expect(batches).toStrictEqual([[1, 2], [3, 4], [5]])
     })
 
     it('passes all items when count is less than concurrency', async () => {
@@ -149,7 +149,7 @@ describe('forBatches', () => {
         { concurrency: 10 },
       )
 
-      expect(batches).toEqual([[1, 2]])
+      expect(batches).toStrictEqual([[1, 2]])
     })
 
     it('does nothing for an empty async iterable', async () => {
@@ -175,7 +175,7 @@ describe('forBatches', () => {
         },
       )
 
-      expect(flushed).toEqual([5, 10, 12])
+      expect(flushed).toStrictEqual([5, 10, 12])
     })
 
     it('does not call flush when source is empty', async () => {
@@ -200,7 +200,7 @@ describe('withDrain', () => {
       calls.push('work-end')
     }, flush)
 
-    expect(calls).toEqual(['work-start', 'flush', 'work-end', 'flush'])
+    expect(calls).toStrictEqual(['work-start', 'flush', 'work-end', 'flush'])
   })
 
   it('calls flush even when work never calls it', async () => {

--- a/internals/utils/src/shell.test.ts
+++ b/internals/utils/src/shell.test.ts
@@ -31,6 +31,6 @@ describe('tokenize', () => {
     // path with spaces in quotes
     ['node "/path/to my/script.js"', ['node', '/path/to my/script.js']],
   ])('tokenize(%s)', (input, expected) => {
-    expect(tokenize(input)).toEqual(expected)
+    expect(tokenize(input)).toStrictEqual(expected)
   })
 })

--- a/packages/adapter-oas/src/adapter.test.ts
+++ b/packages/adapter-oas/src/adapter.test.ts
@@ -62,7 +62,7 @@ describe('adapterOas.stream', () => {
         "Category",
       ]
     `)
-    expect(second.map((s) => s.name)).toEqual(first.map((s) => s.name))
+    expect(second.map((s) => s.name)).toStrictEqual(first.map((s) => s.name))
   })
 
   it('yields operations lazily via for await', async () => {

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -40,7 +40,7 @@ describe('buildAst', () => {
       )
 
       expect(pet?.type).toBe('object')
-      expect(pet?.properties?.map((p) => p.name)).toEqual(expect.arrayContaining(['id', 'name', 'tag']))
+      expect(pet?.properties?.map((p) => p.name)).toStrictEqual(expect.arrayContaining(['id', 'name', 'tag']))
     })
 
     it('marks required properties', async () => {
@@ -79,7 +79,7 @@ describe('buildAst', () => {
       )
 
       expect(status?.type).toBe('enum')
-      expect(status?.enumValues).toEqual(['active', 'inactive', 'pending'])
+      expect(status?.enumValues).toStrictEqual(['active', 'inactive', 'pending'])
     })
 
     it('converts oneOf to union', async () => {
@@ -1151,21 +1151,21 @@ describe('parseSchema const (OAS 3.1)', () => {
     const node = parseSchema(ctx, { schema: { const: 'active' } })
 
     expect(node.type).toBe('enum')
-    expect(ast.narrowSchema(node, 'enum')?.enumValues).toEqual(['active'])
+    expect(ast.narrowSchema(node, 'enum')?.enumValues).toStrictEqual(['active'])
   })
 
   it('maps const number to a single-value enum', () => {
     const node = parseSchema(ctx, { schema: { const: 42 } })
 
     expect(node.type).toBe('enum')
-    expect(ast.narrowSchema(node, 'enum')?.enumValues).toEqual([42])
+    expect(ast.narrowSchema(node, 'enum')?.enumValues).toStrictEqual([42])
   })
 
   it('maps const boolean to a single-value enum', () => {
     const node = parseSchema(ctx, { schema: { const: true } })
 
     expect(node.type).toBe('enum')
-    expect(ast.narrowSchema(node, 'enum')?.enumValues).toEqual([true])
+    expect(ast.narrowSchema(node, 'enum')?.enumValues).toStrictEqual([true])
   })
 
   it('maps const: null to a null scalar', () => {
@@ -1224,7 +1224,7 @@ describe('parseSchema const (OAS 3.1)', () => {
     const isHappyEnum = ast.narrowSchema(isHappyProp?.schema, 'enum')
 
     expect(isHappyEnum?.name).toBeNull()
-    expect(isHappyEnum?.enumValues).toEqual([false])
+    expect(isHappyEnum?.enumValues).toStrictEqual([false])
   })
 })
 
@@ -1744,7 +1744,7 @@ describe('parseSchema object discriminator', () => {
     const petTypeProp = narrowed?.properties?.find((p) => p.name === 'petType')
     const petTypeSchema = ast.narrowSchema(petTypeProp?.schema, 'enum')
     expect(petTypeSchema?.type).toBe('enum')
-    expect(petTypeSchema?.enumValues).toEqual(['Cat', 'Dog'])
+    expect(petTypeSchema?.enumValues).toStrictEqual(['Cat', 'Dog'])
   })
 
   it('leaves other properties unchanged when discriminator is present', () => {
@@ -2053,7 +2053,7 @@ describe('parseSchema nullable', () => {
     const node = parseSchema(ctx, { schema: { enum: ['a', 'b', null] } })
     const narrowed = ast.narrowSchema(node, 'enum')
 
-    expect(narrowed?.enumValues).toEqual(['a', 'b'])
+    expect(narrowed?.enumValues).toStrictEqual(['a', 'b'])
   })
 
   it('does not set nullable when not specified', () => {
@@ -2162,14 +2162,14 @@ describe('parseSchema enum', () => {
     const node = parseSchema(ctx, { schema: { enum: ['foo', 'bar', 'baz'] } })
     const narrowed = ast.narrowSchema(node, 'enum')
 
-    expect(narrowed?.enumValues).toEqual(['foo', 'bar', 'baz'])
+    expect(narrowed?.enumValues).toStrictEqual(['foo', 'bar', 'baz'])
   })
 
   it('deduplicates enum values', () => {
     const node = parseSchema(ctx, { schema: { enum: ['a', 'a', 'b'] } })
     const narrowed = ast.narrowSchema(node, 'enum')
 
-    expect(narrowed?.enumValues).toEqual(['a', 'b'])
+    expect(narrowed?.enumValues).toStrictEqual(['a', 'b'])
   })
 
   it('strips null from enumValues and sets nullable', () => {
@@ -2177,7 +2177,7 @@ describe('parseSchema enum', () => {
     const narrowed = ast.narrowSchema(node, 'enum')
 
     expect(node.nullable).toBe(true)
-    expect(narrowed?.enumValues).toEqual(['a', 'b'])
+    expect(narrowed?.enumValues).toStrictEqual(['a', 'b'])
   })
 
   // drf-spectacular splits blank/null choices into `BlankEnum` ({ enum: [''] }) and
@@ -2193,14 +2193,14 @@ describe('parseSchema enum', () => {
   it('keeps a blank-only enum (BlankEnum) as a single "" member', () => {
     const node = parseSchema(ctx, { schema: { enum: [''] } })
 
-    expect(ast.narrowSchema(node, 'enum')?.enumValues).toEqual([''])
+    expect(ast.narrowSchema(node, 'enum')?.enumValues).toStrictEqual([''])
   })
 
   it('keeps blank and null together as a nullable "" enum', () => {
     const node = parseSchema(ctx, { schema: { enum: ['', null] } })
 
     expect(node.nullable).toBe(true)
-    expect(ast.narrowSchema(node, 'enum')?.enumValues).toEqual([''])
+    expect(ast.narrowSchema(node, 'enum')?.enumValues).toStrictEqual([''])
   })
 
   it('parses the oneOf [enum, BlankEnum, NullEnum] pattern into a valid union', () => {
@@ -2208,7 +2208,7 @@ describe('parseSchema enum', () => {
       schema: { oneOf: [{ type: 'string', enum: ['active', 'inactive'] }, { enum: [''] }, { enum: [null] }] },
     })
 
-    expect(ast.narrowSchema(node, 'union')?.members?.map((m) => m.type)).toEqual(['enum', 'enum', 'null'])
+    expect(ast.narrowSchema(node, 'union')?.members?.map((m) => m.type)).toStrictEqual(['enum', 'enum', 'null'])
   })
 
   it('sets enumNullable from schema nullable combined with null in enum', () => {
@@ -2218,7 +2218,7 @@ describe('parseSchema enum', () => {
     const narrowed = ast.narrowSchema(node, 'enum')
 
     expect(node.nullable).toBe(true)
-    expect(narrowed?.enumValues).toEqual(['a'])
+    expect(narrowed?.enumValues).toStrictEqual(['a'])
   })
 
   it('clears default when default is null and enum is nullable', () => {
@@ -2247,7 +2247,7 @@ describe('parseSchema enum', () => {
     expect(node.type).toBe('enum')
     expect(node.primitive).toBe('number')
     const values = narrowed?.namedEnumValues
-    expect(values?.map((v) => v.value)).toEqual([1, 2, 3])
+    expect(values?.map((v) => v.value)).toStrictEqual([1, 2, 3])
     expect(values?.every((v) => v.primitive === 'number')).toBe(true)
   })
 
@@ -2258,7 +2258,7 @@ describe('parseSchema enum', () => {
     const narrowed = ast.narrowSchema(node, 'enum')
 
     expect(node.primitive).toBe('number')
-    expect(narrowed?.namedEnumValues?.map((v) => v.value)).toEqual([0.5, 1.5])
+    expect(narrowed?.namedEnumValues?.map((v) => v.value)).toStrictEqual([0.5, 1.5])
   })
 
   it('uses stringified value as name for numeric enum values', () => {
@@ -2274,7 +2274,7 @@ describe('parseSchema enum', () => {
     })
     const narrowed = ast.narrowSchema(node, 'enum')
 
-    expect(narrowed?.namedEnumValues?.map((v) => v.value)).toEqual([1, 2])
+    expect(narrowed?.namedEnumValues?.map((v) => v.value)).toStrictEqual([1, 2])
   })
 
   // Boolean enum
@@ -2286,7 +2286,7 @@ describe('parseSchema enum', () => {
 
     expect(node.primitive).toBe('boolean')
     const values = narrowed?.namedEnumValues
-    expect(values?.map((v) => v.value)).toEqual([true, false])
+    expect(values?.map((v) => v.value)).toStrictEqual([true, false])
     expect(values?.every((v) => v.primitive === 'boolean')).toBe(true)
   })
 
@@ -2302,8 +2302,8 @@ describe('parseSchema enum', () => {
     const narrowed = ast.narrowSchema(node, 'enum')
 
     const values = narrowed?.namedEnumValues
-    expect(values?.map((v) => v.name)).toEqual(['One', 'Two', 'Three'])
-    expect(values?.map((v) => v.value)).toEqual([1, 2, 3])
+    expect(values?.map((v) => v.name)).toStrictEqual(['One', 'Two', 'Three'])
+    expect(values?.map((v) => v.value)).toStrictEqual([1, 2, 3])
   })
 
   it('uses x-enum-varnames labels as namedEnumValues names', () => {
@@ -2316,8 +2316,8 @@ describe('parseSchema enum', () => {
     const narrowed = ast.narrowSchema(node, 'enum')
 
     const values = narrowed?.namedEnumValues
-    expect(values?.map((v) => v.name)).toEqual(['Active', 'Inactive'])
-    expect(values?.map((v) => v.value)).toEqual(['active', 'inactive'])
+    expect(values?.map((v) => v.name)).toStrictEqual(['Active', 'Inactive'])
+    expect(values?.map((v) => v.value)).toStrictEqual(['active', 'inactive'])
   })
 
   it('x-enumNames deduplicates names', () => {
@@ -2330,7 +2330,7 @@ describe('parseSchema enum', () => {
     const narrowed = ast.narrowSchema(node, 'enum')
 
     const values = narrowed?.namedEnumValues
-    expect(values?.map((v) => v.name)).toEqual(['A', 'B'])
+    expect(values?.map((v) => v.name)).toStrictEqual(['A', 'B'])
   })
 
   it('x-enumNames sets primitive number for integer type', () => {
@@ -2368,8 +2368,8 @@ describe('parseSchema enum', () => {
 
     const values = narrowed?.namedEnumValues
     // After deduping values to [1, 2], names are looked up by position in the deduped array
-    expect(values?.map((v) => v.name)).toEqual(['First', 'Duplicate'])
-    expect(values?.map((v) => v.value)).toEqual([1, 2])
+    expect(values?.map((v) => v.name)).toStrictEqual(['First', 'Duplicate'])
+    expect(values?.map((v) => v.value)).toStrictEqual([1, 2])
   })
 
   it('x-enumNames falls back to stringified value when fewer names than values', () => {
@@ -2383,8 +2383,8 @@ describe('parseSchema enum', () => {
     const narrowed = ast.narrowSchema(node, 'enum')
 
     const values = narrowed?.namedEnumValues
-    expect(values?.map((v) => v.name)).toEqual(['Ten', '20', '30'])
-    expect(values?.map((v) => v.value)).toEqual([10, 20, 30])
+    expect(values?.map((v) => v.name)).toStrictEqual(['Ten', '20', '30'])
+    expect(values?.map((v) => v.value)).toStrictEqual([10, 20, 30])
   })
 
   it('deduplicates numeric enum values and names without extension key', () => {
@@ -2397,8 +2397,8 @@ describe('parseSchema enum', () => {
     const narrowed = ast.narrowSchema(node, 'enum')
 
     const values = narrowed?.namedEnumValues
-    expect(values?.map((v) => v.name)).toEqual(['5', '10'])
-    expect(values?.map((v) => v.value)).toEqual([5, 10])
+    expect(values?.map((v) => v.name)).toStrictEqual(['5', '10'])
+    expect(values?.map((v) => v.value)).toStrictEqual([5, 10])
   })
 
   // Array + enum normalization
@@ -2411,7 +2411,7 @@ describe('parseSchema enum', () => {
     expect(node.type).toBe('array')
     const itemNode = ast.narrowSchema(narrowed?.items?.[0], 'enum')
     expect(itemNode?.type).toBe('enum')
-    expect(itemNode?.enumValues).toEqual(['x', 'y'])
+    expect(itemNode?.enumValues).toStrictEqual(['x', 'y'])
   })
 
   it('merges existing items schema when normalizing array+enum', () => {
@@ -2423,7 +2423,7 @@ describe('parseSchema enum', () => {
     expect(node.type).toBe('array')
     const itemNode = ast.narrowSchema(narrowed?.items?.[0], 'enum')
     expect(itemNode?.type).toBe('enum')
-    expect(itemNode?.enumValues).toEqual(['x', 'y'])
+    expect(itemNode?.enumValues).toStrictEqual(['x', 'y'])
   })
 })
 
@@ -2797,8 +2797,8 @@ describe('parseSchema array', () => {
 
     expect(array?.type).toBe('array')
     expect(object?.type).toBe('object')
-    expect(object?.properties?.map((p) => p.name)).toEqual(['id', 'type', 'value'])
-    expect(ast.narrowSchema(object?.properties?.find((p) => p.name === 'type')?.schema, 'enum')?.enumValues).toEqual(['area', 'density', 'length'])
+    expect(object?.properties?.map((p) => p.name)).toStrictEqual(['id', 'type', 'value'])
+    expect(ast.narrowSchema(object?.properties?.find((p) => p.name === 'type')?.schema, 'enum')?.enumValues).toStrictEqual(['area', 'density', 'length'])
   })
 
   it('qualifies inline enums inside single-member allOf with the parent name', () => {
@@ -2948,7 +2948,7 @@ describe('parseSchema array', () => {
     expect(responseEnums).toContain('GetMaintenanceStatus200DataStatusEnum')
 
     // The core #3364 guarantee: no enum identifier is emitted by both file owners.
-    expect(componentEnums.filter((name) => responseEnums.includes(name))).toEqual([])
+    expect(componentEnums.filter((name) => responseEnums.includes(name))).toStrictEqual([])
   })
 
   it('preserves nullable on array', () => {
@@ -3552,7 +3552,7 @@ describe('parseSchema discriminator on union (oneOf/anyOf)', () => {
     const sharedPropertiesNode = ast.narrowSchema(topIntersection.members?.[1], 'object')
     const sharedTypeProp = sharedPropertiesNode?.properties?.find((p) => p.name === 'type')
 
-    expect(ast.narrowSchema(sharedTypeProp?.schema, 'enum')?.enumValues).toEqual(['dog', 'cat'])
+    expect(ast.narrowSchema(sharedTypeProp?.schema, 'enum')?.enumValues).toStrictEqual(['dog', 'cat'])
 
     const { members } = unionNode
 
@@ -3561,14 +3561,14 @@ describe('parseSchema discriminator on union (oneOf/anyOf)', () => {
     const dogDiscNode = ast.narrowSchema(dogIntersection!.members![1], 'object')
     const dogTypeProp = dogDiscNode?.properties?.find((p) => p.name === 'type')
     expect(dogTypeProp?.schema.readOnly).toBe(true)
-    expect(ast.narrowSchema(dogTypeProp?.schema, 'enum')?.enumValues).toEqual(['dog'])
+    expect(ast.narrowSchema(dogTypeProp?.schema, 'enum')?.enumValues).toStrictEqual(['dog'])
 
     // Cat member: intersection of Cat ref + synthetic discriminant object { type: 'cat' }
     const catIntersection = ast.narrowSchema(members![1], 'intersection')
     const catDiscNode = ast.narrowSchema(catIntersection!.members![1], 'object')
     const catTypeProp = catDiscNode?.properties?.find((p) => p.name === 'type')
     expect(catTypeProp?.schema.readOnly).toBe(true)
-    expect(ast.narrowSchema(catTypeProp?.schema, 'enum')?.enumValues).toEqual(['cat'])
+    expect(ast.narrowSchema(catTypeProp?.schema, 'enum')?.enumValues).toStrictEqual(['cat'])
   })
 
   it('gives enum sibling properties a name derived from the union schema name', () => {
@@ -3625,14 +3625,14 @@ describe('parseSchema discriminator on union without sibling properties', () => 
     expect(dogIntersection).toBeDefined()
     const dogDiscNode = ast.narrowSchema(dogIntersection!.members![1], 'object')
     const dogTypeProp = dogDiscNode?.properties?.find((p) => p.name === 'type')
-    expect(ast.narrowSchema(dogTypeProp?.schema, 'enum')?.enumValues).toEqual(['dog'])
+    expect(ast.narrowSchema(dogTypeProp?.schema, 'enum')?.enumValues).toStrictEqual(['dog'])
 
     // Cat member: intersection of Cat ref + { type: 'cat' }
     const catIntersection = ast.narrowSchema(members![1], 'intersection')
     expect(catIntersection).toBeDefined()
     const catDiscNode = ast.narrowSchema(catIntersection!.members![1], 'object')
     const catTypeProp = catDiscNode?.properties?.find((p) => p.name === 'type')
-    expect(ast.narrowSchema(catTypeProp?.schema, 'enum')?.enumValues).toEqual(['cat'])
+    expect(ast.narrowSchema(catTypeProp?.schema, 'enum')?.enumValues).toStrictEqual(['cat'])
   })
 
   it('leaves members without a mapping entry as plain refs', () => {
@@ -4068,7 +4068,7 @@ describe('parameter enum naming', () => {
     const enumNode = ast.narrowSchema(statusParam?.schema, 'enum')
 
     expect(enumNode?.name).toBe('ListPetsStatus')
-    expect(enumNode?.enumValues).toEqual(['available', 'pending', 'sold'])
+    expect(enumNode?.enumValues).toStrictEqual(['available', 'pending', 'sold'])
     expect(enumNode?.default).toBe('available')
   })
 })

--- a/packages/adapter-oas/src/refs.test.ts
+++ b/packages/adapter-oas/src/refs.test.ts
@@ -51,7 +51,7 @@ describe('resolveRef', () => {
 
     const result = resolveRef<SchemaObject>(docWithEncoded, '#/components/schemas/Pet%20List')
 
-    expect(result).toEqual({ type: 'array', items: { type: 'string' } })
+    expect(result).toStrictEqual({ type: 'array', items: { type: 'string' } })
   })
 })
 

--- a/packages/adapter-oas/src/refs.test.ts
+++ b/packages/adapter-oas/src/refs.test.ts
@@ -21,16 +21,10 @@ describe('resolveRef', () => {
   it('resolves a local $ref to its schema', () => {
     const result = resolveRef<SchemaObject>(document, '#/components/schemas/Pet')
 
-    expect(result).toMatchInlineSnapshot(`
-      {
-        "properties": {
-          "name": {
-            "type": "string",
-          },
-        },
-        "type": "object",
-      }
-    `)
+    expect(result).toStrictEqual({
+      type: 'object',
+      properties: { name: { type: 'string' } },
+    })
   })
 
   it('returns null for an empty ref', () => {

--- a/packages/adapter-oas/src/resolvers.test.ts
+++ b/packages/adapter-oas/src/resolvers.test.ts
@@ -82,11 +82,11 @@ describe('getDateType', () => {
   })
 
   it('resolves date-time with dateType stringOffset', () => {
-    expect(getDateType({ ...base, dateType: 'stringOffset' }, 'date-time')).toEqual({ type: 'datetime', offset: true })
+    expect(getDateType({ ...base, dateType: 'stringOffset' }, 'date-time')).toStrictEqual({ type: 'datetime', offset: true })
   })
 
   it('resolves date-time with dateType stringLocal', () => {
-    expect(getDateType({ ...base, dateType: 'stringLocal' }, 'date-time')).toEqual({ type: 'datetime', local: true })
+    expect(getDateType({ ...base, dateType: 'stringLocal' }, 'date-time')).toStrictEqual({ type: 'datetime', local: true })
   })
 
   it('resolves date format', () => {
@@ -261,7 +261,7 @@ describe('extractSchemaFromContent', () => {
 
 describe('sortSchemas', () => {
   it('returns an empty object for empty input', () => {
-    expect(sortSchemas({})).toEqual({})
+    expect(sortSchemas({})).toStrictEqual({})
   })
 
   it('preserves order when there are no dependencies', () => {
@@ -271,7 +271,7 @@ describe('sortSchemas', () => {
     }
     const result = sortSchemas(schemas)
 
-    expect(Object.keys(result)).toEqual(['A', 'B'])
+    expect(Object.keys(result)).toStrictEqual(['A', 'B'])
   })
 
   it('places referenced schemas before their dependents', () => {
@@ -380,7 +380,7 @@ describe('getSchemas', () => {
 
   it('returns empty schemas when components is absent', () => {
     const { schemas, nameMapping } = getSchemas(base, {})
-    expect(schemas).toEqual({})
+    expect(schemas).toStrictEqual({})
     expect(nameMapping.size).toBe(0)
   })
 
@@ -495,7 +495,7 @@ describe('getSchemas', () => {
     const { schemas, nameMapping } = getSchemas(document, {})
 
     // first entry keeps original name, second gets numeric suffix
-    expect(Object.keys(schemas).sort()).toEqual(['Pet2', 'pet'])
+    expect(Object.keys(schemas).sort()).toStrictEqual(['Pet2', 'pet'])
     expect(nameMapping.get('#/components/schemas/pet')).toBe('pet')
     expect(nameMapping.get('#/components/schemas/Pet')).toBe('Pet2')
   })
@@ -525,7 +525,7 @@ describe('getSchemas', () => {
 
     const { schemas, nameMapping } = getSchemas(document, {})
 
-    expect(Object.keys(schemas).sort()).toEqual(['PetResponse', 'PetSchema'])
+    expect(Object.keys(schemas).sort()).toStrictEqual(['PetResponse', 'PetSchema'])
     expect(nameMapping.get('#/components/schemas/Pet')).toBe('PetSchema')
     expect(nameMapping.get('#/components/responses/Pet')).toBe('PetResponse')
   })
@@ -567,7 +567,7 @@ describe('getSchemas', () => {
 
     const { schemas, nameMapping } = getSchemas(document, {})
 
-    expect(Object.keys(schemas).sort()).toEqual(['PetRequest', 'PetResponse', 'PetSchema'])
+    expect(Object.keys(schemas).sort()).toStrictEqual(['PetRequest', 'PetResponse', 'PetSchema'])
     expect(nameMapping.get('#/components/schemas/Pet')).toBe('PetSchema')
     expect(nameMapping.get('#/components/responses/Pet')).toBe('PetResponse')
     expect(nameMapping.get('#/components/requestBodies/Pet')).toBe('PetRequest')

--- a/packages/adapter-oas/src/resolvers.test.ts
+++ b/packages/adapter-oas/src/resolvers.test.ts
@@ -68,21 +68,17 @@ describe('getDateType', () => {
   })
 
   it('resolves date-time with dateType string to datetime without offset', () => {
-    expect(getDateType({ ...base, dateType: 'string' }, 'date-time')).toMatchInlineSnapshot(`
-      {
-        "offset": false,
-        "type": "datetime",
-      }
-    `)
+    expect(getDateType({ ...base, dateType: 'string' }, 'date-time')).toStrictEqual({
+      type: 'datetime',
+      offset: false,
+    })
   })
 
   it('resolves date-time with dateType date', () => {
-    expect(getDateType({ ...base, dateType: 'date' }, 'date-time')).toMatchInlineSnapshot(`
-      {
-        "representation": "date",
-        "type": "date",
-      }
-    `)
+    expect(getDateType({ ...base, dateType: 'date' }, 'date-time')).toStrictEqual({
+      type: 'date',
+      representation: 'date',
+    })
   })
 
   it('resolves date-time with dateType stringOffset', () => {
@@ -94,33 +90,25 @@ describe('getDateType', () => {
   })
 
   it('resolves date format', () => {
-    expect(getDateType({ ...base, dateType: 'string' }, 'date')).toMatchInlineSnapshot(`
-      {
-        "representation": "string",
-        "type": "date",
-      }
-    `)
-    expect(getDateType({ ...base, dateType: 'date' }, 'date')).toMatchInlineSnapshot(`
-      {
-        "representation": "date",
-        "type": "date",
-      }
-    `)
+    expect(getDateType({ ...base, dateType: 'string' }, 'date')).toStrictEqual({
+      type: 'date',
+      representation: 'string',
+    })
+    expect(getDateType({ ...base, dateType: 'date' }, 'date')).toStrictEqual({
+      type: 'date',
+      representation: 'date',
+    })
   })
 
   it('resolves time format', () => {
-    expect(getDateType({ ...base, dateType: 'string' }, 'time')).toMatchInlineSnapshot(`
-      {
-        "representation": "string",
-        "type": "time",
-      }
-    `)
-    expect(getDateType({ ...base, dateType: 'date' }, 'time')).toMatchInlineSnapshot(`
-      {
-        "representation": "date",
-        "type": "time",
-      }
-    `)
+    expect(getDateType({ ...base, dateType: 'string' }, 'time')).toStrictEqual({
+      type: 'time',
+      representation: 'string',
+    })
+    expect(getDateType({ ...base, dateType: 'date' }, 'time')).toStrictEqual({
+      type: 'time',
+      representation: 'date',
+    })
   })
 })
 

--- a/packages/adapter-oas/src/stream.test.ts
+++ b/packages/adapter-oas/src/stream.test.ts
@@ -211,7 +211,7 @@ describe('createInputStream', () => {
     const second: Array<string> = []
     for await (const s of node.schemas) second.push(s.name ?? '')
 
-    expect(second).toEqual(first)
+    expect(second).toStrictEqual(first)
     expect(first).toMatchInlineSnapshot(`
       [
         "Pet",

--- a/packages/agent/server/plugins/studio.test.ts
+++ b/packages/agent/server/plugins/studio.test.ts
@@ -29,7 +29,7 @@ describe('Studio Plugin - Message Handling', () => {
       expect(isCommandMessage(message)).toBe(false)
 
       const event = isDataMessage(message, 'kubb:info') ? message : undefined
-      expect(event.payload.type).toEqual('kubb:info')
+      expect(event.payload.type).toStrictEqual('kubb:info')
     })
 
     it('should identify disconnect message with reason "expired"', () => {
@@ -64,11 +64,11 @@ describe('Studio Plugin - Message Handling', () => {
       const expired: AgentMessage = { type: 'disconnect', reason: 'expired' }
       const revoked: AgentMessage = { type: 'disconnect', reason: 'revoked' }
 
-      expect(JSON.parse(JSON.stringify(expired))).toEqual({
+      expect(JSON.parse(JSON.stringify(expired))).toStrictEqual({
         type: 'disconnect',
         reason: 'expired',
       })
-      expect(JSON.parse(JSON.stringify(revoked))).toEqual({
+      expect(JSON.parse(JSON.stringify(revoked))).toStrictEqual({
         type: 'disconnect',
         reason: 'revoked',
       })

--- a/packages/agent/server/utils/agentCache.test.ts
+++ b/packages/agent/server/utils/agentCache.test.ts
@@ -40,8 +40,8 @@ describe('Agent cache', () => {
 
       const [, written] = mockStorage.setItem.mock.calls[0]
       expect(written).toHaveLength(2)
-      expect(written[0].config).toEqual(first)
-      expect(written[1].config).toEqual(second)
+      expect(written[0].config).toStrictEqual(first)
+      expect(written[1].config).toStrictEqual(second)
     })
   })
 
@@ -78,7 +78,7 @@ describe('Agent cache', () => {
         sessionId: 'session-123',
       })
 
-      expect(result).toEqual(second)
+      expect(result).toStrictEqual(second)
     })
 
     it('reads from the correct session-scoped key', async () => {

--- a/packages/ast/src/dedupe.test.ts
+++ b/packages/ast/src/dedupe.test.ts
@@ -80,7 +80,7 @@ describe('buildDedupePlan', () => {
 
     expect(plan.hoisted).toHaveLength(0)
     const objectSignature = schemaSignature(cat)
-    expect(plan.canonicalBySignature.get(objectSignature)).toEqual({ name: 'Cat', ref: '#/components/schemas/Cat' })
+    expect(plan.canonicalBySignature.get(objectSignature)).toStrictEqual({ name: 'Cat', ref: '#/components/schemas/Cat' })
   })
 
   it('ignores nodes the candidate predicate rejects', () => {

--- a/packages/ast/src/factory.test.ts
+++ b/packages/ast/src/factory.test.ts
@@ -248,13 +248,11 @@ describe('createFunctionParameter', () => {
 
     expect(node.kind).toBe('FunctionParameter')
     expect(node.name).toBe('petId')
-    expect(node.type).toMatchInlineSnapshot(`
-      {
-        "kind": "ParamsType",
-        "name": "string",
-        "variant": "reference",
-      }
-    `)
+    expect(node.type).toStrictEqual({
+      kind: 'ParamsType',
+      variant: 'reference',
+      name: 'string',
+    })
     expect(node.optional).toBe(false)
   })
 
@@ -431,12 +429,10 @@ describe('createSource', () => {
 
     expect(node.kind).toBe('Source')
     expect(node.name).toBe('Pet')
-    expect(node.nodes?.[0]).toMatchInlineSnapshot(`
-      {
-        "kind": "Text",
-        "value": "export type Pet = { id: number }",
-      }
-    `)
+    expect(node.nodes?.[0]).toStrictEqual({
+      kind: 'Text',
+      value: 'export type Pet = { id: number }',
+    })
   })
 
   it('supports isExportable flag', () => {

--- a/packages/ast/src/factory.test.ts
+++ b/packages/ast/src/factory.test.ts
@@ -28,8 +28,8 @@ describe('createInput', () => {
     const node = createInput()
 
     expect(node.kind).toBe('Input')
-    expect(node.schemas).toEqual([])
-    expect(node.operations).toEqual([])
+    expect(node.schemas).toStrictEqual([])
+    expect(node.operations).toStrictEqual([])
   })
 
   it('accepts overrides', () => {
@@ -37,7 +37,7 @@ describe('createInput', () => {
     const node = createInput({ schemas: [schema] })
 
     expect(node.schemas).toHaveLength(1)
-    expect(node.operations).toEqual([])
+    expect(node.operations).toStrictEqual([])
   })
 
   it('always sets kind to Input', () => {
@@ -61,9 +61,9 @@ describe('createOperation', () => {
     expect(node.method).toBe('GET')
     expect(node.path).toBe('/pets')
     expect(node.protocol).toBe('http')
-    expect(node.tags).toEqual([])
-    expect(node.parameters).toEqual([])
-    expect(node.responses).toEqual([])
+    expect(node.tags).toStrictEqual([])
+    expect(node.parameters).toStrictEqual([])
+    expect(node.responses).toStrictEqual([])
 
     expectTypeOf(node.method).toEqualTypeOf<'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS' | 'TRACE'>()
     expectTypeOf(node.path).toEqualTypeOf<string>()
@@ -81,7 +81,7 @@ describe('createOperation', () => {
 
     expect(node.summary).toBe('Create a pet')
     expect(node.deprecated).toBe(true)
-    expect(node.tags).toEqual(['pets'])
+    expect(node.tags).toStrictEqual(['pets'])
   })
 
   it('builds a generic operation without HTTP method/path', () => {
@@ -290,7 +290,7 @@ describe('createParameterGroup', () => {
     const node = createParameterGroup({ properties: props })
 
     expect(node.kind).toBe('ParameterGroup')
-    expect(node.properties).toEqual(props)
+    expect(node.properties).toStrictEqual(props)
   })
 
   it('accepts inline and default options', () => {
@@ -315,7 +315,7 @@ describe('createFunctionParameters', () => {
     const node = createFunctionParameters()
 
     expect(node.kind).toBe('FunctionParameters')
-    expect(node.params).toEqual([])
+    expect(node.params).toStrictEqual([])
   })
 
   it('accepts params override', () => {
@@ -327,7 +327,7 @@ describe('createFunctionParameters', () => {
     ]
     const node = createFunctionParameters({ params })
 
-    expect(node.params).toEqual(params)
+    expect(node.params).toStrictEqual(params)
   })
 })
 
@@ -336,7 +336,7 @@ describe('createImport', () => {
     const node = createImport({ name: ['useState'], path: 'react' })
 
     expect(node.kind).toBe('Import')
-    expect(node.name).toEqual(['useState'])
+    expect(node.name).toStrictEqual(['useState'])
     expect(node.path).toBe('react')
   })
 
@@ -364,7 +364,7 @@ describe('createImport', () => {
       isTypeOnly: false,
     })
 
-    expect(node.name).toEqual(['*'])
+    expect(node.name).toStrictEqual(['*'])
   })
 
   it('always sets kind to Import', () => {
@@ -380,7 +380,7 @@ describe('createExport', () => {
     const node = createExport({ name: ['Pet'], path: './Pet' })
 
     expect(node.kind).toBe('Export')
-    expect(node.name).toEqual(['Pet'])
+    expect(node.name).toStrictEqual(['Pet'])
     expect(node.path).toBe('./Pet')
   })
 
@@ -551,7 +551,7 @@ describe('createFile', () => {
       footer: '// end',
     })
 
-    expect(file.meta).toEqual({ tag: 'pets' })
+    expect(file.meta).toStrictEqual({ tag: 'pets' })
     expect(file.banner).toBe('// generated')
     expect(file.footer).toBe('// end')
   })
@@ -613,7 +613,7 @@ describe('createConst', () => {
       JSDoc: { comments: ['@description A pet resource'] },
     })
 
-    expect(node.JSDoc?.comments).toEqual(['@description A pet resource'])
+    expect(node.JSDoc?.comments).toStrictEqual(['@description A pet resource'])
   })
 
   it('accepts child nodes', () => {
@@ -656,7 +656,7 @@ describe('createType', () => {
     })
 
     expect(node.export).toBe(true)
-    expect(node.JSDoc?.comments).toEqual(['@description Status of a pet'])
+    expect(node.JSDoc?.comments).toStrictEqual(['@description Status of a pet'])
   })
 
   it('accepts child nodes', () => {
@@ -709,7 +709,7 @@ describe('createFunction', () => {
     expect(node.async).toBe(true)
     expect(node.params).toBe('id: string')
     expect(node.returnType).toBe('Pet')
-    expect(node.generics).toEqual(['T'])
+    expect(node.generics).toStrictEqual(['T'])
   })
 
   it('accepts default export flag', () => {
@@ -729,7 +729,7 @@ describe('createFunction', () => {
       nodes: [createConst({ name: 'url' })],
     })
 
-    expect(node.JSDoc?.comments).toEqual(['@description Fetch a pet'])
+    expect(node.JSDoc?.comments).toStrictEqual(['@description Fetch a pet'])
     expect(node.nodes).toHaveLength(1)
   })
 
@@ -787,7 +787,7 @@ describe('createArrowFunction', () => {
       nodes: [createConst({ name: 'url' })],
     })
 
-    expect(node.JSDoc?.comments).toEqual(['@description Fetch a pet'])
+    expect(node.JSDoc?.comments).toStrictEqual(['@description Fetch a pet'])
     expect(node.nodes).toHaveLength(1)
   })
 

--- a/packages/ast/src/printer.test.ts
+++ b/packages/ast/src/printer.test.ts
@@ -14,7 +14,7 @@ describe('definePrinter', () => {
     const printer = zodPrinter({ strict: false })
 
     expect(printer.name).toBe('zod')
-    expect(printer.options).toEqual({ strict: false })
+    expect(printer.options).toStrictEqual({ strict: false })
   })
 
   it('returns undefined when no node handler matches', () => {

--- a/packages/ast/src/refs.test.ts
+++ b/packages/ast/src/refs.test.ts
@@ -62,7 +62,7 @@ describe('refMapToObject', () => {
     const map = buildRefMap(buildFixture())
     const obj = refMapToObject(map)
 
-    expect(Object.keys(obj).sort()).toEqual(['Error', 'FullPet', 'NewPet', 'Pet', 'PetList', 'PetOrError'])
+    expect(Object.keys(obj).sort()).toStrictEqual(['Error', 'FullPet', 'NewPet', 'Pet', 'PetList', 'PetOrError'])
 
     expect(obj['Pet']).toMatchInlineSnapshot(`
       {

--- a/packages/ast/src/resolvers.test.ts
+++ b/packages/ast/src/resolvers.test.ts
@@ -74,7 +74,7 @@ describe('collectImports()', () => {
       resolve: () => ({ name: 'Foo', path: './foo.ts' }),
     })
 
-    expect(result).toEqual([])
+    expect(result).toStrictEqual([])
   })
 
   it('returns an import entry for ref nodes when resolve() returns a value', () => {
@@ -111,7 +111,7 @@ describe('collectImports()', () => {
       resolve: () => undefined,
     })
 
-    expect(result).toEqual([])
+    expect(result).toStrictEqual([])
   })
 
   it('collects nested ref imports', () => {

--- a/packages/ast/src/transformers.test.ts
+++ b/packages/ast/src/transformers.test.ts
@@ -61,7 +61,7 @@ describe('setDiscriminatorEnum', () => {
     const typeProp = objectNode?.properties?.find((prop) => prop.name === 'type')
     const enumNode = typeProp?.schema.type === 'enum' ? typeProp.schema : undefined
 
-    expect(enumNode?.enumValues).toEqual(['dog'])
+    expect(enumNode?.enumValues).toStrictEqual(['dog'])
     expect(enumNode?.name).toBeUndefined()
   })
 
@@ -76,7 +76,7 @@ describe('setDiscriminatorEnum', () => {
     const typeProp = objectNode?.properties?.find((prop) => prop.name === 'type')
     const enumNode = typeProp?.schema.type === 'enum' ? typeProp.schema : undefined
 
-    expect(enumNode?.enumValues).toEqual(['dog', 'cat'])
+    expect(enumNode?.enumValues).toStrictEqual(['dog', 'cat'])
     expect(enumNode?.name).toBe('PetTypeEnum')
   })
 
@@ -338,7 +338,7 @@ describe('simplifyUnion()', () => {
       }),
     ]
 
-    expect(simplifyUnion(members)).toEqual(members)
+    expect(simplifyUnion(members)).toStrictEqual(members)
   })
 
   it('removes a string enum when a broader string scalar is present', () => {
@@ -351,7 +351,7 @@ describe('simplifyUnion()', () => {
       createSchema({ type: 'string' }),
     ]
 
-    expect(simplifyUnion(members)).toEqual([members[1]])
+    expect(simplifyUnion(members)).toStrictEqual([members[1]])
   })
 
   it('keeps a const-derived string enum when a broader string scalar is present', () => {
@@ -364,7 +364,7 @@ describe('simplifyUnion()', () => {
       createSchema({ type: 'string' }),
     ]
 
-    expect(simplifyUnion(members)).toEqual(members)
+    expect(simplifyUnion(members)).toStrictEqual(members)
   })
 
   it('keeps a string enum when no broader string scalar is present', () => {
@@ -376,7 +376,7 @@ describe('simplifyUnion()', () => {
       }),
     ]
 
-    expect(simplifyUnion(members)).toEqual(members)
+    expect(simplifyUnion(members)).toStrictEqual(members)
   })
 
   it('removes a number enum when a broader number scalar is present', () => {
@@ -389,7 +389,7 @@ describe('simplifyUnion()', () => {
       createSchema({ type: 'number' }),
     ]
 
-    expect(simplifyUnion(members)).toEqual([members[1]])
+    expect(simplifyUnion(members)).toStrictEqual([members[1]])
   })
 
   it('preserves ref members while simplifying scalar enum members', () => {
@@ -408,7 +408,7 @@ describe('simplifyUnion()', () => {
     ]
     const result = simplifyUnion(members)
 
-    expect(result).toEqual([members[1], members[2]])
+    expect(result).toStrictEqual([members[1], members[2]])
   })
 })
 

--- a/packages/ast/src/utils.test.ts
+++ b/packages/ast/src/utils.test.ts
@@ -34,19 +34,19 @@ describe('caseParams', () => {
   it('camelCases snake_case names', () => {
     const result = caseParams([param('pet_id'), param('order_status')], 'camelcase')
 
-    expect(result.map((p) => p.name)).toEqual(['petId', 'orderStatus'])
+    expect(result.map((p) => p.name)).toStrictEqual(['petId', 'orderStatus'])
   })
 
   it('camelCases kebab-case names', () => {
     const result = caseParams([param('some-param'), param('another-one')], 'camelcase')
 
-    expect(result.map((p) => p.name)).toEqual(['someParam', 'anotherOne'])
+    expect(result.map((p) => p.name)).toStrictEqual(['someParam', 'anotherOne'])
   })
 
   it('leaves already-camelCased names unchanged', () => {
     const result = caseParams([param('petId'), param('limit')], 'camelcase')
 
-    expect(result.map((p) => p.name)).toEqual(['petId', 'limit'])
+    expect(result.map((p) => p.name)).toStrictEqual(['petId', 'limit'])
   })
 
   it('does not mutate the original params', () => {
@@ -70,7 +70,7 @@ describe('caseParams', () => {
   })
 
   it('handles an empty params array', () => {
-    expect(caseParams([], 'camelcase')).toEqual([])
+    expect(caseParams([], 'camelcase')).toStrictEqual([])
   })
 })
 
@@ -146,7 +146,7 @@ describe('createDiscriminantNode', () => {
     if (node.type !== 'object') return
     const enumNode = node.properties?.[0]?.schema
     if (!enumNode || enumNode.type !== 'enum') return
-    expect(enumNode.enumValues).toEqual(['dog'])
+    expect(enumNode.enumValues).toStrictEqual(['dog'])
   })
 })
 
@@ -664,7 +664,7 @@ describe('createOperationParams', () => {
 
       const pathGroup = params.params[0]
       if (pathGroup && pathGroup.kind === 'ParameterGroup') {
-        expect(pathGroup.properties[0]?.type).toEqual({
+        expect(pathGroup.properties[0]?.type).toStrictEqual({
           kind: 'ParamsType',
           variant: 'reference',
           name: 'string',
@@ -1113,7 +1113,7 @@ describe('createOperationParams', () => {
       const pathGroup = params.params[0]
       expect(pathGroup).toBeDefined()
       if (pathGroup && pathGroup.kind === 'ParameterGroup') {
-        expect(pathGroup.properties.map((p) => p.name)).toEqual(['petId', 'storeName'])
+        expect(pathGroup.properties.map((p) => p.name)).toStrictEqual(['petId', 'storeName'])
       }
     })
   })
@@ -1300,7 +1300,7 @@ describe('createOperationParams', () => {
         expect(pathGroup.properties[0]?.name).toBe('petId')
       }
       const queryParam = params.params.find((p) => p.kind === 'FunctionParameter' && p.name === 'params')
-      expect(queryParam?.type).toEqual({
+      expect(queryParam?.type).toStrictEqual({
         kind: 'ParamsType',
         variant: 'reference',
         name: 'ListPetsQueryParams',
@@ -1324,7 +1324,7 @@ describe('typeWrapper option', () => {
 
     const group = params.params[0]
     if (group?.kind === 'ParameterGroup') {
-      expect(group.properties[0]?.type).toEqual({
+      expect(group.properties[0]?.type).toStrictEqual({
         kind: 'ParamsType',
         variant: 'reference',
         name: 'MaybeRefOrGetter<string>',
@@ -1345,7 +1345,7 @@ describe('typeWrapper option', () => {
     })
 
     const bodyParam = params.params.find((p) => p.kind === 'FunctionParameter' && p.name === 'data')
-    expect(bodyParam?.type).toEqual({
+    expect(bodyParam?.type).toStrictEqual({
       kind: 'ParamsType',
       variant: 'reference',
       name: 'MaybeRefOrGetter<CreatePetRequest>',
@@ -1367,7 +1367,7 @@ describe('typeWrapper option', () => {
     })
 
     const queryParam = params.params.find((p) => p.kind === 'FunctionParameter' && p.name === 'params')
-    expect(queryParam?.type).toEqual({
+    expect(queryParam?.type).toStrictEqual({
       kind: 'ParamsType',
       variant: 'reference',
       name: 'MaybeRefOrGetter<ListPetsQueryParams>',
@@ -1387,7 +1387,7 @@ describe('typeWrapper option', () => {
 
     const group = params.params[0]
     if (group?.kind === 'ParameterGroup') {
-      expect(group.properties[0]?.type).toEqual({
+      expect(group.properties[0]?.type).toStrictEqual({
         kind: 'ParamsType',
         variant: 'reference',
         name: 'string',
@@ -1416,7 +1416,7 @@ describe('pathParamsType: inlineSpread', () => {
     if (restParam?.kind === 'FunctionParameter') {
       expect(restParam.rest).toBe(true)
       expect(restParam.name).toBe('pathParams')
-      expect(restParam.type).toEqual({
+      expect(restParam.type).toStrictEqual({
         kind: 'ParamsType',
         variant: 'reference',
         name: 'GetPetByIdPathParams',
@@ -1460,7 +1460,7 @@ describe('pathParamsType: inlineSpread', () => {
 
     const restParam = params.params[0]
     if (restParam?.kind === 'FunctionParameter') {
-      expect(restParam.type).toEqual({
+      expect(restParam.type).toStrictEqual({
         kind: 'ParamsType',
         variant: 'reference',
         name: 'MaybeRefOrGetter<GetPetByIdPathParams>',
@@ -1561,7 +1561,7 @@ describe('combineSources', () => {
   })
 
   it('returns empty array for empty input', () => {
-    expect(combineSources([])).toEqual([])
+    expect(combineSources([])).toStrictEqual([])
   })
 })
 
@@ -1571,7 +1571,7 @@ describe('combineExports', () => {
     const result = combineExports([exp, exp])
 
     expect(result).toHaveLength(1)
-    expect(result[0]!.name).toEqual(['Pet'])
+    expect(result[0]!.name).toStrictEqual(['Pet'])
   })
 
   it('merges named exports from the same path into one entry', () => {
@@ -1635,7 +1635,7 @@ describe('combineExports', () => {
     const b = createExport({ path: './b' })
     const result = combineExports([c, a, b])
 
-    expect(result.map((e) => e.path)).toEqual(['./a', './b', './c'])
+    expect(result.map((e) => e.path)).toStrictEqual(['./a', './b', './c'])
   })
 
   it('deduplicates namespace alias exports', () => {
@@ -1653,7 +1653,7 @@ describe('combineExports', () => {
   })
 
   it('returns empty array for empty input', () => {
-    expect(combineExports([])).toEqual([])
+    expect(combineExports([])).toStrictEqual([])
   })
 })
 
@@ -1737,7 +1737,7 @@ describe('combineImports', () => {
     const b = createImport({ name: ['b'], path: './b' })
     const result = combineImports([c, a, b], [], 'a b c')
 
-    expect(result.map((i) => i.path)).toEqual(['./a', './b', './c'])
+    expect(result.map((i) => i.path)).toStrictEqual(['./a', './b', './c'])
   })
 
   it('skips an import when path equals root', () => {
@@ -1752,7 +1752,7 @@ describe('combineImports', () => {
   })
 
   it('returns empty array for empty input', () => {
-    expect(combineImports([], [], '')).toEqual([])
+    expect(combineImports([], [], '')).toStrictEqual([])
   })
 
   it('keeps aliased named import when the local alias appears in the source', () => {
@@ -1809,7 +1809,7 @@ describe('findCircularSchemas', () => {
       ],
     })
 
-    expect(findCircularSchemas([Category, Pet])).toEqual(new Set())
+    expect(findCircularSchemas([Category, Pet])).toStrictEqual(new Set())
   })
 
   it('detects direct self-reference (TreeNode → TreeNode)', () => {
@@ -1821,7 +1821,7 @@ describe('findCircularSchemas', () => {
       ],
     })
 
-    expect(findCircularSchemas([TreeNode])).toEqual(new Set(['TreeNode']))
+    expect(findCircularSchemas([TreeNode])).toStrictEqual(new Set(['TreeNode']))
   })
 
   it('detects indirect cycle (Pet → Cat → Pet)', () => {
@@ -1842,7 +1842,7 @@ describe('findCircularSchemas', () => {
       ],
     })
 
-    expect(findCircularSchemas([Pet, Cat])).toEqual(new Set(['Pet', 'Cat']))
+    expect(findCircularSchemas([Pet, Cat])).toStrictEqual(new Set(['Pet', 'Cat']))
   })
 
   it('detects refs nested inside unions and arrays', () => {
@@ -1861,7 +1861,7 @@ describe('findCircularSchemas', () => {
       ],
     })
 
-    expect(findCircularSchemas([A])).toEqual(new Set(['A']))
+    expect(findCircularSchemas([A])).toStrictEqual(new Set(['A']))
   })
 
   it('does not flag schemas that only reference cyclic schemas without participating', () => {
@@ -1884,7 +1884,7 @@ describe('findCircularSchemas', () => {
 
   it('skips unnamed schemas', () => {
     const anon = createSchema({ type: 'object' })
-    expect(findCircularSchemas([anon])).toEqual(new Set())
+    expect(findCircularSchemas([anon])).toStrictEqual(new Set())
   })
 })
 
@@ -1930,11 +1930,11 @@ describe('collectReferencedSchemaNames', () => {
       ],
     })
 
-    expect(collectReferencedSchemaNames(schema)).toEqual(new Set(['Category', 'Tag', 'User']))
+    expect(collectReferencedSchemaNames(schema)).toStrictEqual(new Set(['Category', 'Tag', 'User']))
   })
 
   it('returns an empty set for schemas without refs', () => {
-    expect(collectReferencedSchemaNames(createSchema({ type: 'string' }))).toEqual(new Set())
+    expect(collectReferencedSchemaNames(createSchema({ type: 'string' }))).toStrictEqual(new Set())
   })
 })
 
@@ -2021,7 +2021,7 @@ describe('collectUsedSchemaNames', () => {
   it('collects schema names referenced by parameters and responses, and excludes unreachable schemas', () => {
     const result = collectUsedSchemaNames([getItemsOp], schemas)
 
-    expect(result).toEqual(new Set(['ItemStatus', 'ItemsResponse']))
+    expect(result).toStrictEqual(new Set(['ItemStatus', 'ItemsResponse']))
     expect(result.has('OrderStatus')).toBe(false)
     expect(result.has('OrdersResponse')).toBe(false)
   })
@@ -2029,11 +2029,11 @@ describe('collectUsedSchemaNames', () => {
   it('collects schema names from multiple operations', () => {
     const result = collectUsedSchemaNames([getItemsOp, getOrdersOp], schemas)
 
-    expect(result).toEqual(new Set(['ItemStatus', 'ItemsResponse', 'OrderStatus', 'OrdersResponse']))
+    expect(result).toStrictEqual(new Set(['ItemStatus', 'ItemsResponse', 'OrderStatus', 'OrdersResponse']))
   })
 
   it('returns an empty set when the operations list is empty', () => {
-    expect(collectUsedSchemaNames([], schemas)).toEqual(new Set())
+    expect(collectUsedSchemaNames([], schemas)).toStrictEqual(new Set())
   })
 
   it('follows transitive schema references', () => {
@@ -2059,7 +2059,7 @@ describe('collectUsedSchemaNames', () => {
 
     const result = collectUsedSchemaNames([detailOp], [tagSchema, itemSchema, responseSchema])
 
-    expect(result).toEqual(new Set(['ItemDetail', 'Item', 'Tag']))
+    expect(result).toStrictEqual(new Set(['ItemDetail', 'Item', 'Tag']))
   })
 
   it('collects schemas referenced in request body content', () => {
@@ -2081,6 +2081,6 @@ describe('collectUsedSchemaNames', () => {
 
     const result = collectUsedSchemaNames([createItemOp], [bodySchema])
 
-    expect(result).toEqual(new Set(['CreateItemBody']))
+    expect(result).toStrictEqual(new Set(['CreateItemBody']))
   })
 })

--- a/packages/ast/src/visitor.test.ts
+++ b/packages/ast/src/visitor.test.ts
@@ -62,7 +62,7 @@ describe('walk', () => {
       },
     })
 
-    expect(ids).toEqual(['getPetById'])
+    expect(ids).toStrictEqual(['getPetById'])
   })
 
   it('does not mutate the original tree', async () => {

--- a/packages/cli/src/telemetry.test.ts
+++ b/packages/cli/src/telemetry.test.ts
@@ -66,7 +66,7 @@ describe('buildTelemetryEvent', () => {
 
     expect(event.command).toBe('generate')
     expect(event.kubbVersion).toBe('4.0.0')
-    expect(event.plugins).toEqual(plugins)
+    expect(event.plugins).toStrictEqual(plugins)
     expect(event.filesCreated).toBe(10)
     expect(event.status).toBe('success')
     expect(typeof event.duration).toBe('number')
@@ -188,7 +188,7 @@ describe('buildOtlpPayload', () => {
     expect(typeof span!.startTimeUnixNano).toBe('string')
     expect(typeof span!.endTimeUnixNano).toBe('string')
     const attr = span!.attributes?.find((a) => a.key === 'kubb.status')
-    expect(attr?.value).toEqual({ stringValue: 'success' })
+    expect(attr?.value).toStrictEqual({ stringValue: 'success' })
   })
 
   it('should set status code 2 for failed status', () => {

--- a/packages/core/src/FileManager.test.ts
+++ b/packages/core/src/FileManager.test.ts
@@ -16,7 +16,7 @@ function makeFile(path: string, sourceValue?: string, extra?: Partial<Parameters
 describe('FileManager', () => {
   it('starts with an empty file list', () => {
     const manager = new FileManager()
-    expect(manager.files).toEqual([])
+    expect(manager.files).toStrictEqual([])
   })
 
   describe('add', () => {

--- a/packages/core/src/FileProcessor.test.ts
+++ b/packages/core/src/FileProcessor.test.ts
@@ -90,8 +90,8 @@ describe('FileProcessor', () => {
 
       await processor.run(files)
 
-      expect(updates[0]).toEqual({ processed: 1, percentage: 50, total: 2 })
-      expect(updates[1]).toEqual({ processed: 2, percentage: 100, total: 2 })
+      expect(updates[0]).toStrictEqual({ processed: 1, percentage: 50, total: 2 })
+      expect(updates[1]).toStrictEqual({ processed: 2, percentage: 100, total: 2 })
     })
 
     it('returns the original files array', async () => {
@@ -112,7 +112,7 @@ describe('FileProcessor', () => {
 
       await processor.run(files)
 
-      expect(order).toEqual(['/src/a.ts', '/src/b.ts'])
+      expect(order).toStrictEqual(['/src/a.ts', '/src/b.ts'])
     })
 
     it('runs without errors', async () => {
@@ -142,7 +142,7 @@ describe('FileProcessor', () => {
       expect(onStart).toHaveBeenCalledWith([])
       expect(onEnd).toHaveBeenCalledWith([])
       expect(onUpdate).not.toHaveBeenCalled()
-      expect(result).toEqual([])
+      expect(result).toStrictEqual([])
     })
   })
 })

--- a/packages/core/src/createKubb.test.ts
+++ b/packages/core/src/createKubb.test.ts
@@ -85,7 +85,7 @@ describe('createKubb', () => {
     await kubb.setup()
 
     expect(kubb.config?.root).toBe(process.cwd())
-    expect(kubb.config?.parsers).toEqual([])
+    expect(kubb.config?.parsers).toStrictEqual([])
   })
 
   test('if build with one plugin is running the different hooks in the correct order', async () => {
@@ -257,8 +257,8 @@ describe('createKubb', () => {
 
     // In the always-stream path all plugins fan-out together: both files are
     // produced in the same batch and flushed as a single event.
-    expect(batches).toEqual([2])
-    expect(files.map((file) => file.path)).toEqual(['/workspace/src/gen/one.ts', '/workspace/src/gen/two.ts'])
+    expect(batches).toStrictEqual([2])
+    expect(files.map((file) => file.path)).toStrictEqual(['/workspace/src/gen/one.ts', '/workspace/src/gen/two.ts'])
   })
 
   it('cleans up hook-style plugin listeners between builds on shared hooks', async () => {
@@ -356,7 +356,7 @@ describe('createKubb', () => {
 
       expect(files).toHaveLength(count)
       expect(generatedPaths).toHaveLength(count)
-      expect(generatedPaths).toEqual(schemas.map((s) => `/gen/${s.name}.ts`))
+      expect(generatedPaths).toStrictEqual(schemas.map((s) => `/gen/${s.name}.ts`))
     })
 
     it('preserves operation insertion order for collectedOperations across batches', async () => {
@@ -398,7 +398,7 @@ describe('createKubb', () => {
         { hooks: new AsyncEventEmitter<KubbHooks>() },
       ).build()
 
-      expect(receivedOrder).toEqual(operations.map((o) => o.operationId))
+      expect(receivedOrder).toStrictEqual(operations.map((o) => o.operationId))
     })
 
     it('processes schemas from adapter.stream() across batches', async () => {

--- a/packages/core/src/createStorage.test.ts
+++ b/packages/core/src/createStorage.test.ts
@@ -77,12 +77,12 @@ describe('createStorage', () => {
 
     expect(await storage.hasItem('a')).toBe(true)
     expect(await storage.getItem('a')).toBe('1')
-    expect(await storage.getKeys()).toEqual(['a', 'b'])
+    expect(await storage.getKeys()).toStrictEqual(['a', 'b'])
 
     await storage.removeItem('a')
     expect(await storage.hasItem('a')).toBe(false)
 
     await storage.clear()
-    expect(await storage.getKeys()).toEqual([])
+    expect(await storage.getKeys()).toStrictEqual([])
   })
 })

--- a/packages/core/src/definePlugin.test.ts
+++ b/packages/core/src/definePlugin.test.ts
@@ -39,7 +39,7 @@ describe('definePlugin', () => {
     }))({ tag: 'pets' })
 
     expect(plugin.name).toBe('my-hook-plugin')
-    expect(plugin.options).toEqual({ tag: 'pets' })
+    expect(plugin.options).toStrictEqual({ tag: 'pets' })
     expect(typeof plugin.hooks['kubb:plugin:setup']).toBe('function')
   })
 
@@ -50,7 +50,7 @@ describe('definePlugin', () => {
       hooks: {},
     }))
     const plugin = factory()
-    expect(plugin.options).toEqual({})
+    expect(plugin.options).toStrictEqual({})
   })
 })
 
@@ -161,7 +161,7 @@ describe('PluginDriver — hook-style plugin registration', () => {
 
     await events.emit('kubb:plugin:setup', createSetupCtxStub(makeConfig([])))
 
-    expect(capturedOptions[0]).toEqual({ tag: 'pets' })
+    expect(capturedOptions[0]).toStrictEqual({ tag: 'pets' })
   })
 
   it('setResolver() merges partial resolver overrides with framework defaults', async () => {
@@ -265,7 +265,7 @@ describe('PluginDriver — hook-style plugin registration', () => {
     const opts = plugin.options as Record<string, unknown>
     expect(opts.enumType).toBe('asConst')
     expect(opts.syntaxType).toBe('type')
-    expect(opts.output).toEqual({ path: 'types' })
+    expect(opts.output).toStrictEqual({ path: 'types' })
   })
 
   it('external listeners receive kubb:plugin:setup context', async () => {

--- a/packages/core/src/defineResolver.test.ts
+++ b/packages/core/src/defineResolver.test.ts
@@ -193,9 +193,9 @@ describe('defaultResolveFile', () => {
 
     expect(file.baseName).toBe('pet.ts')
     expect(file.path).toBe('/root/types/pet.ts')
-    expect(file.sources).toEqual([])
-    expect(file.imports).toEqual([])
-    expect(file.exports).toEqual([])
+    expect(file.sources).toStrictEqual([])
+    expect(file.imports).toStrictEqual([])
+    expect(file.exports).toStrictEqual([])
   })
 
   it('uses PascalCase file name via resolver.default', () => {

--- a/packages/core/src/storages/fsStorage.test.ts
+++ b/packages/core/src/storages/fsStorage.test.ts
@@ -89,12 +89,12 @@ describe('fsStorage', () => {
 
     const keys = await storage.getKeys(dir)
 
-    expect(keys.sort()).toEqual(['a.ts', 'b.ts', 'sub/c.ts'])
+    expect(keys.sort()).toStrictEqual(['a.ts', 'b.ts', 'sub/c.ts'])
   })
 
   it('getKeys returns empty array for a missing directory', async () => {
     const keys = await fsStorage().getKeys(join(dir, 'missing'))
-    expect(keys).toEqual([])
+    expect(keys).toStrictEqual([])
   })
 
   it('clear removes all files under a base directory', async () => {

--- a/packages/core/src/storages/memoryStorage.test.ts
+++ b/packages/core/src/storages/memoryStorage.test.ts
@@ -55,7 +55,7 @@ describe('memoryStorage', () => {
     await storage.setItem('src/gen/b.ts', '2')
     await storage.setItem('other/c.ts', '3')
 
-    expect((await storage.getKeys()).sort()).toEqual(['other/c.ts', 'src/gen/a.ts', 'src/gen/b.ts'])
+    expect((await storage.getKeys()).sort()).toStrictEqual(['other/c.ts', 'src/gen/a.ts', 'src/gen/b.ts'])
   })
 
   it('getKeys filters by base prefix', async () => {
@@ -65,7 +65,7 @@ describe('memoryStorage', () => {
     await storage.setItem('src/gen/b.ts', '2')
     await storage.setItem('other/c.ts', '3')
 
-    expect((await storage.getKeys('src/gen')).sort()).toEqual(['src/gen/a.ts', 'src/gen/b.ts'])
+    expect((await storage.getKeys('src/gen')).sort()).toStrictEqual(['src/gen/a.ts', 'src/gen/b.ts'])
   })
 
   it('clear with no base removes all keys', async () => {
@@ -75,7 +75,7 @@ describe('memoryStorage', () => {
     await storage.setItem('b', '2')
     await storage.clear()
 
-    expect(await storage.getKeys()).toEqual([])
+    expect(await storage.getKeys()).toStrictEqual([])
   })
 
   it('clear with base removes only matching keys', async () => {
@@ -87,6 +87,6 @@ describe('memoryStorage', () => {
 
     await storage.clear('src/gen')
 
-    expect(await storage.getKeys()).toEqual(['other/c.ts'])
+    expect(await storage.getKeys()).toStrictEqual(['other/c.ts'])
   })
 })

--- a/packages/kubb/src/defineConfig.test.ts
+++ b/packages/kubb/src/defineConfig.test.ts
@@ -90,7 +90,7 @@ describe('defineConfig', () => {
     } as UserConfig)
     const resolved = config as UserConfig
 
-    expect(resolved.output.barrel).toEqual({ type: 'named' })
+    expect(resolved.output.barrel).toStrictEqual({ type: 'named' })
   })
 
   test('preserves explicit output.barrel (including false)', () => {
@@ -105,7 +105,7 @@ describe('defineConfig', () => {
       output: { path: './gen', barrel: false },
     } as UserConfig) as UserConfig
 
-    expect(named.output.barrel).toEqual({ type: 'all' })
+    expect(named.output.barrel).toStrictEqual({ type: 'all' })
     expect(disabled.output.barrel).toBe(false)
   })
 
@@ -146,7 +146,7 @@ describe('defineConfig', () => {
     } as UserConfig)
     const resolved = config as UserConfig
 
-    expect(resolved.output.barrel).toEqual({ type: 'named' })
+    expect(resolved.output.barrel).toStrictEqual({ type: 'named' })
   })
 
   test('preserves existing adapter', () => {
@@ -268,7 +268,7 @@ describe('defineConfig', () => {
     const typedDataConfig: UserConfig<{ data: { openapi: string } }> = dataConfig
 
     expect(typedPathConfig.input!.path).toBe('spec.yaml')
-    expect(typedDataConfig.input!.data).toEqual({ openapi: '3.1.0' })
+    expect(typedDataConfig.input!.data).toStrictEqual({ openapi: '3.1.0' })
   })
 
   test('accepts named configs with hooks', () => {

--- a/packages/middleware-barrel/src/middleware.test.ts
+++ b/packages/middleware-barrel/src/middleware.test.ts
@@ -57,7 +57,7 @@ describe('middlewareBarrel', () => {
     const { files } = await createKubb(config).build()
     const paths = files.map((file) => file.path)
 
-    expect(paths).toEqual(
+    expect(paths).toStrictEqual(
       expect.arrayContaining([
         '/workspace/src/gen/types/pet.ts',
         '/workspace/src/gen/types/index.ts',
@@ -66,7 +66,7 @@ describe('middlewareBarrel', () => {
         '/workspace/src/gen/index.ts',
       ]),
     )
-    expect(files.find((file) => file.path === '/workspace/src/gen/index.ts')?.exports.flatMap((item) => item.name ?? [])).toEqual(
+    expect(files.find((file) => file.path === '/workspace/src/gen/index.ts')?.exports.flatMap((item) => item.name ?? [])).toStrictEqual(
       expect.arrayContaining(['Pet', 'PetSchema']),
     )
   })

--- a/packages/middleware-barrel/src/utils.test.ts
+++ b/packages/middleware-barrel/src/utils.test.ts
@@ -39,7 +39,7 @@ describe('getBarrelFiles', () => {
 
     expect(barrels).toHaveLength(1)
     expect(barrels[0]!.path).toBe(`${ROOT}/index.ts`)
-    expect(barrels[0]!.exports.map((e) => e.path)).toEqual(expect.arrayContaining(['./pet.ts', './user.ts']))
+    expect(barrels[0]!.exports.map((e) => e.path)).toStrictEqual(expect.arrayContaining(['./pet.ts', './user.ts']))
   })
 
   it('generates named exports with barrelType named', () => {
@@ -47,21 +47,21 @@ describe('getBarrelFiles', () => {
     const barrels = [...getBarrelFiles({ outputPath: ROOT, files, barrelType: 'named' })]
 
     expect(barrels).toHaveLength(1)
-    expect(barrels[0]!.exports[0]?.name).toEqual(expect.arrayContaining(['Pet', 'createPet']))
+    expect(barrels[0]!.exports[0]?.name).toStrictEqual(expect.arrayContaining(['Pet', 'createPet']))
   })
 
   it('generates hierarchical barrels when nested is true', () => {
     const files = [makeFile(`${ROOT}/pets/listPets.ts`), makeFile(`${ROOT}/users/getUser.ts`)]
     const barrels = [...getBarrelFiles({ outputPath: ROOT, files, barrelType: 'all', nested: true })]
 
-    expect(barrels.map((b) => b.path)).toEqual(expect.arrayContaining([`${ROOT}/index.ts`, `${ROOT}/pets/index.ts`, `${ROOT}/users/index.ts`]))
+    expect(barrels.map((b) => b.path)).toStrictEqual(expect.arrayContaining([`${ROOT}/index.ts`, `${ROOT}/pets/index.ts`, `${ROOT}/users/index.ts`]))
   })
 
   it('generates per-subdirectory barrels when recursive is true', () => {
     const files = [makeFile(`${ROOT}/pets/listPets.ts`), makeFile(`${ROOT}/users/getUser.ts`)]
     const barrels = [...getBarrelFiles({ outputPath: ROOT, files, barrelType: 'all', recursive: true })]
 
-    expect(barrels.map((b) => b.path)).toEqual(expect.arrayContaining([`${ROOT}/index.ts`, `${ROOT}/pets/index.ts`, `${ROOT}/users/index.ts`]))
+    expect(barrels.map((b) => b.path)).toStrictEqual(expect.arrayContaining([`${ROOT}/index.ts`, `${ROOT}/pets/index.ts`, `${ROOT}/users/index.ts`]))
   })
 })
 

--- a/packages/renderer-jsx/src/createRenderer.test.tsx
+++ b/packages/renderer-jsx/src/createRenderer.test.tsx
@@ -128,7 +128,7 @@ describe('jsxRendererSync', () => {
     await reactRenderer.render(element)
     reactRenderer.unmount()
 
-    expect(syncRenderer.files).toEqual(reactRenderer.files)
+    expect(syncRenderer.files).toStrictEqual(reactRenderer.files)
   })
 
   it('should propagate render errors', async () => {
@@ -172,7 +172,7 @@ describe('jsxRendererSync', () => {
       order.push(file.baseName as string)
     }
 
-    expect(order).toEqual(['first.ts', 'second.ts'])
+    expect(order).toStrictEqual(['first.ts', 'second.ts'])
   })
 
   it('should yield the first file before evaluating the second component', () => {
@@ -215,12 +215,12 @@ describe('jsxRendererSync', () => {
     const result1 = gen.next()
     expect(result1.done).toBe(false)
     expect((result1.value as FileNode).baseName).toBe('first.ts')
-    expect(callOrder).toEqual(['First called'])
+    expect(callOrder).toStrictEqual(['First called'])
 
     const result2 = gen.next()
     expect(result2.done).toBe(false)
     expect((result2.value as FileNode).baseName).toBe('second.ts')
-    expect(callOrder).toEqual(['First called', 'Second called'])
+    expect(callOrder).toStrictEqual(['First called', 'Second called'])
 
     expect(gen.next().done).toBe(true)
   })
@@ -256,7 +256,7 @@ describe('jsxRendererSync', () => {
     const batchRenderer = jsxRendererSync()
     await batchRenderer.render(element)
 
-    expect(streamed).toEqual(batchRenderer.files)
+    expect(streamed).toStrictEqual(batchRenderer.files)
   })
 
   it('should propagate errors thrown during stream', () => {

--- a/packages/renderer-jsx/src/dom.test.ts
+++ b/packages/renderer-jsx/src/dom.test.ts
@@ -9,7 +9,7 @@ describe('dom utilities', () => {
 
       expect(node.nodeName).toBe('kubb-file')
       expect(node.attributes).toBeTypeOf('object')
-      expect(node.childNodes).toEqual([])
+      expect(node.childNodes).toStrictEqual([])
       expect(node.parentNode).toBeNull()
     })
   })

--- a/packages/renderer-jsx/src/utils.test.ts
+++ b/packages/renderer-jsx/src/utils.test.ts
@@ -60,7 +60,7 @@ describe('collectFiles', () => {
     assert(result)
     const node = result.sources[0]
     assert(node?.nodes)
-    expect(node.nodes.map((n) => n.kind)).toEqual(children.map(([, kind]) => kind))
+    expect(node.nodes.map((n) => n.kind)).toStrictEqual(children.map(([, kind]) => kind))
   })
 
   it('should add Break node for br children', () => {
@@ -194,7 +194,7 @@ describe('collectFiles', () => {
     const [result] = collectFiles(root)
     expect(result?.baseName).toBe('pet.ts')
     expect(result?.path).toBe('src/models/pet.ts')
-    expect(result?.meta).toEqual({ tag: 'pet' })
+    expect(result?.meta).toStrictEqual({ tag: 'pet' })
     expect(result?.banner).toBe('// banner')
     expect(result?.footer).toBe('// footer')
     expect(result?.sources[0]?.name).toBe('Pet')
@@ -211,7 +211,7 @@ describe('collectFiles', () => {
     setAttribute(noPath, 'baseName', 'b.ts')
     appendChildNode(root, noPath)
 
-    expect(collectFiles(root)).toEqual([])
+    expect(collectFiles(root)).toStrictEqual([])
   })
 
   it('should traverse nested non-file elements to find files', () => {


### PR DESCRIPTION
## Summary

Standardizes test assertions on `toStrictEqual`, which is intent-revealing, catches extra/`undefined` keys and prototype mismatches, and never drifts silently on `vitest -u`.

1. **Revert #3398's inline snapshots** back to explicit assertions (`resolvers.test.ts`, `refs.test.ts`, `factory.test.ts`).
2. **Repo-wide `toEqual` → `toStrictEqual`** for object/array comparisons across `packages` and `internals` (184 assertions, 36 files).
3. **Document the preference** in the testing skill (`.skills/testing/SKILL.md`).

Verified safe: the full suite passes unchanged after the swap (only the unrelated, pre-existing `@internals/*` / `@kubb/*` workspace build-resolution failures remain, which also fail on `main` without a prior `pnpm build`). No test relied on the looser `toEqual` semantics.

## Test plan
- [x] `vitest run` full suite — 1402 tests pass (no assertion failures from the swap)
- [x] `oxfmt` applied to changed files
- [x] `oxlint ./packages` clean
- No changeset (test-only change)

https://claude.ai/code/session_01LCWTRTc4rLP97tk1GxHTKJ