### PR TITLE
ci: fix invalid release workflow — grant canary job required permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,9 +80,11 @@ jobs:
     needs: [release]
     if: ${{ github.repository_owner == 'kubb-labs' && github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.release.outputs.released != 'true' }}
     permissions:
-      contents: read
+      contents: write
       id-token: write
       packages: write
+      pull-requests: write
+      issues: write
     uses: kubb-labs/config/.github/workflows/release.yml@8317759d6fc145d791f4ceb971e68b05b1c9aa88 # main
     with:
       mode: canary


### PR DESCRIPTION
## Problem

The release workflow is invalid on `main`:

```
Error calling workflow 'kubb-labs/config/.github/workflows/release.yml@8317759…'.
The nested job 'release' is requesting 'contents: write, issues: write, pull-requests: write',
but is only allowed 'contents: read, issues: none, pull-requests: none'.
```

The `canary` job calls the shared reusable workflow with `mode: canary`. GitHub validates the caller's `permissions` against **every** job defined in the reusable workflow — including its internal `release` job (which is skipped at runtime for `mode: canary`, but still validated at parse time). That internal job declares `contents/pull-requests/issues: write`, while the `canary` job only granted `contents: read`.

## Fix

Grant the `canary` job the same full permission set as the `release` job:

```yaml
permissions:
  contents: write
  id-token: write
  packages: write
  pull-requests: write
  issues: write
```

---
_Generated by [Claude Code](https://claude.ai/code/session_011K8ukHFF16GLqvmfLoia8b)_