### PR TITLE
ci: drop --tag beta from changeset publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           MODE: ${{ inputs.mode || 'publish' }}
         run: |
           case "$MODE" in
-            publish) echo "publish=pnpm exec changeset publish --tag beta" >> "$GITHUB_OUTPUT" ;;
+            publish) echo "publish=pnpm exec changeset publish" >> "$GITHUB_OUTPUT" ;;
             staged) echo "publish=pnpm release:stage:ci" >> "$GITHUB_OUTPUT" ;;
             version) echo "publish=" >> "$GITHUB_OUTPUT" ;;
             *) echo "Unknown mode: $MODE" >&2; exit 1 ;;


### PR DESCRIPTION
## Summary

The release workflow was failing with:

```
🦋  error Releasing under custom tag is not allowed in pre mode
```

When releasing under a pre mode (e.g. `beta`), Changesets disallows passing a custom `--tag` because pre mode already handles dist-tag selection. Drop `--tag beta` from the `publish` mode command so the workflow can succeed during pre releases.

## Test plan

- [ ] Re-run the Release workflow in `publish` mode on the `beta` branch and confirm publish completes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WMXzR8gGfFs2iHgvtU6DYH)_