### PR TITLE
fix(ast): export isInputNode and isOutputNode guards

### DIFF
--- a/.changeset/export-ast-input-output-guards.md
+++ b/.changeset/export-ast-input-output-guards.md
@@ -1,0 +1,5 @@
+---
+'@kubb/ast': minor
+---
+
+Export the `isInputNode` and `isOutputNode` type guards from the `@kubb/ast` entry point. Both guards were defined and documented in `guards.ts` but missing from the barrel, so they could not be imported alongside `isOperationNode` and `isSchemaNode`.

--- a/packages/ast/src/index.ts
+++ b/packages/ast/src/index.ts
@@ -29,7 +29,7 @@ export {
   syncOptionality,
   update,
 } from './factory.ts'
-export { isHttpOperationNode, isOperationNode, isSchemaNode, narrowSchema } from './guards.ts'
+export { isHttpOperationNode, isInputNode, isOperationNode, isOutputNode, isSchemaNode, narrowSchema } from './guards.ts'
 export { createPrinterFactory, definePrinter } from './printer.ts'
 export { extractRefName } from './refs.ts'
 export { childName, collectImports, enumPropName, findDiscriminator } from './resolvers.ts'


### PR DESCRIPTION
## What

Re-export the `isInputNode` and `isOutputNode` type guards from the `@kubb/ast` entry point.

## Why

Both guards are defined and documented in `packages/ast/src/guards.ts`, but the barrel (`packages/ast/src/index.ts`) only re-exported `isHttpOperationNode`, `isOperationNode`, `isSchemaNode` and `narrowSchema`. As a result `isInputNode`/`isOutputNode` were not importable from `@kubb/ast`.

This surfaced as a **twoslash error in kubb.dev** (`platform` repo): the `docs/5.x/concepts/ast.md` "type guards" sample imports all of them from `@kubb/ast`, so the build reported:

```
'"@kubb/ast"' has no exported member named 'isInputNode'. Did you mean 'InputNode'?
'"@kubb/ast"' has no exported member named 'isOutputNode'. Did you mean 'OutputNode'?
```

With the guards re-exported, the documented public API matches reality and the docs sample type-checks. No other twoslash blocks needed changes — the remaining flagged blocks intentionally carry `// @errors: 2307` for "import your own file here" examples.

## Verification

- `tsc --noEmit` on `@kubb/ast`: clean
- `vitest run src/guards.test.ts`: 18 passed
- Re-ran a twoslash check over all `docs/5.x` blocks against the local sources: the previously throwing `ast.md` block now passes

Added a `minor` changeset (`@kubb/ast`) since this adds two members to the public surface.

https://claude.ai/code/session_01BZL8cddxeWBXSjUhkPKQcA

---
_Generated by [Claude Code](https://claude.ai/code/session_01BZL8cddxeWBXSjUhkPKQcA)_