### PR TITLE
ci: publish a single GitHub release per version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,16 +66,40 @@ jobs:
           # `release:stage:ci` chains three steps: `release:stage` stages every
           # package on npm (no publish to `latest`), `changeset tag` creates the
           # local git tags and prints the `New tag:` lines the action parses to
-          # push tags and create a GitHub Release per package, and the final echo
-          # records that staging ran. It must be a single script: the action
-          # splits `publish` on whitespace and spawns it directly (no shell), so
-          # `&&` and `>>` only work when wrapped in a script pnpm runs via a shell.
+          # push the tags, and the final echo records that staging ran. It must
+          # be a single script: the action splits `publish` on whitespace and
+          # spawns it directly (no shell), so `&&` and `>>` only work when
+          # wrapped in a script pnpm runs via a shell.
           publish: pnpm release:stage:ci
           commit: 'ci(changesets): version packages'
           setupGitUser: false
+          # Skip changeset's per-package GitHub Releases. The "Create GitHub
+          # release" step below publishes a single release per version instead,
+          # mirroring the consolidated root CHANGELOG.md.
+          createGithubReleases: false
         env:
           NPM_CONFIG_PROVENANCE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub release
+        if: steps.changesets.outputs.staged == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # The fixed-group `kubb@<version>` tag is pushed by the step above and
+        # carries the canonical version used for the root CHANGELOG.md. Reuse it
+        # as the single release, with the latest changelog section as the body.
+        run: |
+          VERSION="$(node -p "require('./packages/kubb/package.json').version")"
+          node internals/changelog/latest.mjs > release-notes.md
+          PRERELEASE=()
+          case "$VERSION" in
+            *-*) PRERELEASE=(--prerelease) ;;
+          esac
+          gh release create "kubb@${VERSION}" \
+            --title "v${VERSION}" \
+            --notes-file release-notes.md \
+            --verify-tag \
+            "${PRERELEASE[@]}"
 
       - name: Publish ${{ inputs.tag || 'canary' }}
         id: canary

--- a/internals/changelog/latest.mjs
+++ b/internals/changelog/latest.mjs
@@ -1,0 +1,28 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const CHANGELOG = path.join(ROOT, 'CHANGELOG.md')
+
+/**
+ * Returns the body of the most recent version block from a CHANGELOG.md string,
+ * stripped of its `## v...` heading so it can serve as a GitHub release body
+ * (the release title already carries the version).
+ */
+export function getLatestSection(markdown) {
+  const start = markdown.search(/^## /m)
+  if (start === -1) return ''
+
+  const rest = markdown.slice(start)
+  const next = rest.slice(3).search(/^## /m)
+  const block = next === -1 ? rest : rest.slice(0, next + 3)
+
+  const newline = block.indexOf('\n')
+  return newline === -1 ? '' : block.slice(newline + 1).trim()
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const markdown = fs.existsSync(CHANGELOG) ? fs.readFileSync(CHANGELOG, 'utf8') : ''
+  process.stdout.write(getLatestSection(markdown))
+}

--- a/internals/changelog/latest.test.ts
+++ b/internals/changelog/latest.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import { getLatestSection } from './latest.mjs'
+
+const changelog = `# Changelog
+
+## v5.0.0-beta.35 — May 30, 2026
+
+### @kubb/core
+
+#### Bug Fixes
+
+- Tighten internal type safety.
+
+### Contributors
+
+[@stijnvanhulle](https://github.com/stijnvanhulle)
+
+## v5.0.0-beta.34 — May 29, 2026
+
+### @kubb/ast
+
+#### Features
+
+- Export the type guards.
+`
+
+describe('getLatestSection', () => {
+  it('returns the most recent block without its version heading', () => {
+    expect(getLatestSection(changelog)).toBe(
+      `### @kubb/core
+
+#### Bug Fixes
+
+- Tighten internal type safety.
+
+### Contributors
+
+[@stijnvanhulle](https://github.com/stijnvanhulle)`,
+    )
+  })
+
+  it('returns an empty string when there is no version block', () => {
+    expect(getLatestSection('# Changelog\n')).toBe('')
+  })
+})


### PR DESCRIPTION
## Why

The root `CHANGELOG.md` is already consolidated into a single aggregated entry per version (via `internals/changelog/index.mjs`), but GitHub Releases were not — `changesets/action` created **one release per package** (~24 per version), each with a thin `Updated dependencies […]` body. This makes the two surfaces inconsistent.

## What

Make GitHub Releases match the changelog: **one release per version**.

- Set `createGithubReleases: false` on the `changesets/action` step so it still stages/publishes and pushes the git tags, but no longer creates the per-package releases.
- Add a `Create GitHub release` step (only when `staged == 'true'`) that:
  - reads the canonical version from the fixed-group `kubb` package,
  - reuses the already-pushed `kubb@<version>` tag (`--verify-tag`),
  - uses the latest `CHANGELOG.md` section as the release body,
  - titles the release `v<version>` and flags prereleases (versions containing `-`).
- Add `internals/changelog/latest.mjs` to extract the most recent changelog section (heading stripped, since the title already carries the version), with a colocated test.

## Notes

- Scoped to the **kubb** repo only, as requested. The `plugins` repo is unchanged.
- `gh` is preinstalled on GitHub-hosted runners; the job already has `contents: write`.
- The fixed group (`["@kubb/*", "kubb", "unplugin-kubb"]`) guarantees `kubb` is always versioned and tagged, so the umbrella tag always exists.

https://claude.ai/code/session_017AJnkxC2zDyrjvgJcSSXkU

---
_Generated by [Claude Code](https://claude.ai/code/session_017AJnkxC2zDyrjvgJcSSXkU)_