### PR TITLE
chore: continue release:stage on failure with turbo --continue

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint:spell": "cspell \"**/*.{ts,md}\" --config ./cspell.json --no-progress",
     "release": "changeset publish",
     "release:canary": "changeset publish --no-git-tag",
-    "release:stage": "turbo run release:stage --filter=./packages/* --concurrency=1 --",
+    "release:stage": "turbo run release:stage --filter=./packages/* --continue --concurrency=1 --",
     "release:stage:ci": "pnpm release:stage && pnpm exec changeset tag && echo \"staged=true\" >> \"${GITHUB_OUTPUT:-/dev/null}\"",
     "start": "turbo run start --filter=./packages/*",
     "test": "vitest run --config ./configs/vitest.config.ts",


### PR DESCRIPTION
## Summary

The `release:stage` script stops as soon as one package fails to publish, leaving the remaining packages unstaged.

This adds turbo's `--continue` flag so the release stage runs through every package even if one fails, matching the behavior already used by `typecheck`.

## Change

```diff
- "release:stage": "turbo run release:stage --filter=./packages/* --concurrency=1 --",
+ "release:stage": "turbo run release:stage --filter=./packages/* --continue --concurrency=1 --",
```

https://claude.ai/code/session_01P7JfZwRUDKrAZAv5XQVnY9

---
_Generated by [Claude Code](https://claude.ai/code/session_01P7JfZwRUDKrAZAv5XQVnY9)_