### PR TITLE
docs: research report for core package improvements

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -135,6 +135,17 @@
     "serialised",
     "Visualisation",
     "deserialise",
-    "materialisation"
+    "materialisation",
+    "mypy",
+    "Turbopack",
+    "pytest",
+    "pluggy",
+    "miette",
+    "codespan",
+    "goroutines",
+    "hookwrapper",
+    "tryfirst",
+    "trylast",
+    "firstresult"
   ]
 }

--- a/plans/core-improvements/architecture-review.md
+++ b/plans/core-improvements/architecture-review.md
@@ -1,0 +1,164 @@
+# Research, architecture review against established projects
+
+> A second research note for PR #3444. The first report (`research.md`) stays inside the current
+> design and cleans it up. This one steps back and asks what Kubb's core could borrow from larger
+> code-processing projects: TypeScript, Vite, Vue, esbuild, oxc/oxlint, TanStack Query, and the
+> plugin and tooling ideas from Rust and Python. Each section names what the reference does, what
+> Kubb does today with a file reference, the change worth making, and the tradeoff. Nothing here is
+> committed work, and the bigger items are flagged as such.
+
+## How Kubb maps to these projects today
+
+Kubb is already shaped like the good examples in this space. It splits a framework-agnostic core
+from adapters and renderers the way TanStack keeps `query-core` separate from `react-query`. It
+streams schemas and operations as async iterables instead of buffering, which is the pull model
+esbuild and Rollup favour. It orders plugins with `enforce` like Vite, and it cleans up resources
+with `using` and `dispose`. So the gaps below are about maturity in four areas the big projects
+have invested in heavily: incremental work, a typed plugin protocol, a real diagnostics model, and
+CPU parallelism.
+
+| Borrow from | Idea | Kubb gap |
+| --- | --- | --- |
+| tsc, Vite, mypy, Turbopack | Incremental build cache and a dependency graph | Watch mode re-runs the whole build |
+| Rollup, Vite, pytest pluggy | Typed hook protocol with declared hook kinds | String-keyed event emitter with erased argument types |
+| Vue compiler, Babel, SWC | Explicit parse, transform, generate phases | Transform logic lives inside the driver loop |
+| tsc, Rust ariadne, oxc miette | Structured diagnostics with codes and source spans | `throw new Error('[kubb] ...')` |
+| esbuild, oxc, SWC | Parallelism across CPU cores | Single event loop, concurrency 8 |
+| oxc atoms and arena, V8 | String interning and flatter AST | A node allocated per schema and operation |
+
+## Incremental generation and a real dependency graph
+
+TypeScript writes a `.tsbuildinfo` so a rebuild only touches what changed. Vite caches pre-bundled
+dependencies under `node_modules/.vite` and keys them by a hash of lockfile and config. mypy and
+Turbopack do the same with content hashes. The shared idea is to remember what produced what, then
+skip inputs whose hash has not moved.
+
+Kubb regenerates everything on every run. Watch mode calls the full `generate()` on any file change
+(`packages/cli/src/runners/generate/run.ts:288-300`), and the `createHash` already in the CLI is
+only used to dedupe post-generate hook commands, not to skip unchanged output. On a large spec in a
+dev loop this is the single biggest cost.
+
+The change is a build manifest that maps a hash of each operation or schema, plus the resolved
+plugin options and the Kubb version, to the output paths it produced. On the next run, inputs whose
+hash is unchanged skip their generators, and the manifest tells the cleaner which stale files to
+remove. This pairs with the pre-scan finding from `research.md` (P1): instead of draining all
+schemas into memory to compute reachability, build an explicit graph of schema to dependent
+operation to output file once, then reuse it for both pruning and incremental skips. This is the
+largest item here and deserves its own spec before any code, because cache invalidation is where
+these systems get subtle.
+
+## A typed hook protocol
+
+Rollup and Vite give plugins a typed context object and a fixed set of hooks with declared kinds:
+some run in sequence, some in parallel, and some stop at the first non-null result. pytest's pluggy
+goes further with hook specifications and implementations marked `tryfirst`, `trylast`, and
+`hookwrapper`, plus `firstresult` hooks. The point is that the hook surface is a typed contract,
+not a bag of events.
+
+Kubb runs on a raw `AsyncEventEmitter` with string-keyed event names, and the listener type is
+erased to `(...args: Array<never>)` at every registration site
+(`packages/core/src/KubbDriver.ts:318`, `:329`, `:340`). That works, but a plugin author gets no
+type help about what a hook receives or returns, and the two listener-tracking structures noted in
+`research.md` (C1) exist because the emitter has no model of hook kinds.
+
+The change is a small typed hook registry that declares each hook's argument and return types and
+its kind: sequential, parallel, or first-result. Ordering still comes from `enforce`, which Kubb
+already has. This removes the `Array<never>` casts, makes the generate hooks discoverable in an
+editor, and gives middleware a defined place in the order rather than relying on registration
+sequence. It is mostly an internal change behind the same public `definePlugin` surface.
+
+## Parse, transform, generate as explicit phases
+
+Vue's compiler is three named stages: `baseParse` produces an AST, `transform` runs an ordered list
+of node transforms and directive transforms, and `generate` prints code. Babel and SWC use the same
+visitor-over-phases shape. Keeping the stages separate is what lets each be tested and extended on
+its own.
+
+In Kubb the transform step is folded into the driver. `#runGenerators` applies the per-plugin
+transformer inline while it walks and dispatches nodes
+(`packages/core/src/KubbDriver.ts:577` onward), so orchestration and transformation are tangled in
+the same method. A plugin author reasoning about how to rewrite a node before generation has to
+read the driver to find out.
+
+The change is to lift transform into a first-class stage: an ordered pipeline of node transforms
+that runs between the adapter's AST and the generators, registered the way Vue registers node
+transforms. The driver then orchestrates three clear phases instead of one large loop, which also
+shrinks the `#runGenerators` hot path from `research.md` (C1).
+
+## A diagnostics model instead of thrown errors
+
+TypeScript reports problems as structured diagnostics: a stable code, a category, a message, a
+source span, and related information. Rust's compiler and libraries like ariadne and codespan, and
+oxc through miette, render those spans as annotated source frames. The value is that a failure
+points at the exact place in the input and can be collected rather than thrown on the first
+problem.
+
+Kubb throws generic errors with a `[kubb]` prefix and wraps plugin failures in `BuildError` from
+`@internals/utils`, with no code, no category, and no pointer back into the OpenAPI document. This
+is the M3 item from `research.md`, and the reference projects show what the target looks like.
+
+The change is a `Diagnostic` type carrying a code, a severity, a message, and a source location
+expressed as a JSON pointer into the spec, collected into the build result and rendered by the CLI
+as an annotated frame. Generators and resolvers emit diagnostics instead of throwing, so one bad
+operation no longer has to abort the run and the user sees where the problem is.
+
+## Parallelism across cores, with honest limits
+
+esbuild owes much of its speed to Go goroutines processing files in parallel, and oxc and SWC use
+Rust threads through rayon. Kubb runs on a single event loop and gets concurrency from async
+batching at width 8 (`SCHEMA_PARALLEL` in `packages/core/src/constants.ts`). That overlaps IO well,
+but the JSX render and TypeScript print for each file are CPU-bound and still run on one thread.
+
+A `worker_threads` pool, through something like piscina, could shard rendering across cores for
+large specs. The honest caveat is that JavaScript is not Go or Rust here: passing nodes to workers
+costs serialization, so this only pays off past a size threshold and the single-threaded path should
+stay the default. Worth prototyping and measuring on a big spec before committing, not adopting on
+faith.
+
+## String interning and a flatter AST
+
+oxc interns identifiers as atoms and allocates AST nodes in an arena, which cuts both memory and the
+pointer chasing that hurts cache locality. V8 does its own string deduplication for similar reasons.
+Kubb allocates a node per schema and per operation, and repeated identifiers like schema names and
+`$ref` targets are fresh strings each time.
+
+Interning identifiers and sharing immutable nodes would lower memory and GC pressure on very large
+specs. In a JavaScript codebase the win is smaller than in Rust, so this ranks below the items
+above and is mainly worth it once the dependency graph from the incremental work already gives a
+natural place to hold interned names.
+
+## A versioned core protocol for external plugins
+
+TanStack keeps a small `query-core` that adapters target, and Vite's Environment API formalized the
+contract between core and its consumers. Kubb already splits core, adapters, renderers, and plugins
+cleanly, and the plugins live in their own monorepo. What is missing is a written, versioned
+description of the contract those external plugins target: the hook surface, the node shapes, and
+the resolver interface. Publishing that protocol as a documented and versioned surface lets plugin
+authors track breaking changes deliberately. This is low effort and high onboarding value, and it
+builds directly on the architecture document proposed in `research.md` (M1).
+
+## Suggested order
+
+Start with the diagnostics model and the typed hook protocol, since both are mostly internal, lift
+type safety and error quality immediately, and make the later work easier to reason about. Do the
+transform-phase extraction next, because it cleans up the same driver hot path the first report
+flagged. Treat incremental generation as its own spec with a measurement gate, since it is the
+highest payoff and the highest risk. Hold the worker pool and AST interning until a profile on a
+large spec shows they earn their complexity. The core-protocol document can run in parallel with any
+of these.
+
+## Open questions
+
+1. Is the dev-loop rebuild cost large enough on real specs to justify an incremental cache and the
+   invalidation complexity it brings, or is watch-mode full rebuild acceptable for now?
+2. Should the typed hook protocol replace `AsyncEventEmitter` outright, or wrap it so the public
+   surface and external plugins stay untouched?
+3. Where does the `Diagnostic` type live, core or `@internals/utils`, given the same question is
+   open for the error model in `research.md`?
+
+## Operating constraints
+
+The same limits from `research.md` apply: ESM only, Node 22, a stable public API through the
+`exports` map, the core size-limit, and a green suite. Anything that adds a worker pool or a cache
+must keep the current single-threaded, no-cache path working as the default so behavior does not
+change for existing users.

--- a/plans/core-improvements/architecture-review.md
+++ b/plans/core-improvements/architecture-review.md
@@ -17,16 +17,20 @@ with `using` and `dispose`. So the gaps below are about maturity in four areas t
 have invested in heavily: incremental work, a typed plugin protocol, a real diagnostics model, and
 CPU parallelism.
 
-| Borrow from | Idea | Kubb gap |
-| --- | --- | --- |
-| tsc, Vite, mypy, Turbopack | Incremental build cache and a dependency graph | Watch mode re-runs the whole build |
-| Rollup, Vite, pytest pluggy | Typed hook protocol with declared hook kinds | String-keyed event emitter with erased argument types |
-| Vue compiler, Babel, SWC | Explicit parse, transform, generate phases | Transform logic lives inside the driver loop |
-| tsc, Rust ariadne, oxc miette | Structured diagnostics with codes and source spans | `throw new Error('[kubb] ...')` |
-| esbuild, oxc, SWC | Parallelism across CPU cores | Single event loop, concurrency 8 |
-| oxc atoms and arena, V8 | String interning and flatter AST | A node allocated per schema and operation |
+Each row links to the section that explains it, with the same impact, effort, and risk shorthand
+as `research.md`. The Kubb gap each one closes is described in its section below.
 
-## Incremental generation and a real dependency graph
+| ID | Idea | Borrow from | Impact | Effort | Risk |
+| --- | --- | --- | --- | --- | --- |
+| A1 | Incremental build cache and a dependency graph | tsc, Vite, mypy, Turbopack | High | High | Medium |
+| A2 | Typed hook protocol with declared hook kinds | Rollup, Vite, pytest pluggy | High | Medium | Low |
+| A3 | Explicit parse, transform, generate phases | Vue, Babel, SWC | Medium | Medium | Low |
+| A4 | Structured diagnostics with codes and source spans | tsc, ariadne, codespan, miette | High | Medium | Low |
+| A5 | Parallel rendering across CPU cores | esbuild, oxc, SWC | Medium | High | Medium |
+| A6 | String interning and a flatter AST | oxc, V8 | Low | High | Medium |
+| A7 | A versioned core protocol for plugins | TanStack Query, Vite | Medium | Low | Low |
+
+## A1. Incremental generation and a real dependency graph
 
 TypeScript writes a `.tsbuildinfo` so a rebuild only touches what changed. Vite caches pre-bundled
 dependencies under `node_modules/.vite` and keys them by a hash of lockfile and config. mypy and
@@ -47,7 +51,7 @@ operation to output file once, then reuse it for both pruning and incremental sk
 largest item here and deserves its own spec before any code, because cache invalidation is where
 these systems get subtle.
 
-## A typed hook protocol
+## A2. A typed hook protocol
 
 Rollup and Vite give plugins a typed context object and a fixed set of hooks with declared kinds:
 some run in sequence, some in parallel, and some stop at the first non-null result. pytest's pluggy
@@ -67,7 +71,7 @@ already has. This removes the `Array<never>` casts, makes the generate hooks dis
 editor, and gives middleware a defined place in the order rather than relying on registration
 sequence. It is mostly an internal change behind the same public `definePlugin` surface.
 
-## Parse, transform, generate as explicit phases
+## A3. Parse, transform, generate as explicit phases
 
 Vue's compiler is three named stages: `baseParse` produces an AST, `transform` runs an ordered list
 of node transforms and directive transforms, and `generate` prints code. Babel and SWC use the same
@@ -85,7 +89,7 @@ that runs between the adapter's AST and the generators, registered the way Vue r
 transforms. The driver then orchestrates three clear phases instead of one large loop, which also
 shrinks the `#runGenerators` hot path from `research.md` (C1).
 
-## A diagnostics model instead of thrown errors
+## A4. A diagnostics model instead of thrown errors
 
 TypeScript reports problems as structured diagnostics: a stable code, a category, a message, a
 source span, and related information. Rust's compiler and libraries like ariadne and codespan, and
@@ -102,7 +106,7 @@ expressed as a JSON pointer into the spec, collected into the build result and r
 as an annotated frame. Generators and resolvers emit diagnostics instead of throwing, so one bad
 operation no longer has to abort the run and the user sees where the problem is.
 
-## Parallelism across cores, with honest limits
+## A5. Parallelism across cores, with honest limits
 
 esbuild owes much of its speed to Go goroutines processing files in parallel, and oxc and SWC use
 Rust threads through rayon. Kubb runs on a single event loop and gets concurrency from async
@@ -115,7 +119,7 @@ costs serialization, so this only pays off past a size threshold and the single-
 stay the default. Worth prototyping and measuring on a big spec before committing, not adopting on
 faith.
 
-## String interning and a flatter AST
+## A6. String interning and a flatter AST
 
 oxc interns identifiers as atoms and allocates AST nodes in an arena, which cuts both memory and the
 pointer chasing that hurts cache locality. V8 does its own string deduplication for similar reasons.
@@ -127,7 +131,7 @@ specs. In a JavaScript codebase the win is smaller than in Rust, so this ranks b
 above and is mainly worth it once the dependency graph from the incremental work already gives a
 natural place to hold interned names.
 
-## A versioned core protocol for external plugins
+## A7. A versioned core protocol for external plugins
 
 TanStack keeps a small `query-core` that adapters target, and Vite's Environment API formalized the
 contract between core and its consumers. Kubb already splits core, adapters, renderers, and plugins
@@ -139,13 +143,13 @@ builds directly on the architecture document proposed in `research.md` (M1).
 
 ## Suggested order
 
-Start with the diagnostics model and the typed hook protocol, since both are mostly internal, lift
+Start with diagnostics (A4) and the typed hook protocol (A2), since both are mostly internal, lift
 type safety and error quality immediately, and make the later work easier to reason about. Do the
-transform-phase extraction next, because it cleans up the same driver hot path the first report
-flagged. Treat incremental generation as its own spec with a measurement gate, since it is the
-highest payoff and the highest risk. Hold the worker pool and AST interning until a profile on a
-large spec shows they earn their complexity. The core-protocol document can run in parallel with any
-of these.
+transform-phase extraction (A3) next, because it cleans up the same driver hot path the first report
+flagged. Treat incremental generation (A1) as its own spec with a measurement gate, since it is the
+highest payoff and the highest risk. Hold the worker pool (A5) and AST interning (A6) until a
+profile on a large spec shows they earn their complexity. The core-protocol document (A7) can run in
+parallel with any of these.
 
 ## Open questions
 
@@ -162,3 +166,47 @@ The same limits from `research.md` apply: ESM only, Node 22, a stable public API
 `exports` map, the core size-limit, and a green suite. Anything that adds a worker pool or a cache
 must keep the current single-threaded, no-cache path working as the default so behavior does not
 change for existing users.
+
+## Libraries and projects referenced
+
+Every external project named across both reports, with the idea Kubb would borrow and the items it
+informs.
+
+| Project | Borrowed idea | Items |
+| --- | --- | --- |
+| TypeScript (tsc) | Incremental `.tsbuildinfo` rebuilds, structured diagnostics | A1, A4 |
+| Vite | Pre-bundle cache keyed by hash, `enforce` ordering, Environment API, `defineConfig` | A1, A2, A7 |
+| Rollup | Typed plugin context and a fixed hook surface | A2 |
+| Vue compiler | The parse, transform, generate phase split and ordered node transforms | A3 |
+| Babel | Visitor-over-phases and the preset and plugin model | A3 |
+| SWC | Rust visitors and rayon parallelism | A3, A5 |
+| esbuild | Go goroutine parallelism and the pull-based model | A5 |
+| oxc and oxlint | Interned atoms, arena allocation, and miette diagnostics | A4, A6 |
+| TanStack Query | A framework-agnostic `query-core` with thin adapters | A7 |
+| pytest and pluggy | Hook specs with `tryfirst`, `trylast`, `hookwrapper`, and `firstresult` | A2 |
+| mypy | An incremental type-check cache | A1 |
+| Turbopack | Content-hash caching | A1 |
+
+Supporting libraries and runtimes named for the proposed changes.
+
+| Library or runtime | Role in the proposals |
+| --- | --- |
+| Rust ariadne | Annotated diagnostic frames (A4) |
+| Rust codespan | Diagnostic source spans (A4) |
+| miette | Diagnostic rendering used by oxc (A4) |
+| rayon | Data parallelism in the Rust tools (A5) |
+| Go goroutines | The parallelism model behind esbuild (A5) |
+| V8 | Runtime string deduplication (A6) |
+| Node `worker_threads` | The thread-pool primitive (A5) |
+| piscina | A worker pool built on `worker_threads` (A5) |
+| `node:crypto` `createHash` | Hashing for the build manifest (A1), already used in the CLI |
+
+Kubb packages and tooling these proposals touch.
+
+| Kubb package or tool | Where it appears |
+| --- | --- |
+| `@kubb/core`, `@kubb/ast`, `@kubb/cli`, `@kubb/kubb` | The core packages under review |
+| `@internals/utils` | `BuildError`, `AsyncEventEmitter`, `URLPath` (A2, A4, and M3, M5 in `research.md`) |
+| `@kubb/renderer-jsx` | The JSX renderer behind the CPU-bound printing (A5) |
+| chokidar | The CLI file watcher behind watch mode (A1) |
+| `size-limit` | The bundle budget on `@kubb/core` (M6 in `research.md`) |

--- a/plans/core-improvements/research.md
+++ b/plans/core-improvements/research.md
@@ -1,0 +1,144 @@
+# Research, core package improvements
+
+> Phase 1 research for reducing complexity, improving performance, and lowering the cost of
+> onboarding new maintainers in the Kubb core packages (`@kubb/core` and its close neighbours
+> `@kubb/ast`, `@kubb/cli`, `@kubb/kubb`). This is a research report, not a committed plan. Every
+> finding points at the code it describes so a maintainer can jump straight to it.
+
+## Current state
+
+The core is in good shape. There is no `any` or `as any` in `@kubb/core`, no `@ts-ignore`, and
+the few non-null assertions are guarded and commented. Caching already exists where it pays off:
+compiled filter patterns (`defineResolver.ts:253`), resolved options behind a two-level WeakMap,
+and the sorted file view that rebuilds only after a write (`FileManager.ts:129`). The pipeline is
+streaming-first, walking schemas and operations as async iterables rather than buffering them, and
+the public surface in `packages/core/src/index.ts` is small and cohesive.
+
+So the work below is polish, not repair. Three files carry most of the weight and most of the
+cognitive load: `createKubb.ts` (1135 lines), `KubbDriver.ts` (933 lines), and `defineResolver.ts`
+(719 lines). The recommendations group into complexity, performance, and maintainer onboarding,
+then close with a suggested order.
+
+## Complexity
+
+C1. Break up `KubbDriver.ts`. It owns plugin normalisation, hook registration, the generator
+pipeline, and file flushing in one class. The generator pipeline alone (`#runGenerators`, roughly
+`KubbDriver.ts:504-700`) holds the schema pre-scan, the per-node `dispatchNode` closure
+(`KubbDriver.ts:577`), and `flushPending` (`KubbDriver.ts:385`). Pulling these into their own
+modules turns one 933 line file into a thin orchestrator over named units that can be read and
+tested on their own. The class also tracks listeners in two places, a hook map and a middleware
+array. Folding them into one registry with a single dispose path removes a class of listener-leak
+bugs on rebuild.
+
+C2. Split `createKubb.ts`. Around 600 of its lines are the `Config`, `UserConfig`, `Output`, and
+`Group` type definitions. Moving those into a `config.ts` leaves the `Kubb` lifecycle class and
+the factory in a file you can read in one screen. While doing this, write down the lifecycle
+contract: several getters throw when read before `setup()` runs, and that ordering is currently
+something a reader has to reconstruct from the throw sites.
+
+C3. Split `defineResolver.ts` by concern. Pattern matching, option resolution, path resolution
+with its traversal guard, and banner and footer rendering are four separate jobs sharing one file.
+Separate files make each testable in isolation and shrink the surface a path-resolution change has
+to reason about.
+
+C4. Collapse the three generator registration blocks. `registerGenerator`
+(`KubbDriver.ts:304-344`) repeats the same shape for `schema`, `operation`, and `operations`:
+guard on plugin name, run the method, apply the hook result, register and track the listener. A
+small table over the three method names removes the repetition and makes adding a fourth hook a
+one-line change.
+
+C5. Merge the two pattern matchers. `matchesOperationPattern` and `matchesSchemaPattern`
+(`defineResolver.ts:271` and `defineResolver.ts:285`) are the same idea split by node type. One
+matcher that dispatches on type reads better and keeps the filter-type list in a single place.
+
+## Performance
+
+P1. The schema pre-scan trades memory for correctness, and that trade is worth measuring. When a
+plugin filters by operation without naming schemas, `#runGenerators` drains the whole schema
+iterable into an array to compute reachable names (`KubbDriver.ts:552-569`). The code already
+knows this is a cost and releases the array as soon as the pre-scan returns, but on a large spec
+the peak is real. This is the one item worth profiling on a big OpenAPI document before deciding
+whether a two-pass or lazy-reachability design earns its complexity. Treat it as an investigation
+with a measurement gate, not a change to make blind.
+
+P2. `memoryStorage.getKeys(base)` materialises every key before filtering
+(`storages/memoryStorage.ts:39-42`). Iterating the map and yielding matches avoids the full copy.
+The win is small but the change is a few lines and removes an allocation from a hot path in
+dry-run and test scenarios.
+
+P3. The plugin dependency sort calls `.includes()` on each comparison
+(`KubbDriver.ts:114-119`), which is quadratic in the dependency lists. Building a set per plugin
+first makes it linear. Real configs rarely have enough plugins for this to matter, so this is a
+tidy-up rather than a fix.
+
+P4. Transformers run per node with no shared memoisation (`KubbDriver.ts:577` onward, applied in
+both the schema and operation passes). Today plugin authors own any caching. Worth noting as a
+known property rather than prescribing a core change, since a core-level cache would need a clear
+invalidation story.
+
+P5. `stringPatternCache` is a module-level map (`defineResolver.ts:253`) that lives for the
+process, not the build. In a long-running host that runs many builds with varied filter patterns
+it grows without bound. A per-build cache or a bounded LRU keeps the behaviour while capping the
+footprint. The WeakMap option cache and the lazy sorted-files cache do not have this problem and
+should stay as they are.
+
+## New-maintainer usability
+
+M1. Add an architecture document for `@kubb/core`. A new maintainer currently reconstructs the
+mental model from a 933 line driver. One page covering the plugin lifecycle (setup, register,
+generate, end), the hook event model and why middleware listeners fire after plugin listeners, the
+file flow from `FileManager` merge and dedupe through `FileProcessor` streaming to `Storage`, and
+the partial-failure model (the `failedPlugins` set and the `kubb:error` hook) saves every future
+reader that reconstruction.
+
+M2. Close the core test gaps. `createAdapter`, `defineGenerator`, `defineParser`, and
+`defineLogger` ship without tests, and every plugin depends on the first two. These are small
+factories, so the tests are cheap to write and they pin down the contracts plugin authors rely on.
+
+M3. Give errors a shape. Validation paths throw a generic `Error`, while plugin failures use
+`BuildError` from `@internals/utils`. There is no shared Kubb error type or code, so the CLI
+cannot categorise what it shows. A small hierarchy or a set of codes, plus a note on which errors
+are recoverable, lets the CLI surface clearer messages and lets programmatic callers branch on
+cause.
+
+M4. Documentation tidy-ups. `index.ts`, `constants.ts`, and `mocks.ts` lack the module JSDoc the
+rest of the package has. Two TODOs in `definePlugin.ts` are still open: a `ByMethod` filter
+alternative (`definePlugin.ts:115`) and an options type that should drop `override`
+(`definePlugin.ts:197`). Resolving or removing them stops them reading as unfinished work.
+
+M5. Document the `@internals/utils` boundary. `BuildError`, `AsyncEventEmitter`, and `URLPath` are
+re-exported from there through `index.ts`, but why they live outside core is not written down. A
+short note on what that package is for and what its contract is removes the puzzle.
+
+M6. Extend `size-limit` beyond core. Only `@kubb/core` runs the 510 KiB gzip check today.
+Applying the same guard to the other core packages catches bloat in the packages that grow fastest.
+
+## Suggested order
+
+Take the low-risk wins first, since they need no design and are covered by existing or trivial
+tests: C4, C5, P2, P3, and M4. Then invest in the documentation and tests that lower onboarding
+cost: M1, M2, M3, M5, and M6. Do the structural splits next, behind the same public exports so
+nothing downstream moves: C2, C3, then C1. Hold P1 until it has been measured on a large spec,
+because its design depends on what the profile shows.
+
+## Open questions
+
+1. Is the pre-scan memory peak (P1) large enough on real specs to justify a redesign, or is the
+   current release-immediately approach already acceptable? Needs a profile before deciding.
+2. During the file splits (C1 to C3), must every currently exported internal stay importable at
+   its current path, or is the only stability guarantee the `@kubb/core` package entry?
+3. Should the error model (M3) live in `@kubb/core` or in `@internals/utils` next to `BuildError`?
+
+## Operating constraints
+
+- ESM only, Node 22, and the public API stays stable through the `exports` map and `typesVersions`.
+- `@kubb/core` must stay under the 510 KiB gzip `size-limit`.
+- The test suite stays green, and any file move is followed by `pnpm lint && pnpm typecheck`.
+- No behaviour change is in scope for this report. It records findings, it does not touch source.
+
+## What this means for a follow-up plan
+
+Each lettered item above maps to one slice. The low-risk group can ship as a single small PR. The
+documentation and test group is independent and can run in parallel. The splits should land one
+file at a time with the suite green between them. P1 gets a measurement slice of its own before any
+code, and its result decides whether a redesign slice follows.

--- a/plans/core-improvements/research.md
+++ b/plans/core-improvements/research.md
@@ -19,6 +19,34 @@ cognitive load: `createKubb.ts` (1135 lines), `KubbDriver.ts` (933 lines), and `
 (719 lines). The recommendations group into complexity, performance, and maintainer onboarding,
 then close with a suggested order.
 
+## At a glance
+
+Each row links to the section that explains it. Impact, effort, and risk are rough calls to help
+sequence the work, not estimates.
+
+| ID | Change | Impact | Effort | Risk | Key file |
+| --- | --- | --- | --- | --- | --- |
+| C1 | Split the driver and unify listener tracking | High | High | Medium | `KubbDriver.ts` |
+| C2 | Move the config types out of `createKubb.ts` | Medium | Medium | Low | `createKubb.ts` |
+| C3 | Split the resolver by concern | Medium | Medium | Low | `defineResolver.ts` |
+| C4 | Collapse the three generator registrations | Low | Low | Low | `KubbDriver.ts:304` |
+| C5 | Merge the two pattern matchers | Low | Low | Low | `defineResolver.ts:271` |
+| P1 | Graph-based reachability for the pre-scan | High | High | Medium | `KubbDriver.ts:552` |
+| P2 | Early-exit `memoryStorage.getKeys` | Low | Low | Low | `memoryStorage.ts:39` |
+| P3 | Set-based plugin dependency sort | Low | Low | Low | `KubbDriver.ts:114` |
+| P4 | Record the transformer memoization tradeoff | Low | Medium | Medium | `KubbDriver.ts:577` |
+| P5 | Bound the pattern cache per build | Low | Low | Low | `defineResolver.ts:253` |
+| M1 | Write the core architecture doc | High | Low | Low | new doc |
+| M2 | Test the factory helpers | Medium | Low | Low | `createAdapter.ts` |
+| M3 | Give errors a shared shape | High | Medium | Low | new type |
+| M4 | Add JSDoc and resolve the two open TODOs | Low | Low | Low | `definePlugin.ts:115` |
+| M5 | Document the `@internals/utils` boundary | Low | Low | Low | `index.ts` |
+| M6 | Extend `size-limit` to more packages | Low | Low | Low | `package.json` |
+
+The fastest path to value is the high-impact, low-effort row group: M1, M3, and the small
+complexity and performance cleanups. The structural splits and the pre-scan rework are where the
+effort and risk concentrate.
+
 ## Complexity
 
 C1. Break up `KubbDriver.ts`. It owns plugin normalization, hook registration, the generator

--- a/plans/core-improvements/research.md
+++ b/plans/core-improvements/research.md
@@ -1,7 +1,7 @@
 # Research, core package improvements
 
 > Phase 1 research for reducing complexity, improving performance, and lowering the cost of
-> onboarding new maintainers in the Kubb core packages (`@kubb/core` and its close neighbours
+> onboarding new maintainers in the Kubb core packages (`@kubb/core` and its close neighbors
 > `@kubb/ast`, `@kubb/cli`, `@kubb/kubb`). This is a research report, not a committed plan. Every
 > finding points at the code it describes so a maintainer can jump straight to it.
 
@@ -21,7 +21,7 @@ then close with a suggested order.
 
 ## Complexity
 
-C1. Break up `KubbDriver.ts`. It owns plugin normalisation, hook registration, the generator
+C1. Break up `KubbDriver.ts`. It owns plugin normalization, hook registration, the generator
 pipeline, and file flushing in one class. The generator pipeline alone (`#runGenerators`, roughly
 `KubbDriver.ts:504-700`) holds the schema pre-scan, the per-node `dispatchNode` closure
 (`KubbDriver.ts:577`), and `flushPending` (`KubbDriver.ts:385`). Pulling these into their own
@@ -61,7 +61,7 @@ the peak is real. This is the one item worth profiling on a big OpenAPI document
 whether a two-pass or lazy-reachability design earns its complexity. Treat it as an investigation
 with a measurement gate, not a change to make blind.
 
-P2. `memoryStorage.getKeys(base)` materialises every key before filtering
+P2. `memoryStorage.getKeys(base)` materializes every key before filtering
 (`storages/memoryStorage.ts:39-42`). Iterating the map and yielding matches avoids the full copy.
 The win is small but the change is a few lines and removes an allocation from a hot path in
 dry-run and test scenarios.
@@ -78,7 +78,7 @@ invalidation story.
 
 P5. `stringPatternCache` is a module-level map (`defineResolver.ts:253`) that lives for the
 process, not the build. In a long-running host that runs many builds with varied filter patterns
-it grows without bound. A per-build cache or a bounded LRU keeps the behaviour while capping the
+it grows without bound. A per-build cache or a bounded LRU keeps the behavior while capping the
 footprint. The WeakMap option cache and the lazy sorted-files cache do not have this problem and
 should stay as they are.
 
@@ -97,7 +97,7 @@ factories, so the tests are cheap to write and they pin down the contracts plugi
 
 M3. Give errors a shape. Validation paths throw a generic `Error`, while plugin failures use
 `BuildError` from `@internals/utils`. There is no shared Kubb error type or code, so the CLI
-cannot categorise what it shows. A small hierarchy or a set of codes, plus a note on which errors
+cannot categorize what it shows. A small hierarchy or a set of codes, plus a note on which errors
 are recoverable, lets the CLI surface clearer messages and lets programmatic callers branch on
 cause.
 
@@ -134,7 +134,7 @@ because its design depends on what the profile shows.
 - ESM only, Node 22, and the public API stays stable through the `exports` map and `typesVersions`.
 - `@kubb/core` must stay under the 510 KiB gzip `size-limit`.
 - The test suite stays green, and any file move is followed by `pnpm lint && pnpm typecheck`.
-- No behaviour change is in scope for this report. It records findings, it does not touch source.
+- No behavior change is in scope for this report. It records findings, it does not touch source.
 
 ## What this means for a follow-up plan
 


### PR DESCRIPTION
## What

Adds a research report at `plans/core-improvements/research.md` covering improvements for the Kubb core packages (`@kubb/core` and its neighbours `@kubb/ast`, `@kubb/cli`, `@kubb/kubb`), prioritized across three axes: reducing complexity, improving performance, and lowering the cost of onboarding new maintainers.

This is a report only. No source files change.

## Why

The core is already well engineered (no `any`/`as any`, no `@ts-ignore`, sensible caching, streaming-first design). The opportunities are polish and onboarding rather than fixing breakage. The report records verified findings with file references so a maintainer can act on them, and ends with a suggested order and open questions.

## Highlights

Complexity: split the three oversized files (`createKubb.ts` 1135, `KubbDriver.ts` 933, `defineResolver.ts` 719), dedupe the three generator-registration blocks, and merge the two pattern matchers.

Performance: profile the schema pre-scan memory peak (`KubbDriver.ts:552-569`) before redesigning, plus small wins in `memoryStorage.getKeys`, the plugin dependency sort, and the unbounded module-level pattern cache.

Maintainer usability: add an `ARCHITECTURE.md` for core, close test gaps on `createAdapter`/`defineGenerator`/`defineParser`/`defineLogger`, give errors a shared shape, and tidy a few doc and TODO gaps.

Every finding points at the code it describes, and each lettered item maps to one follow-up slice.

https://claude.ai/code/session_01UPKoyeR4kCrxBGNVRT8Nwy

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPKoyeR4kCrxBGNVRT8Nwy)_