### PR TITLE
docs: link to kubb.dev/sponsors in Supporting Kubb section

### DIFF
--- a/packages/adapter-oas/README.md
+++ b/packages/adapter-oas/README.md
@@ -74,6 +74,7 @@ All OpenAPI types (`Document`, `Operation`, `SchemaObject`, `HttpMethod`, etc.) 
 Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
+- [See sponsorship tiers and our sponsors](https://kubb.dev/sponsors)
 
 <p align="center">
   <a href="https://github.com/sponsors/stijnvanhulle">

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -345,6 +345,7 @@ You'll receive a stream of events as the code generation progresses.
 Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
+- [See sponsorship tiers and our sponsors](https://kubb.dev/sponsors)
 
 <p align="center">
   <a href="https://github.com/sponsors/stijnvanhulle">

--- a/packages/ast/README.md
+++ b/packages/ast/README.md
@@ -135,6 +135,7 @@ extractRefName('#/components/schemas/Pet') // 'Pet'
 Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
+- [See sponsorship tiers and our sponsors](https://kubb.dev/sponsors)
 
 <p align="center">
   <a href="https://github.com/sponsors/stijnvanhulle">

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -244,6 +244,7 @@ See the [`@kubb/agent` README](../agent/README.md) for full environment variable
 Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
+- [See sponsorship tiers and our sponsors](https://kubb.dev/sponsors)
 
 <p align="center">
   <a href="https://github.com/sponsors/stijnvanhulle">

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -43,6 +43,7 @@ npm install @kubb/core
 Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
+- [See sponsorship tiers and our sponsors](https://kubb.dev/sponsors)
 
 <p align="center">
   <a href="https://github.com/sponsors/stijnvanhulle">

--- a/packages/kubb/README.md
+++ b/packages/kubb/README.md
@@ -68,6 +68,7 @@ See the [documentation](https://kubb.dev) for detailed usage and advanced featur
 Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
+- [See sponsorship tiers and our sponsors](https://kubb.dev/sponsors)
 
 <p align="center">
   <a href="https://github.com/sponsors/stijnvanhulle">

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -175,6 +175,7 @@ export default defineConfig({
 Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
+- [See sponsorship tiers and our sponsors](https://kubb.dev/sponsors)
 
 <p align="center">
   <a href="https://github.com/sponsors/stijnvanhulle">

--- a/packages/middleware-barrel/README.md
+++ b/packages/middleware-barrel/README.md
@@ -82,6 +82,7 @@ After every plugin finishes generating files, `@kubb/middleware-barrel` walks th
 Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
+- [See sponsorship tiers and our sponsors](https://kubb.dev/sponsors)
 
 <p align="center">
   <a href="https://github.com/sponsors/stijnvanhulle">

--- a/packages/parser-md/README.md
+++ b/packages/parser-md/README.md
@@ -76,6 +76,7 @@ Parser instance for `.md` and `.markdown` files. Pass to `defineConfig({ parsers
 Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
+- [See sponsorship tiers and our sponsors](https://kubb.dev/sponsors)
 
 <p align="center">
   <a href="https://github.com/sponsors/stijnvanhulle">

--- a/packages/parser-ts/README.md
+++ b/packages/parser-ts/README.md
@@ -85,6 +85,7 @@ Parser instance for `.tsx` and `.jsx` files. Same API as `parserTs` with JSX sup
 Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
+- [See sponsorship tiers and our sponsors](https://kubb.dev/sponsors)
 
 <p align="center">
   <a href="https://github.com/sponsors/stijnvanhulle">

--- a/packages/renderer-jsx/README.md
+++ b/packages/renderer-jsx/README.md
@@ -108,6 +108,7 @@ Pre-built renderer instance for use directly in Kubb plugins as the `jsxRenderer
 Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
+- [See sponsorship tiers and our sponsors](https://kubb.dev/sponsors)
 
 <p align="center">
   <a href="https://github.com/sponsors/stijnvanhulle">

--- a/packages/unplugin-kubb/README.md
+++ b/packages/unplugin-kubb/README.md
@@ -110,6 +110,7 @@ type Options = {
 Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
+- [See sponsorship tiers and our sponsors](https://kubb.dev/sponsors)
 
 <p align="center">
   <a href="https://github.com/sponsors/stijnvanhulle">


### PR DESCRIPTION
## Summary

Adds a link to the sponsor page (https://kubb.dev/sponsors) in the "Supporting Kubb" section of the README files. Previously these only linked to GitHub Sponsors.

The new bullet sits next to the existing GitHub Sponsors link:

```
- [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
- [See sponsorship tiers and our sponsors](https://kubb.dev/sponsors)
```

## Details

- Updated the package READMEs that share the "Supporting Kubb" section (the root `README.md` is a symlink to `packages/kubb/README.md`, so it picks up the change automatically).
- Docs-only change with no public behavior or version impact, so no changeset is included.

https://claude.ai/code/session_014R3H9ZyL4t6ncwyKwbuFgq

---
_Generated by [Claude Code](https://claude.ai/code/session_014R3H9ZyL4t6ncwyKwbuFgq)_