### PR TITLE
docs(core,kubb): correct default parsers in JSDoc

### DIFF
--- a/packages/core/src/createKubb.ts
+++ b/packages/core/src/createKubb.ts
@@ -100,7 +100,7 @@ export type Config<TInput = Input> = {
    * set of file extensions; a fallback parser handles anything else.
    *
    * Already resolved on the `Config` instance — see `UserConfig` for the
-   * optional form that defaults to `[parserTs, parserTsx]`.
+   * optional form that defaults to `[parserTs, parserTsx, parserMd]`.
    *
    * @example
    * ```ts
@@ -395,7 +395,7 @@ export type UserConfig<TInput = Input> = Omit<Config<TInput>, 'root' | 'plugins'
   root?: string
   /**
    * Custom parsers that convert generated AST nodes to strings (TypeScript, JSON, markdown, etc.).
-   * @default [parserTs]  // from `@kubb/parser-ts`
+   * @default [parserTs, parserTsx, parserMd]  // applied by `defineConfig` from the `kubb` package
    */
   parsers?: Array<Parser>
   /**

--- a/packages/kubb/src/defineConfig.ts
+++ b/packages/kubb/src/defineConfig.ts
@@ -20,7 +20,7 @@ type DefinedConfig<TConfig extends ConfigInput> = TConfig extends (cli: CLIOptio
  *
  * - `root` defaults to `process.cwd()`
  * - `adapter` defaults to `adapterOas()`
- * - `parsers` defaults to `[parserTs, parserTsx]`
+ * - `parsers` defaults to `[parserTs, parserTsx, parserMd]`
  * - `middleware` defaults to `[middlewareBarrel()]`
  * - `output.barrel` defaults to `{ type: 'named' }` **only when `middlewareBarrel` is part of `middleware`**.
  *   When the user provides a custom middleware list without `middlewareBarrel`, `barrel` is left untouched.
@@ -66,7 +66,7 @@ function normalizeConfig<TInput>(config: UserConfig<TInput> | Array<UserConfig<T
  *
  * Defaults applied when omitted:
  * - `adapter` → `adapterOas()` (OpenAPI 2.0/3.0/3.1).
- * - `parsers` → `[parserTs, parserTsx]`.
+ * - `parsers` → `[parserTs, parserTsx, parserMd]`.
  * - `middleware` → `[middlewareBarrel()]`.
  * - `output.barrel` → `{ type: 'named' }` only when `middlewareBarrel` is
  *   in the middleware list.


### PR DESCRIPTION
## Summary

While validating the kubb.dev docs against the code, I found that several JSDoc comments describe the default parser list incorrectly.

`defineConfig` (the `kubb` package) applies `[parserTs, parserTsx, parserMd]` when `parsers` is omitted:

```ts
// packages/kubb/src/defineConfig.ts
parsers: config.parsers?.length ? config.parsers : [parserTs, parserTsx, parserMd],
```

But the docs/comments said `[parserTs, parserTsx]` or `[parserTs]`:

- `packages/kubb/src/defineConfig.ts` — two "Defaults applied" comments missing `parserMd`.
- `packages/core/src/createKubb.ts` — the `Config.parsers` comment and the `UserConfig.parsers` `@default` (which said `[parserTs]`).

This PR aligns those comments with the actual effective default. No behavior change — comments only.

Companion PRs: kubb-labs/platform (kubb.dev 5.x docs) and kubb-labs/plugins (plugin `extension.yaml` sync).

https://claude.ai/code/session_01CsdiVR9myTqrWqdX2f59bk

---
_Generated by [Claude Code](https://claude.ai/code/session_01CsdiVR9myTqrWqdX2f59bk)_