### PR TITLE
docs: replace package README badges with shieldcn.dev badge group

### DIFF
--- a/packages/adapter-oas/README.md
+++ b/packages/adapter-oas/README.md
@@ -88,13 +88,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/adapter-oas.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/adapter-oas.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/adapter-oas
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/adapter-oas.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/adapter-oas.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/adapter-oas
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/adapter-oas.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/adapter-oas.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/adapter-oas.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/adapter-oas.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/adapter-oas

--- a/packages/adapter-oas/README.md
+++ b/packages/adapter-oas/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/@kubb/adapter-oas" target="_blank">
-  <img alt="@kubb/adapter-oas badges" src="https://shieldcn.dev/group/npm/v/@kubb/adapter-oas+npm/dm/@kubb/adapter-oas+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="@kubb/adapter-oas badges" src="https://shieldcn.dev/group/npm/v/@kubb/adapter-oas+npm/dm/@kubb/adapter-oas+github/stars/kubb-labs/kubb+npm/l/@kubb/adapter-oas+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/adapter-oas/README.md
+++ b/packages/adapter-oas/README.md
@@ -94,7 +94,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmx.dev/package/@kubb/adapter-oas
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/adapter-oas.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/adapter-oas.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/adapter-oas.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/adapter-oas

--- a/packages/adapter-oas/README.md
+++ b/packages/adapter-oas/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/@kubb/adapter-oas" target="_blank">
+  <img alt="@kubb/adapter-oas badges" src="https://shieldcn.dev/group/npm/v/@kubb/adapter-oas+npm/dm/@kubb/adapter-oas+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -85,16 +83,3 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT)
-
-<!-- Badges -->
-
-[npm-version-src]: https://img.shields.io/npm/v/@kubb/adapter-oas?flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmjs.com/package/@kubb/adapter-oas
-[npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/adapter-oas?flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/@kubb/adapter-oas
-[license-src]: https://img.shields.io/github/license/kubb-labs/kubb.svg?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
-[coverage-href]: https://www.npmjs.com/package/@kubb/adapter-oas
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle/

--- a/packages/adapter-oas/README.md
+++ b/packages/adapter-oas/README.md
@@ -94,7 +94,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/adapter-oas
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/adapter-oas.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/adapter-oas.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/adapter-oas.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/adapter-oas.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/@kubb/adapter-oas

--- a/packages/adapter-oas/README.md
+++ b/packages/adapter-oas/README.md
@@ -88,13 +88,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/adapter-oas.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/adapter-oas.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/adapter-oas
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/adapter-oas.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/adapter-oas.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/adapter-oas
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/adapter-oas.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/adapter-oas.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/adapter-oas.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/adapter-oas.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/adapter-oas

--- a/packages/adapter-oas/README.md
+++ b/packages/adapter-oas/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -94,7 +94,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/adapter-oas
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/l/@kubb/adapter-oas.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/adapter-oas.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/@kubb/adapter-oas.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@kubb/adapter-oas

--- a/packages/adapter-oas/README.md
+++ b/packages/adapter-oas/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/@kubb/adapter-oas" target="_blank">
-  <img alt="@kubb/adapter-oas badges" src="https://shieldcn.dev/group/npm/v/@kubb/adapter-oas+npm/dm/@kubb/adapter-oas+github/stars/kubb-labs/kubb+npm/l/@kubb/adapter-oas+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -83,3 +85,16 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/adapter-oas.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@kubb/adapter-oas
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/adapter-oas.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@kubb/adapter-oas
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/l/@kubb/adapter-oas.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/packages/adapter-oas/README.md
+++ b/packages/adapter-oas/README.md
@@ -89,12 +89,12 @@ Kubb is an open source project, and its development is funded entirely by sponso
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@kubb/adapter-oas.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@kubb/adapter-oas
+[npm-version-href]: https://npmx.dev/package/@kubb/adapter-oas
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/adapter-oas.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@kubb/adapter-oas
+[npm-downloads-href]: https://npmx.dev/package/@kubb/adapter-oas
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/@kubb/adapter-oas.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/adapter-oas.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@kubb/adapter-oas
+[node-href]: https://npmx.dev/package/@kubb/adapter-oas

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -365,7 +365,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/agent
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/l/@kubb/agent.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/agent.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/@kubb/agent.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@kubb/agent

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -365,7 +365,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/agent
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/agent.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/agent.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/agent.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/agent.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/@kubb/agent

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/@kubb/agent" target="_blank">
-  <img alt="@kubb/agent badges" src="https://shieldcn.dev/group/npm/v/@kubb/agent+npm/dm/@kubb/agent+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="@kubb/agent badges" src="https://shieldcn.dev/group/npm/v/@kubb/agent+npm/dm/@kubb/agent+github/stars/kubb-labs/kubb+npm/l/@kubb/agent+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -365,7 +365,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmx.dev/package/@kubb/agent
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/agent.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/agent.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/agent.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/agent

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -360,12 +360,12 @@ Kubb is an open source project, and its development is funded entirely by sponso
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@kubb/agent.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@kubb/agent
+[npm-version-href]: https://npmx.dev/package/@kubb/agent
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/agent.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@kubb/agent
+[npm-downloads-href]: https://npmx.dev/package/@kubb/agent
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/@kubb/agent.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/agent.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@kubb/agent
+[node-href]: https://npmx.dev/package/@kubb/agent

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -359,13 +359,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/agent.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/agent.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/agent
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/agent.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/agent.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/agent
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/agent.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/agent.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/agent.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/agent.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/agent

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/@kubb/agent" target="_blank">
-  <img alt="@kubb/agent badges" src="https://shieldcn.dev/group/npm/v/@kubb/agent+npm/dm/@kubb/agent+github/stars/kubb-labs/kubb+npm/l/@kubb/agent+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -354,3 +356,16 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [AGPL-3.0-or-later](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-AGPL-3.0)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/agent.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@kubb/agent
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/agent.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@kubb/agent
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/l/@kubb/agent.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -359,13 +359,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/agent.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/agent.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/agent
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/agent.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/agent.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/agent
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/agent.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/agent.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/agent.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/agent.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/agent

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/@kubb/agent" target="_blank">
+  <img alt="@kubb/agent badges" src="https://shieldcn.dev/group/npm/v/@kubb/agent+npm/dm/@kubb/agent+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -356,16 +354,3 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [AGPL-3.0-or-later](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-AGPL-3.0)
-
-<!-- Badges -->
-
-[npm-version-src]: https://img.shields.io/npm/v/@kubb/agent?flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmjs.com/package/@kubb/agent
-[npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/agent?flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/@kubb/agent
-[license-src]: https://img.shields.io/github/license/kubb-labs/kubb.svg?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
-[coverage-href]: https://www.npmjs.com/package/@kubb/agent
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle/

--- a/packages/ast/README.md
+++ b/packages/ast/README.md
@@ -149,13 +149,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/ast.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/ast.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/ast
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/ast.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/ast.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/ast
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/ast.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/ast.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/ast.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/ast.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/ast

--- a/packages/ast/README.md
+++ b/packages/ast/README.md
@@ -150,12 +150,12 @@ Kubb is an open source project, and its development is funded entirely by sponso
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@kubb/ast.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@kubb/ast
+[npm-version-href]: https://npmx.dev/package/@kubb/ast
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/ast.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@kubb/ast
+[npm-downloads-href]: https://npmx.dev/package/@kubb/ast
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/@kubb/ast.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/ast.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@kubb/ast
+[node-href]: https://npmx.dev/package/@kubb/ast

--- a/packages/ast/README.md
+++ b/packages/ast/README.md
@@ -155,7 +155,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmx.dev/package/@kubb/ast
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/ast.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/ast.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/ast.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/ast

--- a/packages/ast/README.md
+++ b/packages/ast/README.md
@@ -149,13 +149,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/ast.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/ast.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/ast
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/ast.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/ast.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/ast
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/ast.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/ast.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/ast.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/ast.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/ast

--- a/packages/ast/README.md
+++ b/packages/ast/README.md
@@ -155,7 +155,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/ast
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/ast.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/ast.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/ast.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/ast.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/@kubb/ast

--- a/packages/ast/README.md
+++ b/packages/ast/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/@kubb/ast" target="_blank">
+  <img alt="@kubb/ast badges" src="https://shieldcn.dev/group/npm/v/@kubb/ast+npm/dm/@kubb/ast+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -146,16 +144,3 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT)
-
-<!-- Badges -->
-
-[npm-version-src]: https://img.shields.io/npm/v/@kubb/ast?flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmjs.com/package/@kubb/ast
-[npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/ast?flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/@kubb/ast
-[license-src]: https://img.shields.io/github/license/kubb-labs/kubb.svg?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
-[coverage-href]: https://www.npmjs.com/package/@kubb/ast
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle/

--- a/packages/ast/README.md
+++ b/packages/ast/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -155,7 +155,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/ast
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/l/@kubb/ast.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/ast.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/@kubb/ast.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@kubb/ast

--- a/packages/ast/README.md
+++ b/packages/ast/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/@kubb/ast" target="_blank">
-  <img alt="@kubb/ast badges" src="https://shieldcn.dev/group/npm/v/@kubb/ast+npm/dm/@kubb/ast+github/stars/kubb-labs/kubb+npm/l/@kubb/ast+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -144,3 +146,16 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/ast.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@kubb/ast
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/ast.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@kubb/ast
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/l/@kubb/ast.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/packages/ast/README.md
+++ b/packages/ast/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/@kubb/ast" target="_blank">
-  <img alt="@kubb/ast badges" src="https://shieldcn.dev/group/npm/v/@kubb/ast+npm/dm/@kubb/ast+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="@kubb/ast badges" src="https://shieldcn.dev/group/npm/v/@kubb/ast+npm/dm/@kubb/ast+github/stars/kubb-labs/kubb+npm/l/@kubb/ast+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -267,7 +267,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmx.dev/package/@kubb/cli
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/cli.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/cli.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/cli.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/cli

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/@kubb/cli" target="_blank">
-  <img alt="@kubb/cli badges" src="https://shieldcn.dev/group/npm/v/@kubb/cli+npm/dm/@kubb/cli+github/stars/kubb-labs/kubb+npm/l/@kubb/cli+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -256,3 +258,16 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/cli.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@kubb/cli
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/cli.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@kubb/cli
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/l/@kubb/cli.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -267,7 +267,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/cli
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/cli.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/cli.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/cli.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/cli.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/@kubb/cli

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -261,13 +261,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/cli.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/cli.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/cli
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/cli.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/cli.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/cli
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/cli.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/cli.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/cli.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/cli.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/cli

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -262,12 +262,12 @@ Kubb is an open source project, and its development is funded entirely by sponso
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@kubb/cli.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@kubb/cli
+[npm-version-href]: https://npmx.dev/package/@kubb/cli
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/cli.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@kubb/cli
+[npm-downloads-href]: https://npmx.dev/package/@kubb/cli
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/@kubb/cli.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/cli.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@kubb/cli
+[node-href]: https://npmx.dev/package/@kubb/cli

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/@kubb/cli" target="_blank">
+  <img alt="@kubb/cli badges" src="https://shieldcn.dev/group/npm/v/@kubb/cli+npm/dm/@kubb/cli+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -258,20 +256,3 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT)
-
-<!-- Badges -->
-
-[npm-version-src]: https://img.shields.io/npm/v/@kubb/cli?flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmjs.com/package/@kubb/cli
-[npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/cli?flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/@kubb/cli
-[license-src]: https://img.shields.io/github/license/kubb-labs/kubb.svg?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[build-src]: https://img.shields.io/github/actions/workflow/status/kubb-labs/kubb/ci.yaml?style=flat&colorA=18181B&colorB=f58517
-[build-href]: https://www.npmjs.com/package/@kubb/cli
-[minified-src]: https://img.shields.io/bundlephobia/min/@kubb/cli?style=flat&colorA=18181B&colorB=f58517
-[minified-href]: https://www.npmjs.com/package/@kubb/cli
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
-[coverage-href]: https://www.npmjs.com/package/@kubb/cli
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle/

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -267,7 +267,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/cli
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/l/@kubb/cli.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/cli.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/@kubb/cli.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@kubb/cli

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -261,13 +261,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/cli.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/cli.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/cli
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/cli.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/cli.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/cli
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/cli.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/cli.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/cli.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/cli.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/cli

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/@kubb/cli" target="_blank">
-  <img alt="@kubb/cli badges" src="https://shieldcn.dev/group/npm/v/@kubb/cli+npm/dm/@kubb/cli+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="@kubb/cli badges" src="https://shieldcn.dev/group/npm/v/@kubb/cli+npm/dm/@kubb/cli+github/stars/kubb-labs/kubb+npm/l/@kubb/cli+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/@kubb/core" target="_blank">
-  <img alt="@kubb/core badges" src="https://shieldcn.dev/group/npm/v/@kubb/core+npm/dm/@kubb/core+github/stars/kubb-labs/kubb+npm/l/@kubb/core+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -52,3 +54,16 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/core.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@kubb/core
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/core.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@kubb/core
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/l/@kubb/core.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -26,7 +26,7 @@
 
 Core engine for Kubb's plugin-based code generation system. Provides the plugin driver, file manager, `defineConfig`, `definePlugin`, `defineMiddleware`, and the build orchestration layer used by every Kubb plugin.
 
-> **Note:** Most users should install the [`kubb`](https://npmjs.com/package/kubb) meta-package instead of `@kubb/core` directly. Install `@kubb/core` only when building custom plugins or extending the Kubb internals.
+> **Note:** Most users should install the [`kubb`](https://npmx.dev/package/kubb) meta-package instead of `@kubb/core` directly. Install `@kubb/core` only when building custom plugins or extending the Kubb internals.
 
 ## Installation
 
@@ -58,12 +58,12 @@ Kubb is an open source project, and its development is funded entirely by sponso
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@kubb/core.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@kubb/core
+[npm-version-href]: https://npmx.dev/package/@kubb/core
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/core.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@kubb/core
+[npm-downloads-href]: https://npmx.dev/package/@kubb/core
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/@kubb/core.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/core.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@kubb/core
+[node-href]: https://npmx.dev/package/@kubb/core

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -57,13 +57,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/core.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/core.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/core
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/core.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/core.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/core
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/core.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/core.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/core.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/core.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/core

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/@kubb/core" target="_blank">
+  <img alt="@kubb/core badges" src="https://shieldcn.dev/group/npm/v/@kubb/core+npm/dm/@kubb/core+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -54,16 +52,3 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT)
-
-<!-- Badges -->
-
-[npm-version-src]: https://img.shields.io/npm/v/@kubb/core?flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmjs.com/package/@kubb/core
-[npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/core?flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/@kubb/core
-[license-src]: https://img.shields.io/npm/l/%40kubb%2Fcore?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
-[coverage-href]: https://www.npmjs.com/package/@kubb/core
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle/

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/@kubb/core" target="_blank">
-  <img alt="@kubb/core badges" src="https://shieldcn.dev/group/npm/v/@kubb/core+npm/dm/@kubb/core+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="@kubb/core badges" src="https://shieldcn.dev/group/npm/v/@kubb/core+npm/dm/@kubb/core+github/stars/kubb-labs/kubb+npm/l/@kubb/core+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -57,13 +57,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/core.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/core.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/core
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/core.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/core.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/core
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/core.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/core.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/core.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/core.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/core

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -63,7 +63,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/core
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/l/@kubb/core.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/core.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/@kubb/core.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@kubb/core

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -63,7 +63,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/core
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/core.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/core.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/core.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/core.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/@kubb/core

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -63,7 +63,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmx.dev/package/@kubb/core
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/core.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/core.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/core.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/core

--- a/packages/kubb/README.md
+++ b/packages/kubb/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/kubb" target="_blank">
-  <img alt="kubb badges" src="https://shieldcn.dev/group/npm/v/kubb+npm/dm/kubb+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="kubb badges" src="https://shieldcn.dev/group/npm/v/kubb+npm/dm/kubb+github/stars/kubb-labs/kubb+npm/l/kubb+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/kubb/README.md
+++ b/packages/kubb/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/kubb" target="_blank">
-  <img alt="kubb badges" src="https://shieldcn.dev/group/npm/v/kubb+npm/dm/kubb+github/stars/kubb-labs/kubb+npm/l/kubb+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -188,5 +190,15 @@ See [LICENSE](./LICENSE) for details.
 
 <!-- Badges -->
 
-[contributors-src]: https://img.shields.io/github/contributors/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517&label=%20
+[npm-version-src]: https://shieldcn.dev/npm/v/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/kubb
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/kubb
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/l/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[contributors-src]: https://shieldcn.dev/github/contributors/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [contributors-href]: #contributors-

--- a/packages/kubb/README.md
+++ b/packages/kubb/README.md
@@ -196,9 +196,9 @@ See [LICENSE](./LICENSE) for details.
 [npm-downloads-href]: https://npmjs.com/package/kubb
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/kubb.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/kubb.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/kubb
 [contributors-src]: https://shieldcn.dev/github/contributors/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [contributors-href]: #contributors-

--- a/packages/kubb/README.md
+++ b/packages/kubb/README.md
@@ -7,6 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
+[![Coverage][coverage-src]][coverage-href]
 [![Node][node-src]][node-href]
 
 <h4>
@@ -202,3 +203,5 @@ See [LICENSE](./LICENSE) for details.
 [node-href]: https://npmx.dev/package/kubb
 [contributors-src]: https://shieldcn.dev/github/contributors/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [contributors-href]: #contributors-
+[coverage-src]: https://shieldcn.dev/codecov/github/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[coverage-href]: https://app.codecov.io/gh/kubb-labs/kubb

--- a/packages/kubb/README.md
+++ b/packages/kubb/README.md
@@ -191,14 +191,14 @@ See [LICENSE](./LICENSE) for details.
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/kubb
+[npm-version-href]: https://npmx.dev/package/kubb
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/kubb
+[npm-downloads-href]: https://npmx.dev/package/kubb
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/kubb
+[node-href]: https://npmx.dev/package/kubb
 [contributors-src]: https://shieldcn.dev/github/contributors/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [contributors-href]: #contributors-

--- a/packages/kubb/README.md
+++ b/packages/kubb/README.md
@@ -191,17 +191,17 @@ See [LICENSE](./LICENSE) for details.
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/kubb
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/kubb
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/kubb
-[contributors-src]: https://shieldcn.dev/github/contributors/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[contributors-src]: https://shieldcn.dev/github/contributors/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [contributors-href]: #contributors-
-[coverage-src]: https://shieldcn.dev/codecov/github/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[coverage-src]: https://shieldcn.dev/codecov/github/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [coverage-href]: https://app.codecov.io/gh/kubb-labs/kubb

--- a/packages/kubb/README.md
+++ b/packages/kubb/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -196,9 +196,9 @@ See [LICENSE](./LICENSE) for details.
 [npm-downloads-href]: https://npmjs.com/package/kubb
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/l/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/kubb.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/kubb.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/kubb
 [contributors-src]: https://shieldcn.dev/github/contributors/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [contributors-href]: #contributors-

--- a/packages/kubb/README.md
+++ b/packages/kubb/README.md
@@ -197,7 +197,7 @@ See [LICENSE](./LICENSE) for details.
 [npm-downloads-href]: https://npmx.dev/package/kubb
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/kubb.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/kubb

--- a/packages/kubb/README.md
+++ b/packages/kubb/README.md
@@ -191,17 +191,17 @@ See [LICENSE](./LICENSE) for details.
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/kubb
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/kubb
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/kubb
-[contributors-src]: https://shieldcn.dev/github/contributors/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[contributors-src]: https://shieldcn.dev/github/contributors/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [contributors-href]: #contributors-
-[coverage-src]: https://shieldcn.dev/codecov/github/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[coverage-src]: https://shieldcn.dev/codecov/github/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [coverage-href]: https://app.codecov.io/gh/kubb-labs/kubb

--- a/packages/kubb/README.md
+++ b/packages/kubb/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/kubb" target="_blank">
+  <img alt="kubb badges" src="https://shieldcn.dev/group/npm/v/kubb+npm/dm/kubb+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -190,19 +188,5 @@ See [LICENSE](./LICENSE) for details.
 
 <!-- Badges -->
 
-[npm-version-src]: https://img.shields.io/npm/v/@kubb/core?flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmx.dev/package/@kubb/core
-[npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/core?flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/@kubb/core
-[license-src]: https://img.shields.io/npm/l/%40kubb%2Fcore?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT
-[build-src]: https://img.shields.io/github/actions/workflow/status/kubb-labs/kubb/ci.yaml?style=flat&colorA=18181B&colorB=f58517
-[build-href]: https://www.npmjs.com/package/@kubb/core
-[minified-src]: https://img.shields.io/bundlephobia/min/@kubb/core?style=flat&colorA=18181B&colorB=f58517
-[minified-href]: https://www.npmjs.com/package/@kubb/core
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
-[coverage-href]: https://www.npmjs.com/package/@kubb/core
 [contributors-src]: https://img.shields.io/github/contributors/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517&label=%20
 [contributors-href]: #contributors-
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle/

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -195,7 +195,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmx.dev/package/@kubb/mcp
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/mcp.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/mcp.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/mcp.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/mcp

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/@kubb/mcp" target="_blank">
-  <img alt="@kubb/mcp badges" src="https://shieldcn.dev/group/npm/v/@kubb/mcp+npm/dm/@kubb/mcp+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="@kubb/mcp badges" src="https://shieldcn.dev/group/npm/v/@kubb/mcp+npm/dm/@kubb/mcp+github/stars/kubb-labs/kubb+npm/l/@kubb/mcp+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -189,13 +189,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/mcp.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/mcp
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/mcp.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/mcp
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/mcp.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/mcp.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/mcp

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -190,12 +190,12 @@ Kubb is an open source project, and its development is funded entirely by sponso
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@kubb/mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@kubb/mcp
+[npm-version-href]: https://npmx.dev/package/@kubb/mcp
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@kubb/mcp
+[npm-downloads-href]: https://npmx.dev/package/@kubb/mcp
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/@kubb/mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@kubb/mcp
+[node-href]: https://npmx.dev/package/@kubb/mcp

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -195,7 +195,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/mcp
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/l/@kubb/mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/mcp.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/@kubb/mcp.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@kubb/mcp

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -195,7 +195,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/mcp
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/mcp.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/mcp.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/@kubb/mcp

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -189,13 +189,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/mcp.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/mcp.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/mcp
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/mcp.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/mcp.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/mcp
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/mcp.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/mcp.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/mcp.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/mcp.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/mcp

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/@kubb/mcp" target="_blank">
+  <img alt="@kubb/mcp badges" src="https://shieldcn.dev/group/npm/v/@kubb/mcp+npm/dm/@kubb/mcp+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -186,16 +184,3 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT)
-
-<!-- Badges -->
-
-[npm-version-src]: https://img.shields.io/npm/v/@kubb/mcp?flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmjs.com/package/@kubb/mcp
-[npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/mcp?flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/@kubb/mcp
-[license-src]: https://img.shields.io/github/license/kubb-labs/kubb.svg?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
-[coverage-href]: https://www.npmjs.com/package/@kubb/mcp
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle/

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/@kubb/mcp" target="_blank">
-  <img alt="@kubb/mcp badges" src="https://shieldcn.dev/group/npm/v/@kubb/mcp+npm/dm/@kubb/mcp+github/stars/kubb-labs/kubb+npm/l/@kubb/mcp+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -184,3 +186,16 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@kubb/mcp
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@kubb/mcp
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/l/@kubb/mcp.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/packages/middleware-barrel/README.md
+++ b/packages/middleware-barrel/README.md
@@ -96,13 +96,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/middleware-barrel.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/middleware-barrel.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/middleware-barrel
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/middleware-barrel.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/middleware-barrel.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/middleware-barrel
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/middleware-barrel.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/middleware-barrel.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/middleware-barrel.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/middleware-barrel.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/middleware-barrel

--- a/packages/middleware-barrel/README.md
+++ b/packages/middleware-barrel/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -102,7 +102,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/middleware-barrel
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/l/@kubb/middleware-barrel.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/middleware-barrel.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/@kubb/middleware-barrel.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@kubb/middleware-barrel

--- a/packages/middleware-barrel/README.md
+++ b/packages/middleware-barrel/README.md
@@ -97,12 +97,12 @@ Kubb is an open source project, and its development is funded entirely by sponso
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@kubb/middleware-barrel.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@kubb/middleware-barrel
+[npm-version-href]: https://npmx.dev/package/@kubb/middleware-barrel
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/middleware-barrel.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@kubb/middleware-barrel
+[npm-downloads-href]: https://npmx.dev/package/@kubb/middleware-barrel
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/@kubb/middleware-barrel.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/middleware-barrel.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@kubb/middleware-barrel
+[node-href]: https://npmx.dev/package/@kubb/middleware-barrel

--- a/packages/middleware-barrel/README.md
+++ b/packages/middleware-barrel/README.md
@@ -96,13 +96,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/middleware-barrel.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/middleware-barrel.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/middleware-barrel
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/middleware-barrel.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/middleware-barrel.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/middleware-barrel
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/middleware-barrel.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/middleware-barrel.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/middleware-barrel.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/middleware-barrel.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/middleware-barrel

--- a/packages/middleware-barrel/README.md
+++ b/packages/middleware-barrel/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/@kubb/middleware-barrel" target="_blank">
+  <img alt="@kubb/middleware-barrel badges" src="https://shieldcn.dev/group/npm/v/@kubb/middleware-barrel+npm/dm/@kubb/middleware-barrel+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -93,16 +91,3 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT)
-
-<!-- Badges -->
-
-[npm-version-src]: https://img.shields.io/npm/v/@kubb/middleware-barrel?flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmjs.com/package/@kubb/middleware-barrel
-[npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/middleware-barrel?flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/@kubb/middleware-barrel
-[license-src]: https://img.shields.io/github/license/kubb-labs/kubb.svg?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
-[coverage-href]: https://www.npmjs.com/package/@kubb/middleware-barrel
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle/

--- a/packages/middleware-barrel/README.md
+++ b/packages/middleware-barrel/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/@kubb/middleware-barrel" target="_blank">
-  <img alt="@kubb/middleware-barrel badges" src="https://shieldcn.dev/group/npm/v/@kubb/middleware-barrel+npm/dm/@kubb/middleware-barrel+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="@kubb/middleware-barrel badges" src="https://shieldcn.dev/group/npm/v/@kubb/middleware-barrel+npm/dm/@kubb/middleware-barrel+github/stars/kubb-labs/kubb+npm/l/@kubb/middleware-barrel+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/middleware-barrel/README.md
+++ b/packages/middleware-barrel/README.md
@@ -102,7 +102,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/middleware-barrel
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/middleware-barrel.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/middleware-barrel.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/middleware-barrel.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/middleware-barrel.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/@kubb/middleware-barrel

--- a/packages/middleware-barrel/README.md
+++ b/packages/middleware-barrel/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/@kubb/middleware-barrel" target="_blank">
-  <img alt="@kubb/middleware-barrel badges" src="https://shieldcn.dev/group/npm/v/@kubb/middleware-barrel+npm/dm/@kubb/middleware-barrel+github/stars/kubb-labs/kubb+npm/l/@kubb/middleware-barrel+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -91,3 +93,16 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/middleware-barrel.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@kubb/middleware-barrel
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/middleware-barrel.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@kubb/middleware-barrel
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/l/@kubb/middleware-barrel.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/packages/middleware-barrel/README.md
+++ b/packages/middleware-barrel/README.md
@@ -102,7 +102,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmx.dev/package/@kubb/middleware-barrel
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/middleware-barrel.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/middleware-barrel.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/middleware-barrel.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/middleware-barrel

--- a/packages/parser-md/README.md
+++ b/packages/parser-md/README.md
@@ -90,13 +90,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/parser-md.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/parser-md.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/parser-md
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/parser-md.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/parser-md.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/parser-md
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/parser-md.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/parser-md.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/parser-md.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/parser-md.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/parser-md

--- a/packages/parser-md/README.md
+++ b/packages/parser-md/README.md
@@ -91,12 +91,12 @@ Kubb is an open source project, and its development is funded entirely by sponso
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@kubb/parser-md.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@kubb/parser-md
+[npm-version-href]: https://npmx.dev/package/@kubb/parser-md
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/parser-md.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@kubb/parser-md
+[npm-downloads-href]: https://npmx.dev/package/@kubb/parser-md
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/@kubb/parser-md.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/parser-md.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@kubb/parser-md
+[node-href]: https://npmx.dev/package/@kubb/parser-md

--- a/packages/parser-md/README.md
+++ b/packages/parser-md/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/@kubb/parser-md" target="_blank">
-  <img alt="@kubb/parser-md badges" src="https://shieldcn.dev/group/npm/v/@kubb/parser-md+npm/dm/@kubb/parser-md+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="@kubb/parser-md badges" src="https://shieldcn.dev/group/npm/v/@kubb/parser-md+npm/dm/@kubb/parser-md+github/stars/kubb-labs/kubb+npm/l/@kubb/parser-md+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/parser-md/README.md
+++ b/packages/parser-md/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -96,7 +96,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/parser-md
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/l/@kubb/parser-md.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/parser-md.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/@kubb/parser-md.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@kubb/parser-md

--- a/packages/parser-md/README.md
+++ b/packages/parser-md/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/@kubb/parser-md" target="_blank">
-  <img alt="@kubb/parser-md badges" src="https://shieldcn.dev/group/npm/v/@kubb/parser-md+npm/dm/@kubb/parser-md+github/stars/kubb-labs/kubb+npm/l/@kubb/parser-md+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -85,3 +87,16 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/parser-md.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@kubb/parser-md
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/parser-md.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@kubb/parser-md
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/l/@kubb/parser-md.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/packages/parser-md/README.md
+++ b/packages/parser-md/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/@kubb/parser-md" target="_blank">
+  <img alt="@kubb/parser-md badges" src="https://shieldcn.dev/group/npm/v/@kubb/parser-md+npm/dm/@kubb/parser-md+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -87,16 +85,3 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT)
-
-<!-- Badges -->
-
-[npm-version-src]: https://img.shields.io/npm/v/@kubb/parser-md?flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmjs.com/package/@kubb/parser-md
-[npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/parser-md?flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/@kubb/parser-md
-[license-src]: https://img.shields.io/github/license/kubb-labs/kubb.svg?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
-[coverage-href]: https://www.npmjs.com/package/@kubb/parser-md
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle/

--- a/packages/parser-md/README.md
+++ b/packages/parser-md/README.md
@@ -96,7 +96,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmx.dev/package/@kubb/parser-md
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/parser-md.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/parser-md.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/parser-md.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/parser-md

--- a/packages/parser-md/README.md
+++ b/packages/parser-md/README.md
@@ -96,7 +96,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/parser-md
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/parser-md.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/parser-md.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/parser-md.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/parser-md.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/@kubb/parser-md

--- a/packages/parser-md/README.md
+++ b/packages/parser-md/README.md
@@ -90,13 +90,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/parser-md.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/parser-md.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/parser-md
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/parser-md.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/parser-md.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/parser-md
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/parser-md.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/parser-md.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/parser-md.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/parser-md.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/parser-md

--- a/packages/parser-ts/README.md
+++ b/packages/parser-ts/README.md
@@ -105,7 +105,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/parser-ts
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/parser-ts.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/parser-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/parser-ts.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/parser-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/@kubb/parser-ts

--- a/packages/parser-ts/README.md
+++ b/packages/parser-ts/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/@kubb/parser-ts" target="_blank">
+  <img alt="@kubb/parser-ts badges" src="https://shieldcn.dev/group/npm/v/@kubb/parser-ts+npm/dm/@kubb/parser-ts+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -96,16 +94,3 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT)
-
-<!-- Badges -->
-
-[npm-version-src]: https://img.shields.io/npm/v/@kubb/parser-ts?flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmjs.com/package/@kubb/parser-ts
-[npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/parser-ts?flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/@kubb/parser-ts
-[license-src]: https://img.shields.io/github/license/kubb-labs/kubb.svg?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
-[coverage-href]: https://www.npmjs.com/package/@kubb/parser-ts
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle/

--- a/packages/parser-ts/README.md
+++ b/packages/parser-ts/README.md
@@ -105,7 +105,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmx.dev/package/@kubb/parser-ts
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/parser-ts.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/parser-ts.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/parser-ts.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/parser-ts

--- a/packages/parser-ts/README.md
+++ b/packages/parser-ts/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -105,7 +105,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/parser-ts
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/l/@kubb/parser-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/parser-ts.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/@kubb/parser-ts.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@kubb/parser-ts

--- a/packages/parser-ts/README.md
+++ b/packages/parser-ts/README.md
@@ -99,13 +99,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/parser-ts.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/parser-ts.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/parser-ts
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/parser-ts.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/parser-ts.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/parser-ts
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/parser-ts.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/parser-ts.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/parser-ts.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/parser-ts.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/parser-ts

--- a/packages/parser-ts/README.md
+++ b/packages/parser-ts/README.md
@@ -99,13 +99,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/parser-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/parser-ts.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/parser-ts
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/parser-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/parser-ts.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/parser-ts
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/parser-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/parser-ts.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/parser-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/parser-ts.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/parser-ts

--- a/packages/parser-ts/README.md
+++ b/packages/parser-ts/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/@kubb/parser-ts" target="_blank">
-  <img alt="@kubb/parser-ts badges" src="https://shieldcn.dev/group/npm/v/@kubb/parser-ts+npm/dm/@kubb/parser-ts+github/stars/kubb-labs/kubb+npm/l/@kubb/parser-ts+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -94,3 +96,16 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/parser-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@kubb/parser-ts
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/parser-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@kubb/parser-ts
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/l/@kubb/parser-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/packages/parser-ts/README.md
+++ b/packages/parser-ts/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/@kubb/parser-ts" target="_blank">
-  <img alt="@kubb/parser-ts badges" src="https://shieldcn.dev/group/npm/v/@kubb/parser-ts+npm/dm/@kubb/parser-ts+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="@kubb/parser-ts badges" src="https://shieldcn.dev/group/npm/v/@kubb/parser-ts+npm/dm/@kubb/parser-ts+github/stars/kubb-labs/kubb+npm/l/@kubb/parser-ts+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/parser-ts/README.md
+++ b/packages/parser-ts/README.md
@@ -100,12 +100,12 @@ Kubb is an open source project, and its development is funded entirely by sponso
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@kubb/parser-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@kubb/parser-ts
+[npm-version-href]: https://npmx.dev/package/@kubb/parser-ts
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/parser-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@kubb/parser-ts
+[npm-downloads-href]: https://npmx.dev/package/@kubb/parser-ts
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/@kubb/parser-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/parser-ts.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@kubb/parser-ts
+[node-href]: https://npmx.dev/package/@kubb/parser-ts

--- a/packages/renderer-jsx/README.md
+++ b/packages/renderer-jsx/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/@kubb/renderer-jsx" target="_blank">
-  <img alt="@kubb/renderer-jsx badges" src="https://shieldcn.dev/group/npm/v/@kubb/renderer-jsx+npm/dm/@kubb/renderer-jsx+github/stars/kubb-labs/kubb+npm/l/@kubb/renderer-jsx+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -117,3 +119,16 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/renderer-jsx.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/@kubb/renderer-jsx
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/renderer-jsx.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/@kubb/renderer-jsx
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/l/@kubb/renderer-jsx.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle

--- a/packages/renderer-jsx/README.md
+++ b/packages/renderer-jsx/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -128,7 +128,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/renderer-jsx
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/l/@kubb/renderer-jsx.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/renderer-jsx.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/@kubb/renderer-jsx.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/@kubb/renderer-jsx

--- a/packages/renderer-jsx/README.md
+++ b/packages/renderer-jsx/README.md
@@ -122,13 +122,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/renderer-jsx.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/renderer-jsx.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/renderer-jsx
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/renderer-jsx.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/renderer-jsx.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/renderer-jsx
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/renderer-jsx.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/renderer-jsx.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/renderer-jsx.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/renderer-jsx.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/renderer-jsx

--- a/packages/renderer-jsx/README.md
+++ b/packages/renderer-jsx/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/@kubb/renderer-jsx" target="_blank">
-  <img alt="@kubb/renderer-jsx badges" src="https://shieldcn.dev/group/npm/v/@kubb/renderer-jsx+npm/dm/@kubb/renderer-jsx+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="@kubb/renderer-jsx badges" src="https://shieldcn.dev/group/npm/v/@kubb/renderer-jsx+npm/dm/@kubb/renderer-jsx+github/stars/kubb-labs/kubb+npm/l/@kubb/renderer-jsx+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/renderer-jsx/README.md
+++ b/packages/renderer-jsx/README.md
@@ -128,7 +128,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/@kubb/renderer-jsx
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/renderer-jsx.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/renderer-jsx.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/renderer-jsx.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/renderer-jsx.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/@kubb/renderer-jsx

--- a/packages/renderer-jsx/README.md
+++ b/packages/renderer-jsx/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/@kubb/renderer-jsx" target="_blank">
+  <img alt="@kubb/renderer-jsx badges" src="https://shieldcn.dev/group/npm/v/@kubb/renderer-jsx+npm/dm/@kubb/renderer-jsx+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -119,16 +117,3 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT)
-
-<!-- Badges -->
-
-[npm-version-src]: https://img.shields.io/npm/v/@kubb/renderer-jsx?flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmjs.com/package/@kubb/renderer-jsx
-[npm-downloads-src]: https://img.shields.io/npm/dm/@kubb/renderer-jsx?flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/@kubb/renderer-jsx
-[license-src]: https://img.shields.io/github/license/kubb-labs/kubb.svg?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
-[coverage-href]: https://www.npmjs.com/package/@kubb/renderer-jsx
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle/

--- a/packages/renderer-jsx/README.md
+++ b/packages/renderer-jsx/README.md
@@ -122,13 +122,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/renderer-jsx.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/renderer-jsx.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/@kubb/renderer-jsx
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/renderer-jsx.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/renderer-jsx.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/@kubb/renderer-jsx
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/renderer-jsx.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/renderer-jsx.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/@kubb/renderer-jsx.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/@kubb/renderer-jsx.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/renderer-jsx

--- a/packages/renderer-jsx/README.md
+++ b/packages/renderer-jsx/README.md
@@ -123,12 +123,12 @@ Kubb is an open source project, and its development is funded entirely by sponso
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@kubb/renderer-jsx.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/@kubb/renderer-jsx
+[npm-version-href]: https://npmx.dev/package/@kubb/renderer-jsx
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/renderer-jsx.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/@kubb/renderer-jsx
+[npm-downloads-href]: https://npmx.dev/package/@kubb/renderer-jsx
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/@kubb/renderer-jsx.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/renderer-jsx.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/@kubb/renderer-jsx
+[node-href]: https://npmx.dev/package/@kubb/renderer-jsx

--- a/packages/renderer-jsx/README.md
+++ b/packages/renderer-jsx/README.md
@@ -128,7 +128,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmx.dev/package/@kubb/renderer-jsx
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/@kubb/renderer-jsx.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/@kubb/renderer-jsx.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/@kubb/renderer-jsx.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/@kubb/renderer-jsx

--- a/packages/unplugin-kubb/README.md
+++ b/packages/unplugin-kubb/README.md
@@ -124,13 +124,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/unplugin-kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/unplugin-kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/unplugin-kubb
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/unplugin-kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/unplugin-kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/unplugin-kubb
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/unplugin-kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/unplugin-kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/unplugin-kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/unplugin-kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/unplugin-kubb

--- a/packages/unplugin-kubb/README.md
+++ b/packages/unplugin-kubb/README.md
@@ -7,7 +7,7 @@
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
 [![Stars][stars-src]][stars-href]
 [![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+[![Node][node-src]][node-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -130,7 +130,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/unplugin-kubb
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/l/unplugin-kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/unplugin-kubb.svg?variant=ghost&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle
+[node-src]: https://shieldcn.dev/npm/node/unplugin-kubb.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmjs.com/package/unplugin-kubb

--- a/packages/unplugin-kubb/README.md
+++ b/packages/unplugin-kubb/README.md
@@ -124,13 +124,13 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <!-- Badges -->
 
-[npm-version-src]: https://shieldcn.dev/npm/v/unplugin-kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-version-src]: https://shieldcn.dev/npm/v/unplugin-kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-version-href]: https://npmx.dev/package/unplugin-kubb
-[npm-downloads-src]: https://shieldcn.dev/npm/dm/unplugin-kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/unplugin-kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [npm-downloads-href]: https://npmx.dev/package/unplugin-kubb
-[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/unplugin-kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/unplugin-kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/unplugin-kubb.svg?variant=secondary&size=sm&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/unplugin-kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/unplugin-kubb

--- a/packages/unplugin-kubb/README.md
+++ b/packages/unplugin-kubb/README.md
@@ -4,7 +4,7 @@
   </a>
 
 <a href="https://npmjs.com/package/unplugin-kubb" target="_blank">
-  <img alt="unplugin-kubb badges" src="https://shieldcn.dev/group/npm/v/unplugin-kubb+npm/dm/unplugin-kubb+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+  <img alt="unplugin-kubb badges" src="https://shieldcn.dev/group/npm/v/unplugin-kubb+npm/dm/unplugin-kubb+github/stars/kubb-labs/kubb+npm/l/unplugin-kubb+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
 </a>
 
 <h4>

--- a/packages/unplugin-kubb/README.md
+++ b/packages/unplugin-kubb/README.md
@@ -130,7 +130,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmx.dev/package/unplugin-kubb
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/unplugin-kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/unplugin-kubb.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/unplugin-kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmx.dev/package/unplugin-kubb

--- a/packages/unplugin-kubb/README.md
+++ b/packages/unplugin-kubb/README.md
@@ -125,12 +125,12 @@ Kubb is an open source project, and its development is funded entirely by sponso
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/unplugin-kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmjs.com/package/unplugin-kubb
+[npm-version-href]: https://npmx.dev/package/unplugin-kubb
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/unplugin-kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmjs.com/package/unplugin-kubb
+[npm-downloads-href]: https://npmx.dev/package/unplugin-kubb
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/unplugin-kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/unplugin-kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmjs.com/package/unplugin-kubb
+[node-href]: https://npmx.dev/package/unplugin-kubb

--- a/packages/unplugin-kubb/README.md
+++ b/packages/unplugin-kubb/README.md
@@ -130,7 +130,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 [npm-downloads-href]: https://npmjs.com/package/unplugin-kubb
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
-[license-src]: https://shieldcn.dev/npm/license/unplugin-kubb.svg?variant=ghost&size=xs&theme=zinc&mode=dark
+[license-src]: https://shieldcn.dev/npm/license/unplugin-kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[node-src]: https://shieldcn.dev/npm/node/unplugin-kubb.svg?variant=outline&size=xs&theme=zinc&mode=dark
+[node-src]: https://shieldcn.dev/npm/node/unplugin-kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
 [node-href]: https://npmjs.com/package/unplugin-kubb

--- a/packages/unplugin-kubb/README.md
+++ b/packages/unplugin-kubb/README.md
@@ -3,11 +3,9 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-[![npm version][npm-version-src]][npm-version-href]
-[![npm downloads][npm-downloads-src]][npm-downloads-href]
-[![Coverage][coverage-src]][coverage-href]
-[![License][license-src]][license-href]
-[![Sponsors][sponsors-src]][sponsors-href]
+<a href="https://npmjs.com/package/unplugin-kubb" target="_blank">
+  <img alt="unplugin-kubb badges" src="https://shieldcn.dev/group/npm/v/unplugin-kubb+npm/dm/unplugin-kubb+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark">
+</a>
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -121,20 +119,3 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT)
-
-<!-- Badges -->
-
-[npm-version-src]: https://img.shields.io/npm/v/unplugin-kubb?flat&colorA=18181B&colorB=f58517
-[npm-version-href]: https://npmjs.com/package/unplugin-kubb
-[npm-downloads-src]: https://img.shields.io/npm/dm/unplugin-kubb?flat&colorA=18181B&colorB=f58517
-[npm-downloads-href]: https://npmjs.com/package/unplugin-kubb
-[license-src]: https://img.shields.io/github/license/kubb-labs/kubb.svg?flat&colorA=18181B&colorB=f58517
-[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
-[build-src]: https://img.shields.io/github/actions/workflow/status/kubb-labs/kubb/ci.yaml?style=flat&colorA=18181B&colorB=f58517
-[build-href]: https://www.npmjs.com/package/unplugin-kubb
-[minified-src]: https://img.shields.io/bundlephobia/min/unplugin-kubb?style=flat&colorA=18181B&colorB=f58517
-[minified-href]: https://www.npmjs.com/package/unplugin-kubb
-[coverage-src]: https://img.shields.io/codecov/c/github/kubb-labs/kubb?style=flat&colorA=18181B&colorB=f58517
-[coverage-href]: https://www.npmjs.com/package/unplugin-kubb
-[sponsors-src]: https://img.shields.io/github/sponsors/stijnvanhulle?style=flat&colorA=18181B&colorB=f58517
-[sponsors-href]: https://github.com/sponsors/stijnvanhulle/

--- a/packages/unplugin-kubb/README.md
+++ b/packages/unplugin-kubb/README.md
@@ -3,9 +3,11 @@
     <img src="https://kubb.dev/og.png" alt="Kubb banner">
   </a>
 
-<a href="https://npmjs.com/package/unplugin-kubb" target="_blank">
-  <img alt="unplugin-kubb badges" src="https://shieldcn.dev/group/npm/v/unplugin-kubb+npm/dm/unplugin-kubb+github/stars/kubb-labs/kubb+npm/l/unplugin-kubb+badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark">
-</a>
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Sponsors][sponsors-src]][sponsors-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -119,3 +121,16 @@ Kubb is an open source project, and its development is funded entirely by sponso
 ## License
 
 [MIT](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/unplugin-kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmjs.com/package/unplugin-kubb
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/unplugin-kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmjs.com/package/unplugin-kubb
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/l/unplugin-kubb.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[sponsors-src]: https://shieldcn.dev/badge/sponsors-stijnvanhulle-EA4AAA.svg?variant=branded&size=xs&theme=zinc&mode=dark
+[sponsors-href]: https://github.com/sponsors/stijnvanhulle


### PR DESCRIPTION
## Summary

- Replace the five flat shields.io badges (npm version, downloads, coverage, license, sponsors) on every package README with a single shieldcn.dev badge group rendered as one shadcn-styled image
- Apply `variant=branded`, `size=xs`, `theme=zinc`, `mode=dark` to every group so the dark zinc look matches across all 12 packages
- Drop the now-unused reference-style `[*-src]` / `[*-href]` link defs at the bottom of each README; the meta package keeps `[contributors-*]` since it is still referenced by the Contributors heading
- Fix the meta `kubb` package README, which previously pointed all badges at `@kubb/core`

## Test plan

- [ ] Open `packages/core/README.md` (and any other touched README) on GitHub and confirm the shieldcn group image renders with brand colors per segment
- [ ] Hit the group URL in a browser to confirm `shieldcn.dev` returns a 200 SVG:
      ``https://shieldcn.dev/group/npm/v/@kubb/core+npm/dm/@kubb/core+github/stars/kubb-labs/kubb+codecov/c/github/kubb-labs/kubb+github/license/kubb-labs/kubb+github/sponsors/stijnvanhulle.svg?variant=branded&size=xs&theme=zinc&mode=dark``
- [ ] `grep -RE '\[(npm-version|npm-downloads|coverage|license|sponsors|build|minified)-(src|href)\]:' packages/` returns nothing under modified READMEs

https://claude.ai/code/session_013waRRjU1q7UcNXb3Tnnvqa

---
_Generated by [Claude Code](https://claude.ai/code/session_013waRRjU1q7UcNXb3Tnnvqa)_