### PR TITLE
refactor(core): remove any and unnecessary casts from internal types

### DIFF
--- a/.changeset/core-type-safety-escape-hatches.md
+++ b/.changeset/core-type-safety-escape-hatches.md
@@ -1,0 +1,5 @@
+---
+'@kubb/core': patch
+---
+
+Tighten internal type safety by removing `any` and unnecessary casts. The `Parser` type now defaults `TMeta` to `object` instead of `any`, `getContext` returns an honest `Omit<GeneratorContext, 'options'>` rather than laundering a missing field through `as unknown as`, and a couple of `as never` casts are replaced with proper optional types. No runtime behavior or public API change.

--- a/packages/core/src/KubbDriver.ts
+++ b/packages/core/src/KubbDriver.ts
@@ -418,7 +418,7 @@ export class KubbDriver {
         )
       }
 
-      const generatorPlugins: Array<{ plugin: NormalizedPlugin; context: GeneratorContext; hrStart: ReturnType<typeof process.hrtime> }> = []
+      const generatorPlugins: Array<{ plugin: NormalizedPlugin; context: Omit<GeneratorContext, 'options'>; hrStart: ReturnType<typeof process.hrtime> }> = []
 
       for (const plugin of this.plugins.values()) {
         const context = this.getContext(plugin)
@@ -502,14 +502,14 @@ export class KubbDriver {
   }
 
   async #runGenerators(
-    entries: Array<{ plugin: NormalizedPlugin; context: GeneratorContext; hrStart: ReturnType<typeof process.hrtime> }>,
+    entries: Array<{ plugin: NormalizedPlugin; context: Omit<GeneratorContext, 'options'>; hrStart: ReturnType<typeof process.hrtime> }>,
     flushPending: () => Promise<void>,
   ): Promise<{ timings: Map<string, number>; failed: Set<{ plugin: Plugin; error: Error }> }> {
     const timings = new Map<string, number>()
     const failed = new Set<{ plugin: Plugin; error: Error }>()
     type PluginState = {
       plugin: NormalizedPlugin
-      generatorContext: GeneratorContext
+      generatorContext: Omit<GeneratorContext, 'options'>
       generators: Array<Generator>
       hrStart: ReturnType<typeof process.hrtime>
       failed: boolean
@@ -635,7 +635,7 @@ export class KubbDriver {
     // Saves an N-sized allocation that lives until the build ends, on the common
     // path where plugins only define per-node `gen.operation`.
     const needsCollectedOperations = this.hooks.listenerCount('kubb:generate:operations') > 0 || states.some((s) => s.generators.some((g) => !!g.operations))
-    const collectedOperations: Array<OperationNode> = needsCollectedOperations ? [] : (undefined as never)
+    const collectedOperations: Array<OperationNode> | undefined = needsCollectedOperations ? [] : undefined
 
     // Run schemas before operations: the two passes share `flushPending` and the
     // FileProcessor's event emitter, so running them concurrently would interleave
@@ -648,7 +648,7 @@ export class KubbDriver {
     await forBatches(
       operations,
       (nodes) => {
-        if (needsCollectedOperations) collectedOperations.push(...nodes)
+        if (needsCollectedOperations) collectedOperations?.push(...nodes)
         return Promise.all(nodes.flatMap((n) => states.map((state) => dispatchNode(state, n, operationDispatch))))
       },
       { concurrency: SCHEMA_PARALLEL, flush: flushPending },
@@ -663,9 +663,10 @@ export class KubbDriver {
           // excludes/includes/overrides that resolve to null in dispatchOperation must also
           // be hidden from the batched gen.operations() hook, otherwise grouped/barrel
           // generators emit references to operation files that the per-op hook intentionally skipped.
+          const ops = collectedOperations ?? []
           const pluginOperations = state.optionsAreStatic
-            ? collectedOperations
-            : collectedOperations.filter((node) => {
+            ? ops
+            : ops.filter((node) => {
                 const transformed = plugin.transformer ? transform(node, plugin.transformer) : node
                 const { exclude, include, override } = plugin.options
 
@@ -775,7 +776,7 @@ export class KubbDriver {
     return this.#resolvers.get(pluginName) ?? this.plugins.get(pluginName)?.resolver ?? this.#getDefaultResolver(pluginName)
   }
 
-  getContext<TOptions extends PluginFactoryOptions>(plugin: NormalizedPlugin<TOptions>): GeneratorContext<TOptions> & Record<string, unknown> {
+  getContext<TOptions extends PluginFactoryOptions>(plugin: NormalizedPlugin<TOptions>): Omit<GeneratorContext<TOptions>, 'options'> {
     const driver = this
 
     return {
@@ -801,8 +802,10 @@ export class KubbDriver {
       get meta(): InputMeta {
         return driver.inputNode?.meta ?? { circularNames: [], enumNames: [] }
       },
-      get adapter(): Adapter | null {
-        return driver.adapter
+      get adapter(): Adapter {
+        // Generators only read `adapter` during AST hooks, which run after the
+        // adapter is set, so it is guaranteed defined at read time.
+        return driver.adapter!
       },
       get resolver() {
         return driver.getResolver(plugin.name)
@@ -840,7 +843,7 @@ export class KubbDriver {
 
         return openInStudioFn(inputNode, studioUrl, options)
       },
-    } as unknown as GeneratorContext<TOptions>
+    }
   }
 
   getPlugin<TName extends keyof Kubb.PluginRegistry>(pluginName: TName): Plugin<Kubb.PluginRegistry[TName]> | undefined

--- a/packages/core/src/createKubb.ts
+++ b/packages/core/src/createKubb.ts
@@ -945,7 +945,7 @@ function resolveConfig(userConfig: UserConfig): Config {
           ...(typeof userConfig.devtools === 'boolean' ? {} : userConfig.devtools),
         }
       : undefined,
-    plugins: (userConfig.plugins ?? []) as unknown as Config['plugins'],
+    plugins: userConfig.plugins ?? [],
   }
 }
 

--- a/packages/core/src/defineParser.ts
+++ b/packages/core/src/defineParser.ts
@@ -9,7 +9,7 @@ type PrintOptions = {
  * written to disk. Kubb ships with TypeScript and TSX parsers; add your own
  * for new file types (JSON, Markdown, ...).
  */
-export type Parser<TMeta extends object = any, TNode = unknown> = {
+export type Parser<TMeta extends object = object, TNode = unknown> = {
   /**
    * Display name used in diagnostics and the parser registry.
    */


### PR DESCRIPTION
## Context

`@kubb/core` is well-architected, but a few type-safety escape hatches in `src` directly violated the repo's own code-style rule (*"Never use `any` or `as any`. Use proper types, generics, or `unknown`/`never`."*). These casts laundered away missing fields and widened generics, so the compiler couldn't catch real mistakes at those boundaries.

This PR removes the escape hatches that can be eliminated **without any runtime behavior or public-API change**. One load-bearing cast is deliberately left in place (see below).

## Changes

- **`defineParser.ts`** — `Parser<TMeta extends object = any>` → `= object`, matching the sibling defaults on `FileNode`/`UserFileNode`.
- **`createKubb.ts`** — removed the dead `as unknown as Config['plugins']` double cast; the value is already `Array<Plugin>`.
- **`KubbDriver.ts`**
  - `getContext` now returns an honest `Omit<GeneratorContext, 'options'>` instead of `as unknown as GeneratorContext`. The builder genuinely omits `options` (callers add it), so the cast was hiding a missing required field. Rippled the matching annotations on the entries array, `#runGenerators`, and `PluginState`.
  - The `adapter` getter now reflects its documented always-defined contract (`Adapter` rather than `Adapter | null`), which the old blanket cast had been masking.
  - `collectedOperations` uses `Array<OperationNode> | undefined` with optional access instead of `undefined as never`.

## Intentionally NOT changed

The `handler as never` casts in the `on`/`off` hook-dispatch loops (`KubbDriver.ts`) are load-bearing: handlers are stored type-erased across a `keyof KubbHooks` union, so the key→handler correlation is gone at the storage boundary. Removing the cast would need a large refactor or just relocate it — no safety gain.

## Verification

- `pnpm typecheck` ✅ (core)
- `pnpm test` ✅ (137 tests pass, no test changes needed)
- `pnpm lint` ✅ (oxlint clean)
- Dependent packages (`parser-ts`, `renderer-jsx`, `cli`) typecheck clean. (The pre-existing `@kubb/parser-md` module-resolution error in the `kubb` package is unrelated to this change.)

A `@kubb/core` patch changeset is included.

https://claude.ai/code/session_01SLjcCJEUPG52TpfDNFjcw8

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLjcCJEUPG52TpfDNFjcw8)_