### PR TITLE
ci: publish a canary on every main commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,3 +73,19 @@ jobs:
       notify: true
     secrets:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+
+  canary:
+    name: Canary
+    needs: [release]
+    if: ${{ github.repository_owner == 'kubb-labs' && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.release.outputs.released != 'true' }}
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
+    uses: kubb-labs/config/.github/workflows/release.yml@main
+    with:
+      mode: canary
+      owner: 'kubb-labs'
+      publish: 'pnpm release'
+      stage: 'pnpm release:stage:ci'
+      build: 'pnpm run build'


### PR DESCRIPTION
## Summary

Restores "canary on every main commit" using the shared reusable release workflow.

A new `canary` job runs after `release` on push to `main` and publishes a `-canary.<timestamp>` build under the `canary` dist-tag **whenever the release published or staged nothing** (`needs.release.outputs.released != 'true'`). This mirrors the previous fallback behaviour (the old `if: steps.changesets.outputs.published != 'true'` canary step), now delegated to `kubb-labs/config`'s reusable workflow in `mode: canary`:

- Version stamping uses the shared `canary.sh` (timestamp path — required because this repo is in Changesets pre-mode, where `changeset version --snapshot` is rejected).
- Publishing reuses the repo's normal `publish` command with `-- --tag canary`, so `latest`/`beta` are never touched.

## Dependency

⚠️ Requires **kubb-labs/config#15** to merge first — it adds the `canary` mode and the `released` workflow output to `release.yml@main` that this job relies on.

https://claude.ai/code/session_014GnjNfRj9w7jBo8DyrCbFe

---
_Generated by [Claude Code](https://claude.ai/code/session_014GnjNfRj9w7jBo8DyrCbFe)_