### PR TITLE
docs: new Kubb-using companies for outreach

### DIFF
--- a/companies-using-kubb-outreach.md
+++ b/companies-using-kubb-outreach.md
@@ -1,0 +1,64 @@
+# New Companies Using Kubb — Outreach Leads
+
+> Additional companies and organizations found using Kubb that are **not** already listed in [`companies-using-kubb.md`](./companies-using-kubb.md).
+>
+> Identified by scanning GitHub for `@kubb/core`, `@kubb/plugin-client`, and related dependencies in public `package.json` files, then filtering for organization-type accounts and real companies (excluding bug-reproduction repos, test tasks, student exercises, and individual portfolio projects).
+>
+> Kubb versions are sourced directly from each repository's `package.json`. The existing list applies a "v4+ only" filter; here we keep companies on older majors too, since any active Kubb user is a valid outreach target — version is flagged so you can prioritize.
+>
+> _Compiled: May 29, 2026_
+
+---
+
+## ✉️ Companies With a Public Contact Email (priority outreach)
+
+| Organization | Description | Contact Email | Kubb Version | Repository | GitHub |
+|---|---|---|---|---|---|
+| **Index Coop** | Largest provider of on-chain structured DeFi products (sector index, leverage & yield products); DAO | [institutions@indexcoop.com](mailto:institutions@indexcoop.com) (also [iclegal@indexcoop.com](mailto:iclegal@indexcoop.com)) | `4.1.2` (`@kubb/core`) ✅ v4 | [index-app](https://github.com/IndexCoop/index-app) | [@IndexCoop](https://github.com/IndexCoop) |
+| **Otimize Solutions** | Brazilian custom-software factory (8+ yrs) building products for startups & enterprises | [comercial@otimizesolutions.com.br](mailto:comercial@otimizesolutions.com.br) | `^4.12.11` ✅ v4 | [valor-judicial-frontend](https://github.com/otimizesolutions/valor-judicial-frontend) | [@otimizesolutions](https://github.com/otimizesolutions) |
+| **Dynamic Labs** | Multi-chain wallet-based authentication, authorization & orchestration platform (dynamic.xyz) | [hello@dynamic.xyz](mailto:hello@dynamic.xyz) | `~2.21.2` ⚠️ v2 | [mpc-node-server-demo](https://github.com/dynamic-labs-oss/mpc-node-server-demo) | [@dynamic-labs-oss](https://github.com/dynamic-labs-oss) |
+| **Pinax** | Blockchain data infrastructure & Substreams provider (Canada) | [info@pinax.network](mailto:info@pinax.network) | `^2.23.3` ⚠️ v2 | [antelope-transactions-api](https://github.com/pinax-network/antelope-transactions-api) | [@pinax-network](https://github.com/pinax-network) |
+| **Naptha AI** | Operating system / infrastructure for human–agent (multi-agent) organizations | [team@naptha.ai](mailto:team@naptha.ai) | `^3.5.0` ⚠️ v3 | [naptchat](https://github.com/NapthaAI/naptchat) | [@NapthaAI](https://github.com/NapthaAI) |
+
+## 🏢 Organizations Without a Public Email (use GitHub Issues / web form)
+
+| Organization | Description | Contact Channel | Kubb Version | Repository | GitHub |
+|---|---|---|---|---|---|
+| **CloudCrafter** | Open-source self-hosted application deployment platform / PaaS (Netherlands) | GitHub Issues | `^3.7.0` ⚠️ v3 | [CloudCrafter](https://github.com/cloudcrafter-oss/CloudCrafter) | [@cloudcrafter-oss](https://github.com/cloudcrafter-oss) |
+| **LatticeBCLab** (晶格链实验室) | Professional blockchain development team (data-space connectors, SDKs) | GitHub Issues | `^3.18.2` ⚠️ v3 | [tds-connector-ui](https://github.com/LatticeBCLab/tds-connector-ui) | [@LatticeBCLab](https://github.com/LatticeBCLab) |
+| **Gatherloop** | Community gathering space & café; maintains an open-source POS (Indonesia) | [gatherloop.co](http://gatherloop.co) | `^2.19.6` ⚠️ v2 | [gatherloop-pos](https://github.com/gatherloop/gatherloop-pos) | [@gatherloop](https://github.com/gatherloop) |
+| **CampusCribs** | Student-housing rental platform (frontend + OpenAPI spec) | GitHub Issues | — | [campuscribs-frontend](https://github.com/CampusCribs/campuscribs-frontend) | [@CampusCribs](https://github.com/CampusCribs) |
+
+## 👤 Notable Individual (potential contributor outreach)
+
+| Developer | Affiliation / Context | Contact | Kubb Usage |
+|---|---|---|---|
+| [@tlthiago](https://github.com/tlthiago) (Thiago Alves) | Fullstack dev @ Mart Minas; building **Synnerdata** (multi-tenant SaaS w/ Power BI + payment gateway) | LinkedIn `in/thiagolmalves` | [synnerdata-web-n](https://github.com/tlthiago/synnerdata-web-n) |
+
+---
+
+## 📊 Summary
+
+| Bucket | Count |
+|---|---|
+| Companies with a public email | 5 |
+| Organizations without a public email | 4 |
+| Notable individuals | 1 |
+| **Total new leads** | **10** |
+
+### Email-ready outreach shortlist
+
+- Index Coop — institutions@indexcoop.com
+- Otimize Solutions — comercial@otimizesolutions.com.br
+- Dynamic Labs — hello@dynamic.xyz
+- Pinax — info@pinax.network
+- Naptha AI — team@naptha.ai
+
+---
+
+## 🔍 Method & Notes
+
+- Source: GitHub code search for `@kubb/core` / `@kubb/plugin-client` in public `package.json` files (May 2026), cross-referenced against the existing `companies-using-kubb.md` to remove duplicates.
+- Excluded from this list (already in `companies-using-kubb.md`): Equinor, Xata, Automattic, NYC Planning, StuDocu, NVDB Vegdata, Aembit, Hola Boss AI, NumbersStation AI, Taco IDE, LenneTech, Webpractik, Riven Media, MorcaLabs, niceyup, alienplatform, TreeMov, Blockful, Tough Dev School, GenerateNU, GeeksHacking, bluds-sa, BobaBoard, openresponses, next-dev-team, Anvoria.
+- Also excluded: Kubb's own bug-reproduction repos (e.g. IanVS/*, LuudJanssen, SCdF, jakobberglund, dovranJorayev, waonpad, la55u), test tasks (e.g. DexArt's Entain test), and individual portfolio/learning projects with no company behind them.
+- ⚠️ = Kubb major below v4 (outdated vs. the existing list's v4+ filter, but still an active user worth contacting). ✅ = v4+.

--- a/cspell.json
+++ b/cspell.json
@@ -21,6 +21,7 @@
     "docs/guide/base-url.md",
     "docs/ecosystem.md",
     "docs/about.md",
+    "companies-using-kubb-outreach.md",
     "getParams.test.ts",
     "paramsCasing.test.ts",
     "paramsCasing.ts"


### PR DESCRIPTION
## Summary

Adds `companies-using-kubb-outreach.md` — a list of **new** companies/organizations found using Kubb that are **not** already in `companies-using-kubb.md`, with contact emails for sponsorship outreach.

Found via GitHub code search for `@kubb/core` / `@kubb/plugin-client` in public `package.json` files, then filtered to real companies (excluding bug-repro repos, test tasks, and individual portfolio projects) and de-duplicated against the existing list.

### Email-ready leads
| Company | Email | Kubb |
|---|---|---|
| Index Coop | institutions@indexcoop.com | 4.1.2 ✅ |
| Otimize Solutions | comercial@otimizesolutions.com.br | ^4.12.11 ✅ |
| Dynamic Labs | hello@dynamic.xyz | ~2.21.2 ⚠️ |
| Pinax | info@pinax.network | ^2.23.3 ⚠️ |
| Naptha AI | team@naptha.ai | ^3.5.0 ⚠️ |

Plus 4 orgs without a public email (CloudCrafter, LatticeBCLab, Gatherloop, CampusCribs) and 1 notable individual (Synnerdata / @tlthiago). ⚠️ = Kubb major below v4.

https://claude.ai/code/session_01AF1sKHuqpPDmVCzsvTUPkz

---
_Generated by [Claude Code](https://claude.ai/code/session_01AF1sKHuqpPDmVCzsvTUPkz)_