### PR TITLE
fix(core): emit kubb:plugin:end per plugin so progress advances

### DIFF
--- a/.changeset/fix-kubb-driver-per-plugin-progress.md
+++ b/.changeset/fix-kubb-driver-per-plugin-progress.md
@@ -1,0 +1,8 @@
+---
+"@kubb/core": patch
+---
+
+Restore progressive `Plugins N/M` progress in the CLI. The driver now runs each plugin's
+generator pass sequentially, so `kubb:plugin:end` fires as each plugin finishes instead of
+once the whole batch pass is over. The CLI counter advances 2/9, 3/9, ..., 9/9 again rather
+than jumping from 1/9 straight to 9/9 at the end of the run.

--- a/packages/core/src/KubbDriver.ts
+++ b/packages/core/src/KubbDriver.ts
@@ -473,6 +473,11 @@ export class KubbDriver {
    * A failing plugin contributes an error diagnostic so the rest of the build continues.
    * Every plugin also contributes a `timing` diagnostic.
    *
+   * Plugins run sequentially so `kubb:plugin:end` fires as each plugin completes, instead
+   * of all at once after every plugin has marched through the parallel batches together.
+   * That ordering is what drives the CLI's `Plugins N/M` counter; without it the bar would
+   * sit at the initial value until the very end of the run.
+   *
    * When `entries` is empty or `this.inputNode` is `null`, every entry still gets a
    * `kubb:plugin:end` so middleware listeners (the barrel writer and friends) complete.
    */
@@ -526,22 +531,27 @@ export class KubbDriver {
 
     const emitsSchemaHook = this.hooks.listenerCount('kubb:generate:schema') > 0
     const emitsOperationHook = this.hooks.listenerCount('kubb:generate:operation') > 0
+    const emitsOperationsHook = this.hooks.listenerCount('kubb:generate:operations') > 0
+
+    // Buffer the streaming adapter's nodes once. Each plugin reads the same buffer
+    // instead of re-parsing the document per pass, and the pruning pre-scan below
+    // shares it too (previously it iterated its own copies).
+    const schemasBuffer: Array<SchemaNode> = []
+    for await (const schema of schemas) schemasBuffer.push(schema)
+    const operationsBuffer: Array<OperationNode> = []
+    for await (const operation of operations) operationsBuffer.push(operation)
 
     // Pre-scan: plugins with operation-based includes (but no schemaName include) need
     // the reachable schema set. This requires the full schema graph in memory at once,
-    // since transitive reachability can't be derived from a single node. `allSchemas` is
-    // released as soon as the pre-scan returns, so the main passes get fresh iterators.
+    // since transitive reachability can't be derived from a single node.
     const pruningStates = states.filter(({ plugin }) => {
       const { include } = plugin.options
       return (include?.some(({ type }) => OPERATION_FILTER_TYPES.has(type)) ?? false) && !(include?.some(({ type }) => type === 'schemaName') ?? false)
     })
 
     if (pruningStates.length > 0) {
-      const allSchemas: Array<SchemaNode> = []
-      for await (const schema of schemas) allSchemas.push(schema)
-
       const includedOpsByState = new Map<PluginState, Array<OperationNode>>(pruningStates.map((state) => [state, []]))
-      for await (const operation of operations) {
+      for (const operation of operationsBuffer) {
         for (const state of pruningStates) {
           const { exclude, include, override } = state.plugin.options
           const options = state.generatorContext.resolver.resolveOptions(operation, { options: state.plugin.options, exclude, include, override })
@@ -550,7 +560,7 @@ export class KubbDriver {
       }
 
       for (const state of pruningStates) {
-        state.allowedSchemaNames = collectUsedSchemaNames(includedOpsByState.get(state) ?? [], allSchemas)
+        state.allowedSchemaNames = collectUsedSchemaNames(includedOpsByState.get(state) ?? [], schemasBuffer)
         includedOpsByState.delete(state)
       }
     }
@@ -628,30 +638,29 @@ export class KubbDriver {
       emit: emitsOperationHook ? (node: OperationNode, ctx: GeneratorContext) => this.hooks.emit('kubb:generate:operation', node, ctx) : null,
     } as const
 
-    // Skip building the aggregated operations array when nothing consumes it. Saves an
-    // N-sized allocation on the common path where plugins only define per-node `gen.operation`.
-    const needsCollectedOperations =
-      this.hooks.listenerCount('kubb:generate:operations') > 0 || states.some((state) => state.generators.some((gen) => !!gen.operations))
-    const collectedOperations: Array<OperationNode> | undefined = needsCollectedOperations ? [] : undefined
-
-    // Run schemas before operations: the two passes share `flushPending` and the
-    // FileProcessor's event emitter, so running them concurrently would interleave
-    // `kubb:files:processing:start|end` events and race on the shared dirty list.
-    await forBatches(schemas, (nodes) => Promise.all(nodes.flatMap((node) => states.map((state) => dispatchNode(state, node, schemaDispatch)))), {
-      concurrency: SCHEMA_PARALLEL,
-      flush: flushPending,
-    })
-
-    await forBatches(
-      operations,
-      (nodes) => {
-        if (needsCollectedOperations) collectedOperations?.push(...nodes)
-        return Promise.all(nodes.flatMap((node) => states.map((state) => dispatchNode(state, node, operationDispatch))))
-      },
-      { concurrency: SCHEMA_PARALLEL, flush: flushPending },
-    )
-
     for (const state of states) {
+      // Skip building the aggregated operations array when this plugin doesn't consume it.
+      // Saves an N-sized allocation when the plugin only defines per-node `gen.operation`.
+      const needsCollectedOperations = emitsOperationsHook || state.generators.some((gen) => !!gen.operations)
+      const collectedOperations: Array<OperationNode> | undefined = needsCollectedOperations ? [] : undefined
+
+      // Run schemas before operations: the two passes share `flushPending` and the
+      // FileProcessor's event emitter, so running them concurrently would interleave
+      // `kubb:files:processing:start|end` events and race on the shared dirty list.
+      await forBatches(schemasBuffer, (nodes) => Promise.all(nodes.map((node) => dispatchNode(state, node, schemaDispatch))), {
+        concurrency: SCHEMA_PARALLEL,
+        flush: flushPending,
+      })
+
+      await forBatches(
+        operationsBuffer,
+        (nodes) => {
+          if (needsCollectedOperations) collectedOperations?.push(...nodes)
+          return Promise.all(nodes.map((node) => dispatchNode(state, node, operationDispatch)))
+        },
+        { concurrency: SCHEMA_PARALLEL, flush: flushPending },
+      )
+
       if (!state.failed && needsCollectedOperations) {
         try {
           const { plugin, generatorContext, generators } = state

--- a/packages/core/src/createKubb.test.ts
+++ b/packages/core/src/createKubb.test.ts
@@ -241,7 +241,7 @@ describe('createKubb', () => {
     expect(endSpy).toHaveBeenCalled()
   })
 
-  it('flushes generated files after each schema batch across all active plugins', async () => {
+  it('flushes generated files per plugin so kubb:plugin:end fires progressively', async () => {
     const hooks = new AsyncEventEmitter<KubbHooks>()
     const batches: Array<number> = []
     hooks.on('kubb:files:processing:start', ({ files }) => {
@@ -285,11 +285,18 @@ describe('createKubb', () => {
       plugins: [makePlugin('plugin-one', '/workspace/src/gen/one.ts'), makePlugin('plugin-two', '/workspace/src/gen/two.ts')] as unknown as Array<Plugin>,
     } satisfies Config
 
+    const endOrder: Array<string> = []
+    hooks.on('kubb:plugin:end', ({ plugin }) => {
+      endOrder.push(plugin.name)
+    })
+
     const { files } = await createKubb(streamingConfig, { hooks }).build()
 
-    // In the always-stream path all plugins fan-out together: both files are
-    // produced in the same batch and flushed as a single event.
-    expect(batches).toStrictEqual([2])
+    // Each plugin runs its generator pass sequentially, so its file batch flushes
+    // before the next plugin starts. Two plugins, two single-file flushes — and the
+    // `plugin:end` order matches that progression, which drives the CLI counter.
+    expect(batches).toStrictEqual([1, 1])
+    expect(endOrder).toStrictEqual(['plugin-one', 'plugin-two'])
     expect(files.map((file) => file.path)).toStrictEqual(['/workspace/src/gen/one.ts', '/workspace/src/gen/two.ts'])
   })
 


### PR DESCRIPTION
## Summary

The CLI's `Plugins N/M` counter sat at `1/9` for the whole run and then jumped to `9/9` at the very end:

```
◇  Plugins 1/9 | Files 26/26 | 164ms elapsed
◇  Plugins 1/9 | Files 24/24 | 171ms elapsed
◇  Plugins 1/9 | Files 9/9 | 224ms elapsed
◇  Plugins 1/9 | Files 65/65 | 253ms elapsed
◇  Plugins 1/9 | Files 34/34 | 280ms elapsed
◇  Plugins 9/9 | Files 0/48 | 298ms elapsed
```

Regression from `61ca887` (refactor: split driver into parse/transform/generate). The new generator phase ran every plugin against the same batch of nodes in parallel (`Promise.all(nodes.flatMap(node => states.map(...)))`), then emitted `kubb:plugin:end` for all plugins back-to-back in a final loop. The clack logger advances the bar on each `plugin:end`, so all increments landed in a single render tick.

## Fix

`KubbDriver.#runGenerators` now runs each plugin's schemas + operations sequentially. Each plugin's `kubb:plugin:end` fires as soon as that plugin's generator pass finishes, so the counter ticks 2/9 → 3/9 → ... → 9/9 as the run progresses. The adapter's streaming nodes are buffered once up front so plugins don't re-parse the document N times, and the pruning pre-scan shares the same buffers.

Per-plugin parallelism inside each batch is preserved (`forBatches` still runs `concurrency: SCHEMA_PARALLEL`); only the cross-plugin fan-out is gone.

## Test plan

- [x] `pnpm --filter @kubb/core test` (215 passed)
- [x] `pnpm typecheck` across the workspace
- [x] `pnpm lint`
- [x] Updated `createKubb.test.ts` to assert progressive `plugin:end` order + per-plugin file flushes
- [ ] Verify locally: `KUBB_DISABLE_TELEMETRY=1 kubb generate` should now show `Plugins 2/9`, `3/9`, ... incrementing as each plugin completes

https://claude.ai/code/session_01Nv2HR2iawKk7EFXLqFJstv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nv2HR2iawKk7EFXLqFJstv)_