### PR TITLE
fix(cli): don't fail oxlint on gitignored generated output

### DIFF
--- a/.changeset/cli-oxlint-gitignored-output.md
+++ b/.changeset/cli-oxlint-gitignored-output.md
@@ -1,0 +1,7 @@
+---
+'@kubb/cli': patch
+---
+
+Fix `lint: 'auto'` (and `lint: 'oxlint'`) failing with "No files found to lint" when the generated output directory is gitignored.
+
+The oxlint hook passed the output directory with `--no-ignore`, but oxlint's `--no-ignore` only disables `.eslintignore`, not `.gitignore`. Generated output dirs are usually gitignored, so oxlint walked the directory, skipped every file, and exited non-zero. The hook now also passes `--no-error-on-unmatched-pattern`, so a fully gitignored output dir is skipped instead of failing the run.

--- a/internals/utils/src/linters.test.ts
+++ b/internals/utils/src/linters.test.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { detectLinter } from './linters.ts'
+import { detectLinter, linters } from './linters.ts'
 
 vi.mock('node:child_process', () => ({
   spawn: vi.fn(),
@@ -55,5 +55,14 @@ describe('detectLinter', () => {
 
     const result = await detectLinter()
     expect(result).toBeNull()
+  })
+})
+
+describe('linters.oxlint.args', () => {
+  // Oxlint honors `.gitignore` during directory traversal even with `--no-ignore`, so a gitignored
+  // output dir resolves to no files. `--no-error-on-unmatched-pattern` keeps that from failing the
+  // run with "No files found to lint".
+  it('lints the output directory without erroring on a gitignored (empty) match', () => {
+    expect(linters.oxlint.args('./gen')).toStrictEqual(['--fix', '--no-ignore', '--no-error-on-unmatched-pattern', './gen'])
   })
 })

--- a/internals/utils/src/linters.ts
+++ b/internals/utils/src/linters.ts
@@ -20,8 +20,11 @@ export const linters = {
   },
   oxlint: {
     command: 'oxlint',
-    // --no-ignore so oxlint lints the folder even when it's gitignored (generated output dirs usually are).
-    args: (outputPath: string) => ['--fix', '--no-ignore', outputPath],
+    // Oxlint still honors `.gitignore` during directory traversal even with `--no-ignore` (which
+    // only disables `.eslintignore`), so a gitignored output dir resolves to no files.
+    // `--no-error-on-unmatched-pattern` keeps that from failing the run with "No files found to
+    // lint"; such a dir is simply skipped rather than linted.
+    args: (outputPath: string) => ['--fix', '--no-ignore', '--no-error-on-unmatched-pattern', outputPath],
     errorMessage: 'Oxlint not found',
   },
 } as const


### PR DESCRIPTION
## Summary

Fixes `lint: 'auto'` / `lint: 'oxlint'` failing with **"No files found to lint"** (`KUBB_LINT_FAILED`) whenever the generated output directory is gitignored — the common case, since generated dirs are usually in `.gitignore`.

## Root cause

The oxlint hook in `internals/utils/src/linters.ts` passes the output **directory** with `--no-ignore`:

```ts
args: (outputPath) => ['--fix', '--no-ignore', outputPath]
```

The comment assumed `--no-ignore` makes oxlint lint a gitignored folder. It does not — oxlint's `--no-ignore` only disables `.eslintignore` (and `--ignore-path` / `--ignore-pattern`), **not `.gitignore`**. So oxlint walked the directory, skipped every gitignored file, found 0 files, and exited non-zero.

I verified no flag combination makes a directory walk include gitignored files:

| Invocation | Result |
|---|---|
| `oxlint --fix --no-ignore <dir>` | exit 1, "No files found" |
| `+ --disable-nested-config` | exit 1, "No files found" |
| `--ignore-path=/dev/null` (± `--no-ignore`) | exit 1, "No files found" |
| `--no-ignore --no-error-on-unmatched-pattern <dir>` | **exit 0** |

## Fix

Add `--no-error-on-unmatched-pattern` to the oxlint args:

```ts
args: (outputPath) => ['--fix', '--no-ignore', '--no-error-on-unmatched-pattern', outputPath]
```

A fully gitignored output dir is now **skipped** instead of failing the run; non-gitignored output is still linted as before. (Linting gitignored output would require passing files explicitly, which risks arg-length limits on very large outputs — those configs already opt out with `lint: false`.)

## Verification

- Updated the unit test for `linters.oxlint.args`; `@internals/utils` suite passes (`@kubb/cli` typecheck clean).
- End-to-end: built `@kubb/cli`, dropped it into the kubb-plugins e2e harness (which reproduced the failure), re-ran `kubb generate` — **0** `KUBB_LINT_FAILED` and **0** "No files found" across all configs (previously every config failed).

Unblocks the kubb-plugins e2e CI.

https://claude.ai/code/session_01A7NDxyeCXjFmhzhUUrMnCQ