### PR TITLE
feat(unplugin-kubb): virtual kubb:gen modules with HMR

### DIFF
--- a/.changeset/unplugin-virtual-modules.md
+++ b/.changeset/unplugin-virtual-modules.md
@@ -4,7 +4,7 @@
 
 Add a `virtual` option that serves generated code as in-memory `kubb:` modules with hot reload.
 
-With `virtual: true`, generation runs into memory instead of writing files to disk, so the output directory stays empty and the source tree keeps no generated code. Import the root barrel from `kubb`, or a single file with `kubb:<path>` relative to the output path. Editing the input spec triggers a Vite HMR update for the modules that changed, with no page reload. Other bundlers still resolve the virtual modules but do not hot-reload them.
+With `virtual: true`, generation runs into memory instead of writing files to disk, so the output directory stays empty and the source tree keeps no generated code. Import the root barrel from `kubb:gen`, or a single file with `kubb:gen/<path>` relative to the output path. The `kubb:gen` namespace keeps these imports separate from the real `kubb` package. Editing the input spec triggers a Vite HMR update for the modules that changed, with no page reload. Other bundlers still resolve the virtual modules but do not hot-reload them.
 
 ```ts
 import kubb from 'unplugin-kubb/vite'

--- a/.changeset/unplugin-virtual-modules.md
+++ b/.changeset/unplugin-virtual-modules.md
@@ -1,0 +1,29 @@
+---
+"unplugin-kubb": minor
+---
+
+Add a `virtual` option that serves generated code as in-memory `kubb:` modules with hot reload.
+
+With `virtual: true`, generation runs into memory instead of writing files to disk, so the output directory stays empty and the source tree keeps no generated code. Import the root barrel from `kubb`, or a single file with `kubb:<path>` relative to the output path. Editing the input spec triggers a Vite HMR update for the modules that changed, with no page reload. Other bundlers still resolve the virtual modules but do not hot-reload them.
+
+```ts
+import kubb from 'unplugin-kubb/vite'
+
+export default defineConfig({
+  plugins: [
+    kubb({
+      virtual: true,
+      config: {
+        input: { path: './petstore.yaml' },
+        output: { path: './gen' },
+      },
+    }),
+  ],
+})
+```
+
+Because nothing is written to disk, the modules are typed loosely as `any`. Reference the ambient declarations once so the editor stops flagging the imports:
+
+```ts
+/// <reference types="unplugin-kubb/virtual" />
+```

--- a/packages/unplugin-kubb/README.md
+++ b/packages/unplugin-kubb/README.md
@@ -108,7 +108,7 @@ type Options = {
 
 ### virtual
 
-Serve the generated code as in-memory `kubb:` virtual modules instead of writing it to disk, and hot-reload it when the input spec changes. Generation runs into memory, so the output directory stays empty and your source tree keeps no generated files. Defaults to `false`.
+Serve the generated code as in-memory `kubb:gen` virtual modules instead of writing it to disk, and hot-reload it when the input spec changes. Generation runs into memory, so the output directory stays empty and your source tree keeps no generated files. The `kubb:gen` namespace keeps these imports separate from the real `kubb` package. Defaults to `false`.
 
 ```typescript
 import kubb from 'unplugin-kubb/vite'
@@ -126,11 +126,11 @@ export default defineConfig({
 })
 ```
 
-Import the root barrel from `kubb`, or a single file with `kubb:<path>` relative to the output path:
+Import the root barrel from `kubb:gen`, or a single file with `kubb:gen/<path>` relative to the output path:
 
 ```typescript
-import { getPets } from 'kubb'
-import { getPetById } from 'kubb:client/getPetById.ts'
+import { getPets } from 'kubb:gen'
+import { getPetById } from 'kubb:gen/client/getPetById.ts'
 ```
 
 Editing the input spec triggers a Vite HMR update for the modules that changed, with no page reload. Other bundlers still resolve the virtual modules but do not hot-reload them.

--- a/packages/unplugin-kubb/README.md
+++ b/packages/unplugin-kubb/README.md
@@ -101,8 +101,44 @@ Define the options for Kubb.
 
 ```typescript [Options]
 type Options = {
-  config: UserConfig
+  config?: UserConfig
+  virtual?: boolean
 }
+```
+
+### virtual
+
+Serve the generated code as in-memory `kubb:` virtual modules instead of writing it to disk, and hot-reload it when the input spec changes. Generation runs into memory, so the output directory stays empty and your source tree keeps no generated files. Defaults to `false`.
+
+```typescript
+import kubb from 'unplugin-kubb/vite'
+
+export default defineConfig({
+  plugins: [
+    kubb({
+      virtual: true,
+      config: {
+        input: { path: './petstore.yaml' },
+        output: { path: './gen' },
+      },
+    }),
+  ],
+})
+```
+
+Import the root barrel from `kubb`, or a single file with `kubb:<path>` relative to the output path:
+
+```typescript
+import { getPets } from 'kubb'
+import { getPetById } from 'kubb:client/getPetById.ts'
+```
+
+Editing the input spec triggers a Vite HMR update for the modules that changed, with no page reload. Other bundlers still resolve the virtual modules but do not hot-reload them.
+
+Because nothing is written to disk, there is no file to type against and the modules are typed loosely as `any`. Reference the ambient declarations once so the editor stops flagging the imports:
+
+```typescript
+/// <reference types="unplugin-kubb/virtual" />
 ```
 
 ## Supporting Kubb

--- a/packages/unplugin-kubb/package.json
+++ b/packages/unplugin-kubb/package.json
@@ -27,6 +27,7 @@
   "files": [
     "src",
     "dist",
+    "virtual.d.ts",
     "!/**/**.test.**",
     "!/**/__tests__/**",
     "!/**/__snapshots__/**"
@@ -93,7 +94,10 @@
       "import": "./dist/webpack.js",
       "require": "./dist/webpack.cjs"
     },
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./virtual": {
+      "types": "./virtual.d.ts"
+    }
   },
   "publishConfig": {
     "access": "public",

--- a/packages/unplugin-kubb/src/types.ts
+++ b/packages/unplugin-kubb/src/types.ts
@@ -5,4 +5,16 @@ export type Options = {
    * Kubb config passed to the unplugin entry point.
    */
   config?: UserConfig
+  /**
+   * Serve generated code as in-memory `kubb:` virtual modules instead of writing it to disk, and
+   * hot-reload it when the input spec changes (Vite only). Import the root barrel from `kubb`, or a
+   * single file via `kubb:<path>` (relative to the output path).
+   *
+   * Generation runs into memory, so the output directory stays empty. Other bundlers still resolve
+   * the virtual modules but do not hot-reload them. Types are loosely typed in this mode; see the
+   * `unplugin-kubb/virtual` ambient declaration.
+   *
+   * @default false
+   */
+  virtual?: boolean
 }

--- a/packages/unplugin-kubb/src/types.ts
+++ b/packages/unplugin-kubb/src/types.ts
@@ -6,9 +6,9 @@ export type Options = {
    */
   config?: UserConfig
   /**
-   * Serve generated code as in-memory `kubb:` virtual modules instead of writing it to disk, and
-   * hot-reload it when the input spec changes (Vite only). Import the root barrel from `kubb`, or a
-   * single file via `kubb:<path>` (relative to the output path).
+   * Serve generated code as in-memory `kubb:gen` virtual modules instead of writing it to disk, and
+   * hot-reload it when the input spec changes (Vite only). Import the root barrel from `kubb:gen`, or
+   * a single file via `kubb:gen/<path>` (relative to the output path).
    *
    * Generation runs into memory, so the output directory stays empty. Other bundlers still resolve
    * the virtual modules but do not hot-reload them. Types are loosely typed in this mode; see the

--- a/packages/unplugin-kubb/src/unpluginFactory.test.ts
+++ b/packages/unplugin-kubb/src/unpluginFactory.test.ts
@@ -177,7 +177,8 @@ describe('unpluginFactory', () => {
     await pluginOptions.buildStart?.call(createBuildContext())
 
     const resolveId = pluginOptions.resolveId
-    const resolved = typeof resolveId === 'function' ? await resolveId.call(createBuildContext(), 'kubb:component.tsx', undefined, { isEntry: false }) : 'not-a-function'
+    const resolved =
+      typeof resolveId === 'function' ? await resolveId.call(createBuildContext(), 'kubb:component.tsx', undefined, { isEntry: false }) : 'not-a-function'
     expect(resolved).toBeNull()
   })
 

--- a/packages/unplugin-kubb/src/unpluginFactory.test.ts
+++ b/packages/unplugin-kubb/src/unpluginFactory.test.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import { createMockedAdapter } from '@kubb/core/mocks'
 import { ast, definePlugin, type Storage, type UserConfig } from '@kubb/core'
 import { describe, expect, test, vi } from 'vitest'
-import type { UnpluginBuildContext } from 'unplugin'
+import type { UnpluginBuildContext, UnpluginContext } from 'unplugin'
 import nuxtModule from './nuxt.ts'
 import { unpluginFactory } from './unpluginFactory.ts'
 import vite from './vite.ts'
@@ -18,12 +18,16 @@ function getPluginOptions(options: KubbUnpluginOptions) {
   return options
 }
 
-function createBuildContext(): UnpluginBuildContext {
+function createBuildContext(): UnpluginBuildContext & UnpluginContext {
   return {
     addWatchFile: vi.fn(),
     emitFile: vi.fn(),
     getWatchFiles: vi.fn(() => []),
     parse: vi.fn(),
+    error: vi.fn((reason) => {
+      throw typeof reason === 'string' ? new Error(reason) : reason
+    }),
+    warn: vi.fn(),
   }
 }
 
@@ -124,6 +128,57 @@ describe('unpluginFactory', () => {
     await pluginOptions.buildStart?.call(createBuildContext())
 
     expect(clear).toHaveBeenCalledWith(path.resolve(root, './gen'))
+  })
+
+  test('serves generated files as kubb: virtual modules', async () => {
+    const file = ast.createFile({
+      path: 'gen/component.tsx',
+      baseName: 'component.tsx',
+      imports: [ast.createImport({ name: ['jsx'], path: 'react/jsx-runtime' })],
+      sources: [ast.createSource({ nodes: [ast.createText('export const Component = jsx("div", {})')] })],
+    })
+    const plugin = definePlugin(() => ({
+      name: 'plugin',
+      hooks: {
+        'kubb:plugin:setup'(ctx) {
+          ctx.injectFile(file)
+        },
+      },
+    }))()
+    const config = {
+      input: { path: 'https://example.com/openapi.json' },
+      output: { path: './gen' },
+      adapter: createMockedAdapter(),
+      plugins: [plugin],
+    } satisfies UserConfig
+    const pluginOptions = getPluginOptions(unpluginFactory({ config, virtual: true }, { framework: 'vite' }))
+
+    await pluginOptions.buildStart?.call(createBuildContext())
+
+    const resolveId = pluginOptions.resolveId
+    const load = pluginOptions.load
+    const resolved = typeof resolveId === 'function' ? await resolveId.call(createBuildContext(), 'kubb:component.tsx', undefined, { isEntry: false }) : null
+    expect(resolved).toBe('\0kubb:component.tsx')
+
+    const loaded = typeof load === 'function' && typeof resolved === 'string' ? await load.call(createBuildContext(), resolved) : null
+    expect(loaded).toMatchObject({ code: expect.stringContaining('react/jsx-runtime') })
+  })
+
+  test('does not resolve virtual modules when virtual mode is off', async () => {
+    const { storage } = createMemoryStorage()
+    const config = {
+      input: { path: 'https://example.com/openapi.json' },
+      output: { path: './gen' },
+      adapter: createMockedAdapter(),
+      storage,
+    } satisfies UserConfig
+    const pluginOptions = getPluginOptions(unpluginFactory({ config }, { framework: 'vite' }))
+
+    await pluginOptions.buildStart?.call(createBuildContext())
+
+    const resolveId = pluginOptions.resolveId
+    const resolved = typeof resolveId === 'function' ? await resolveId.call(createBuildContext(), 'kubb:component.tsx', undefined, { isEntry: false }) : 'not-a-function'
+    expect(resolved).toBeNull()
   })
 
   test('fails the host build when generation fails', async () => {

--- a/packages/unplugin-kubb/src/unpluginFactory.test.ts
+++ b/packages/unplugin-kubb/src/unpluginFactory.test.ts
@@ -130,7 +130,7 @@ describe('unpluginFactory', () => {
     expect(clear).toHaveBeenCalledWith(path.resolve(root, './gen'))
   })
 
-  test('serves generated files as kubb: virtual modules', async () => {
+  test('serves generated files as kubb:gen virtual modules', async () => {
     const file = ast.createFile({
       path: 'gen/component.tsx',
       baseName: 'component.tsx',
@@ -157,8 +157,9 @@ describe('unpluginFactory', () => {
 
     const resolveId = pluginOptions.resolveId
     const load = pluginOptions.load
-    const resolved = typeof resolveId === 'function' ? await resolveId.call(createBuildContext(), 'kubb:component.tsx', undefined, { isEntry: false }) : null
-    expect(resolved).toBe('\0kubb:component.tsx')
+    const resolved =
+      typeof resolveId === 'function' ? await resolveId.call(createBuildContext(), 'kubb:gen/component.tsx', undefined, { isEntry: false }) : null
+    expect(resolved).toBe('\0kubb:gen/component.tsx')
 
     const loaded = typeof load === 'function' && typeof resolved === 'string' ? await load.call(createBuildContext(), resolved) : null
     expect(loaded).toMatchObject({ code: expect.stringContaining('react/jsx-runtime') })
@@ -178,7 +179,7 @@ describe('unpluginFactory', () => {
 
     const resolveId = pluginOptions.resolveId
     const resolved =
-      typeof resolveId === 'function' ? await resolveId.call(createBuildContext(), 'kubb:component.tsx', undefined, { isEntry: false }) : 'not-a-function'
+      typeof resolveId === 'function' ? await resolveId.call(createBuildContext(), 'kubb:gen/component.tsx', undefined, { isEntry: false }) : 'not-a-function'
     expect(resolved).toBeNull()
   })
 

--- a/packages/unplugin-kubb/src/unpluginFactory.ts
+++ b/packages/unplugin-kubb/src/unpluginFactory.ts
@@ -1,23 +1,38 @@
+import { resolve } from 'node:path'
 import process from 'node:process'
-import { AsyncEventEmitter } from '@internals/utils'
+import { AsyncEventEmitter, URLPath } from '@internals/utils'
 import { adapterOas } from '@kubb/adapter-oas'
-import { type Config, createKubb, Diagnostics, type KubbHooks } from '@kubb/core'
+import { type Config, createKubb, Diagnostics, fsCache, type KubbHooks, memoryStorage } from '@kubb/core'
 import { middlewareBarrel, middlewareBarrelName } from '@kubb/middleware-barrel'
 import { parserTs, parserTsx } from '@kubb/parser-ts'
 import type { UnpluginFactory } from 'unplugin'
 import { version as unpluginVersion } from '../package.json'
 import type { Options } from './types.ts'
+import { buildVirtualStore, diffStores, loadVirtual, resolveVirtual, toResolvedId, type VirtualStore } from './virtual.ts'
 
 type RollupContext = {
   info?: (message: string) => void
   warn?: (message: string) => void
   error?: (message: string) => void
+  addWatchFile?: (id: string) => void
+}
+
+// The slice of the Vite dev server we use, kept loose so we don't pin a Vite version.
+type ViteServerLike = {
+  moduleGraph?: { getModuleById?: (id: string) => unknown }
+  reloadModule?: (mod: unknown) => unknown
 }
 
 export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, meta) => {
   const name = 'unplugin-kubb' as const
   const hooks = new AsyncEventEmitter<KubbHooks>()
   const isVite = meta.framework === 'vite'
+  const virtual = !!options?.virtual
+
+  let store: VirtualStore | null = null
+  let inputPath: string | null = null
+  let server: ViteServerLike | null = null
+  let regenerating: Promise<void> | null = null
 
   hooks.on('kubb:lifecycle:start', ({ version }) => {
     console.log(`Kubb Unplugin ${version} 🧩`)
@@ -45,12 +60,6 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, m
     console.log(`✓ ${plugin.name} completed in ${durationStr}`)
   })
 
-  hooks.on('kubb:files:processing:end', () => {
-    const text = '✓ Files written successfully'
-
-    console.log(text)
-  })
-
   hooks.on('kubb:generation:end', ({ config, status, diagnostics }) => {
     console.log(config.name ? `✓ Generation completed for ${config.name}` : '✓ Generation completed')
 
@@ -67,11 +76,11 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, m
     )
   })
 
-  async function runBuild(ctx: RollupContext) {
-    if (!options?.config) {
-      ;(ctx.error ?? console.error)(`[${name}] Config is not set`)
-      return
-    }
+  // Builds the resolved Kubb config plus the output root and the spec path to watch. Mirrors the
+  // `defineConfig` defaults (adapter, parsers, middleware, output, cache) and, in virtual mode,
+  // forces `memoryStorage` so nothing is written to disk.
+  function buildConfig(): { userConfig: Config; outputRoot: string; inputPath: string | null } | null {
+    if (!options?.config) return null
 
     const middleware = options.config.middleware?.length ? options.config.middleware : [middlewareBarrel()]
     const hasBarrelMiddleware = middleware.some((m) => m.name === middlewareBarrelName)
@@ -79,43 +88,53 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, m
     if (hasBarrelMiddleware && output.barrel === undefined) {
       output.barrel = { type: 'named' }
     }
-    if (output.format === undefined) {
-      output.format = false
-    }
-    if (output.lint === undefined) {
-      output.lint = false
-    }
+    if (output.format === undefined) output.format = false
+    if (output.lint === undefined) output.lint = false
 
-    const config = {
+    const storage = virtual ? memoryStorage() : options.config.storage
+
+    const userConfig = {
       ...options.config,
       adapter: options.config.adapter ?? adapterOas(),
       parsers: options.config.parsers?.length ? options.config.parsers : [parserTs, parserTsx],
       middleware,
       output,
-    }
-    const hrStart = process.hrtime()
+      cache: options.config.cache === undefined ? fsCache() : options.config.cache,
+      ...(storage ? { storage } : {}),
+    } as Config
 
+    const root = userConfig.root || process.cwd()
+    const input = userConfig.input
+    const resolvedInput = input && 'path' in input && !new URLPath(input.path).isURL ? resolve(root, input.path) : null
+
+    return { userConfig, outputRoot: resolve(root, output.path), inputPath: resolvedInput }
+  }
+
+  // Runs one generation pass. Returns the new virtual store (or `null` when not virtual or on
+  // failure) without mutating shared state, so callers decide whether to swap it in.
+  async function generate(): Promise<{ ok: boolean; nextStore: VirtualStore | null; message?: string; cause?: Error }> {
+    const resolved = buildConfig()
+    if (!resolved) {
+      return { ok: false, nextStore: null, message: 'Config is not set' }
+    }
+    inputPath = resolved.inputPath
+
+    const hrStart = process.hrtime()
     await hooks.emit('kubb:lifecycle:start', { version: unpluginVersion })
 
-    const userConfig = config as Config
-
-    const kubb = createKubb(userConfig, { hooks })
+    const kubb = createKubb(resolved.userConfig, { hooks })
     await kubb.setup()
-
-    const resolvedConfig = kubb.config ?? userConfig
+    const resolvedConfig = kubb.config ?? resolved.userConfig
 
     await hooks.emit('kubb:generation:start', { config: resolvedConfig })
 
     const { diagnostics, files, storage } = await kubb.safeBuild()
-
     const hasFailures = Diagnostics.hasError(diagnostics)
 
     // Surface every problem by severity. Unplugin has no diagnostic renderer, so route
     // errors/warnings/info to the channels it does listen on. Non-problem diagnostics are skipped.
     for (const diagnostic of diagnostics) {
-      if (!Diagnostics.isProblem(diagnostic)) {
-        continue
-      }
+      if (!Diagnostics.isProblem(diagnostic)) continue
       if (diagnostic.severity === 'error') {
         hooks.emit('kubb:error', { error: diagnostic.cause ?? new Error(diagnostic.message) })
       } else if (diagnostic.severity === 'warning') {
@@ -133,29 +152,79 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, m
       status: hasFailures ? 'failed' : 'success',
       hrStart,
     })
-
     await hooks.emit('kubb:lifecycle:end')
 
     if (hasFailures) {
       const failedCount = Diagnostics.failedPlugins(diagnostics).length
       const firstError = diagnostics.filter(Diagnostics.isProblem).find((diagnostic) => diagnostic.severity === 'error')
       const message = failedCount > 0 ? `Build Error with ${failedCount} failed plugins` : (firstError?.message ?? 'Build failed')
-      if (ctx.error) {
-        ctx.error(`[${name}] ${message}`)
-        return
-      }
-
-      throw new Error(`[${name}] ${message}`, { cause: firstError?.cause })
+      return { ok: false, nextStore: null, message, cause: firstError?.cause }
     }
+
+    const nextStore = virtual ? await buildVirtualStore({ storage, outputRoot: resolved.outputRoot }) : null
+    return { ok: true, nextStore }
+  }
+
+  // Regenerates after the spec changes and pushes a targeted HMR update for the changed modules,
+  // keeping the last good store when generation fails.
+  async function regenerate(): Promise<void> {
+    if (regenerating) return regenerating
+    regenerating = (async () => {
+      try {
+        const result = await generate()
+        if (!result.nextStore) return
+        const { changed, removed } = diffStores(store, result.nextStore)
+        store = result.nextStore
+        if (!server) return
+        for (const relativePath of [...changed, ...removed]) {
+          const mod = server.moduleGraph?.getModuleById?.(toResolvedId(relativePath))
+          if (mod) server.reloadModule?.(mod)
+        }
+      } finally {
+        regenerating = null
+      }
+    })()
+    return regenerating
   }
 
   return {
     name,
     enforce: 'pre',
-    apply: isVite ? 'build' : undefined,
+    // Virtual mode must also run in dev (Vite serve), where HMR lives.
+    apply: virtual ? undefined : isVite ? 'build' : undefined,
     async buildStart() {
-      await runBuild(this as unknown as RollupContext)
+      const ctx = this as unknown as RollupContext
+      const result = await generate()
+      if (result.nextStore) store = result.nextStore
+      if (inputPath) ctx.addWatchFile?.(inputPath)
+
+      if (!result.ok) {
+        const message = `[${name}] ${result.message ?? 'Build failed'}`
+        if (ctx.error) {
+          ctx.error(message)
+          return
+        }
+        throw new Error(message, { cause: result.cause })
+      }
     },
-    vite: {},
+    resolveId(id, importer) {
+      if (!virtual || !store) return null
+      return resolveVirtual({ id, importer: importer ?? undefined, store })
+    },
+    load(id) {
+      if (!virtual || !store) return null
+      const code = loadVirtual({ id, store })
+      return code === null ? null : { code, map: null }
+    },
+    vite: {
+      configureServer(viteServer) {
+        server = viteServer as unknown as ViteServerLike
+      },
+      async hotUpdate(update) {
+        if (!virtual || update.file !== inputPath) return
+        await regenerate()
+        return []
+      },
+    },
   }
 }

--- a/packages/unplugin-kubb/src/unpluginFactory.ts
+++ b/packages/unplugin-kubb/src/unpluginFactory.ts
@@ -2,7 +2,7 @@ import { resolve } from 'node:path'
 import process from 'node:process'
 import { AsyncEventEmitter, URLPath } from '@internals/utils'
 import { adapterOas } from '@kubb/adapter-oas'
-import { type Config, createKubb, Diagnostics, fsCache, type KubbHooks, memoryStorage } from '@kubb/core'
+import { type Config, createKubb, Diagnostics, fsCache, type KubbHooks, memoryStorage, type ProblemDiagnostic } from '@kubb/core'
 import { middlewareBarrel, middlewareBarrelName } from '@kubb/middleware-barrel'
 import { parserTs, parserTsx } from '@kubb/parser-ts'
 import type { UnpluginFactory } from 'unplugin'
@@ -156,7 +156,7 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, m
 
     if (hasFailures) {
       const failedCount = Diagnostics.failedPlugins(diagnostics).length
-      const firstError = diagnostics.filter(Diagnostics.isProblem).find((diagnostic) => diagnostic.severity === 'error')
+      const firstError = diagnostics.find((diagnostic): diagnostic is ProblemDiagnostic => Diagnostics.isProblem(diagnostic) && diagnostic.severity === 'error')
       const message = failedCount > 0 ? `Build Error with ${failedCount} failed plugins` : (firstError?.message ?? 'Build failed')
       return { ok: false, nextStore: null, message, cause: firstError?.cause }
     }
@@ -173,10 +173,10 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, m
       try {
         const result = await generate()
         if (!result.nextStore) return
-        const { changed, removed } = diffStores(store, result.nextStore)
+        const affected = diffStores(store, result.nextStore)
         store = result.nextStore
         if (!server) return
-        for (const relativePath of [...changed, ...removed]) {
+        for (const relativePath of affected) {
           const mod = server.moduleGraph?.getModuleById?.(toResolvedId(relativePath))
           if (mod) server.reloadModule?.(mod)
         }

--- a/packages/unplugin-kubb/src/virtual.test.ts
+++ b/packages/unplugin-kubb/src/virtual.test.ts
@@ -70,16 +70,16 @@ describe('resolveVirtual', () => {
     'client/getPet.ts': 'getPet',
   })
 
-  test('maps the bare entry to the root barrel', () => {
-    expect(resolveVirtual({ id: 'kubb', importer: undefined, store })).toBe(toResolvedId('index.ts'))
+  test('maps the kubb:gen entry to the root barrel', () => {
+    expect(resolveVirtual({ id: 'kubb:gen', importer: undefined, store })).toBe(toResolvedId('index.ts'))
   })
 
-  test('returns null for the bare entry when no barrel exists', () => {
-    expect(resolveVirtual({ id: 'kubb', importer: undefined, store: makeStore({ 'models/Pet.ts': 'pet' }, null) })).toBeNull()
+  test('returns null for the kubb:gen entry when no barrel exists', () => {
+    expect(resolveVirtual({ id: 'kubb:gen', importer: undefined, store: makeStore({ 'models/Pet.ts': 'pet' }, null) })).toBeNull()
   })
 
-  test('resolves an explicit kubb: file id', () => {
-    expect(resolveVirtual({ id: 'kubb:models/Pet.ts', importer: undefined, store })).toBe(toResolvedId('models/Pet.ts'))
+  test('resolves an explicit kubb:gen file id', () => {
+    expect(resolveVirtual({ id: 'kubb:gen/models/Pet.ts', importer: undefined, store })).toBe(toResolvedId('models/Pet.ts'))
   })
 
   test('resolves a relative import between two virtual modules', () => {
@@ -97,7 +97,7 @@ describe('resolveVirtual', () => {
   })
 
   test('returns null for an unknown virtual file', () => {
-    expect(resolveVirtual({ id: 'kubb:does/not/exist.ts', importer: undefined, store })).toBeNull()
+    expect(resolveVirtual({ id: 'kubb:gen/does/not/exist.ts', importer: undefined, store })).toBeNull()
   })
 })
 
@@ -119,23 +119,23 @@ describe('loadVirtual', () => {
 })
 
 describe('diffStores', () => {
-  test('reports every file as changed when there is no previous store', () => {
+  test('reports every file as affected when there is no previous store', () => {
     const next = makeStore({ 'a.ts': '1', 'b.ts': '2' })
 
-    expect(diffStores(null, next)).toStrictEqual({ changed: ['a.ts', 'b.ts'], removed: [] })
+    expect(diffStores(null, next)).toStrictEqual(new Set(['a.ts', 'b.ts']))
   })
 
   test('reports only files whose content changed', () => {
     const prev = makeStore({ 'a.ts': '1', 'b.ts': '2' })
     const next = makeStore({ 'a.ts': '1', 'b.ts': '2-updated' })
 
-    expect(diffStores(prev, next)).toStrictEqual({ changed: ['b.ts'], removed: [] })
+    expect(diffStores(prev, next)).toStrictEqual(new Set(['b.ts']))
   })
 
-  test('reports files that vanished as removed', () => {
+  test('reports files that vanished as affected', () => {
     const prev = makeStore({ 'a.ts': '1', 'b.ts': '2' })
     const next = makeStore({ 'a.ts': '1' })
 
-    expect(diffStores(prev, next)).toStrictEqual({ changed: [], removed: ['b.ts'] })
+    expect(diffStores(prev, next)).toStrictEqual(new Set(['b.ts']))
   })
 })

--- a/packages/unplugin-kubb/src/virtual.test.ts
+++ b/packages/unplugin-kubb/src/virtual.test.ts
@@ -1,0 +1,141 @@
+import path from 'node:path'
+import type { Storage } from '@kubb/core'
+import { describe, expect, test } from 'vitest'
+import { buildVirtualStore, candidateKeys, diffStores, fromResolvedId, loadVirtual, resolveVirtual, toResolvedId, type VirtualStore } from './virtual.ts'
+
+function createStorage(files: Record<string, string>): Storage {
+  const store = new Map(Object.entries(files))
+  return {
+    name: 'memory',
+    async hasItem(key) {
+      return store.has(key)
+    },
+    async getItem(key) {
+      return store.get(key) ?? null
+    },
+    async setItem(key, value) {
+      store.set(key, value)
+    },
+    async removeItem(key) {
+      store.delete(key)
+    },
+    async getKeys(base) {
+      const keys = [...store.keys()]
+      return base ? keys.filter((key) => key.startsWith(base)) : keys
+    },
+    async clear() {
+      store.clear()
+    },
+  }
+}
+
+const outputRoot = path.resolve('/project/gen')
+
+function makeStore(map: Record<string, string>, barrelRelPath: string | null = 'index.ts'): VirtualStore {
+  return { map: new Map(Object.entries(map)), barrelRelPath }
+}
+
+describe('buildVirtualStore', () => {
+  test('keys files by their output-relative POSIX path and detects the barrel', async () => {
+    const storage = createStorage({
+      [path.join(outputRoot, 'index.ts')]: 'export * from "./Pet.ts"',
+      [path.join(outputRoot, 'models', 'Pet.ts')]: 'export type Pet = {}',
+    })
+
+    const store = await buildVirtualStore({ storage, outputRoot })
+
+    expect([...store.map.keys()].sort()).toStrictEqual(['index.ts', 'models/Pet.ts'])
+    expect(store.barrelRelPath).toBe('index.ts')
+  })
+
+  test('reports no barrel when none was generated', async () => {
+    const storage = createStorage({ [path.join(outputRoot, 'models', 'Pet.ts')]: 'export type Pet = {}' })
+
+    const store = await buildVirtualStore({ storage, outputRoot })
+
+    expect(store.barrelRelPath).toBeNull()
+  })
+})
+
+describe('candidateKeys', () => {
+  test('covers both the bare specifier and the ones that carry a file extension', () => {
+    expect(candidateKeys('./Pet')).toStrictEqual(['Pet', 'Pet.ts', 'Pet.tsx', 'Pet.js', 'Pet.jsx', 'Pet/index.ts'])
+  })
+})
+
+describe('resolveVirtual', () => {
+  const store = makeStore({
+    'index.ts': 'barrel',
+    'models/Pet.ts': 'pet',
+    'client/getPet.ts': 'getPet',
+  })
+
+  test('maps the bare entry to the root barrel', () => {
+    expect(resolveVirtual({ id: 'kubb', importer: undefined, store })).toBe(toResolvedId('index.ts'))
+  })
+
+  test('returns null for the bare entry when no barrel exists', () => {
+    expect(resolveVirtual({ id: 'kubb', importer: undefined, store: makeStore({ 'models/Pet.ts': 'pet' }, null) })).toBeNull()
+  })
+
+  test('resolves an explicit kubb: file id', () => {
+    expect(resolveVirtual({ id: 'kubb:models/Pet.ts', importer: undefined, store })).toBe(toResolvedId('models/Pet.ts'))
+  })
+
+  test('resolves a relative import between two virtual modules', () => {
+    const importer = toResolvedId('index.ts')
+    expect(resolveVirtual({ id: './models/Pet', importer, store })).toBe(toResolvedId('models/Pet.ts'))
+  })
+
+  test('resolves a relative import that walks up a directory', () => {
+    const importer = toResolvedId('client/getPet.ts')
+    expect(resolveVirtual({ id: '../models/Pet.ts', importer, store })).toBe(toResolvedId('models/Pet.ts'))
+  })
+
+  test('ignores relative imports from non-virtual importers', () => {
+    expect(resolveVirtual({ id: './models/Pet', importer: '/some/real/file.ts', store })).toBeNull()
+  })
+
+  test('returns null for an unknown virtual file', () => {
+    expect(resolveVirtual({ id: 'kubb:does/not/exist.ts', importer: undefined, store })).toBeNull()
+  })
+})
+
+describe('loadVirtual', () => {
+  const store = makeStore({ 'models/Pet.ts': 'export type Pet = {}' })
+
+  test('returns the source for a resolved virtual id', () => {
+    expect(loadVirtual({ id: toResolvedId('models/Pet.ts'), store })).toBe('export type Pet = {}')
+  })
+
+  test('returns null when the id is not virtual', () => {
+    expect(loadVirtual({ id: '/some/real/file.ts', store })).toBeNull()
+  })
+
+  test('round-trips through toResolvedId/fromResolvedId', () => {
+    expect(fromResolvedId(toResolvedId('models/Pet.ts'))).toBe('models/Pet.ts')
+    expect(fromResolvedId('/not/virtual.ts')).toBeNull()
+  })
+})
+
+describe('diffStores', () => {
+  test('reports every file as changed when there is no previous store', () => {
+    const next = makeStore({ 'a.ts': '1', 'b.ts': '2' })
+
+    expect(diffStores(null, next)).toStrictEqual({ changed: ['a.ts', 'b.ts'], removed: [] })
+  })
+
+  test('reports only files whose content changed', () => {
+    const prev = makeStore({ 'a.ts': '1', 'b.ts': '2' })
+    const next = makeStore({ 'a.ts': '1', 'b.ts': '2-updated' })
+
+    expect(diffStores(prev, next)).toStrictEqual({ changed: ['b.ts'], removed: [] })
+  })
+
+  test('reports files that vanished as removed', () => {
+    const prev = makeStore({ 'a.ts': '1', 'b.ts': '2' })
+    const next = makeStore({ 'a.ts': '1' })
+
+    expect(diffStores(prev, next)).toStrictEqual({ changed: [], removed: ['b.ts'] })
+  })
+})

--- a/packages/unplugin-kubb/src/virtual.ts
+++ b/packages/unplugin-kubb/src/virtual.ts
@@ -1,0 +1,94 @@
+import { posix, relative } from 'node:path'
+import type { Storage } from '@kubb/core'
+import { toPosixPath } from '@internals/utils'
+
+/** Bare entry import, mapping to the root barrel. */
+export const VIRTUAL_ENTRY = 'kubb'
+/** Prefix for importing a specific generated file, e.g. `kubb:client/usePets.ts`. */
+export const VIRTUAL_PREFIX = 'kubb:'
+/** Resolved id prefix. The leading null byte marks it virtual so other plugins ignore it. */
+export const RESOLVED_PREFIX = '\0kubb:'
+
+/**
+ * The in-memory generated output served as virtual modules. `map` is keyed by path relative to the
+ * output root (POSIX). `barrelRelPath` is the root barrel that the bare `kubb` import maps to, or
+ * `null` when no barrel was generated.
+ */
+export type VirtualStore = {
+  map: Map<string, string>
+  barrelRelPath: string | null
+}
+
+/** Reads every generated file from `storage` into a store keyed by output-relative POSIX paths. */
+export async function buildVirtualStore({ storage, outputRoot }: { storage: Storage; outputRoot: string }): Promise<VirtualStore> {
+  const map = new Map<string, string>()
+  for (const key of await storage.getKeys()) {
+    const source = await storage.getItem(key)
+    if (source === null) continue
+    map.set(toPosixPath(relative(outputRoot, key)), source)
+  }
+  return { map, barrelRelPath: map.has('index.ts') ? 'index.ts' : null }
+}
+
+/** Candidate Map keys for a specifier, covering both the bare specifier and the ones that carry a file extension. */
+export function candidateKeys(relativePath: string): Array<string> {
+  const base = relativePath.replace(/^\.?\//, '').replace(/\/$/, '')
+  return [base, `${base}.ts`, `${base}.tsx`, `${base}.js`, `${base}.jsx`, `${base}/index.ts`]
+}
+
+export function toResolvedId(relativePath: string): string {
+  return `${RESOLVED_PREFIX}${relativePath}`
+}
+
+export function fromResolvedId(id: string): string | null {
+  return id.startsWith(RESOLVED_PREFIX) ? id.slice(RESOLVED_PREFIX.length) : null
+}
+
+function resolveKey(relativePath: string, store: VirtualStore): string | null {
+  for (const candidate of candidateKeys(relativePath)) {
+    if (store.map.has(candidate)) return toResolvedId(candidate)
+  }
+  return null
+}
+
+/**
+ * Maps an import specifier to a resolved virtual id, or `null` when it isn't ours. Handles the bare
+ * `kubb` entry, explicit `kubb:<file>` ids, and relative imports between already-virtual modules
+ * (how Kubb's generated files reference each other).
+ */
+export function resolveVirtual({ id, importer, store }: { id: string; importer: string | undefined; store: VirtualStore }): string | null {
+  if (id === VIRTUAL_ENTRY) {
+    return store.barrelRelPath ? toResolvedId(store.barrelRelPath) : null
+  }
+  if (id.startsWith(VIRTUAL_PREFIX)) {
+    return resolveKey(id.slice(VIRTUAL_PREFIX.length), store)
+  }
+  if (importer && fromResolvedId(importer) !== null && (id.startsWith('./') || id.startsWith('../'))) {
+    const importerRelative = fromResolvedId(importer)!
+    const target = posix.normalize(posix.join(posix.dirname(importerRelative), id))
+    return resolveKey(target, store)
+  }
+  return null
+}
+
+/** Returns the source for a resolved virtual id, or `null` when the id isn't a known virtual module. */
+export function loadVirtual({ id, store }: { id: string; store: VirtualStore }): string | null {
+  const relativePath = fromResolvedId(id)
+  if (relativePath === null) return null
+  return store.map.get(relativePath) ?? null
+}
+
+/** Relative paths whose content changed or vanished between two stores, for targeted HMR. */
+export function diffStores(prev: VirtualStore | null, next: VirtualStore): { changed: Array<string>; removed: Array<string> } {
+  const changed: Array<string> = []
+  const removed: Array<string> = []
+  for (const [relativePath, source] of next.map) {
+    if (!prev || prev.map.get(relativePath) !== source) changed.push(relativePath)
+  }
+  if (prev) {
+    for (const relativePath of prev.map.keys()) {
+      if (!next.map.has(relativePath)) removed.push(relativePath)
+    }
+  }
+  return { changed, removed }
+}

--- a/packages/unplugin-kubb/src/virtual.ts
+++ b/packages/unplugin-kubb/src/virtual.ts
@@ -2,16 +2,16 @@ import { posix, relative } from 'node:path'
 import type { Storage } from '@kubb/core'
 import { toPosixPath } from '@internals/utils'
 
-/** Bare entry import, mapping to the root barrel. */
-export const VIRTUAL_ENTRY = 'kubb'
-/** Prefix for importing a specific generated file, e.g. `kubb:client/usePets.ts`. */
-export const VIRTUAL_PREFIX = 'kubb:'
+/** Entry import, mapping to the root barrel. Namespaced so it never collides with the real `kubb` package. */
+export const VIRTUAL_ENTRY = 'kubb:gen'
+/** Prefix for importing a specific generated file, e.g. `kubb:gen/client/usePets.ts`. */
+export const VIRTUAL_PREFIX = 'kubb:gen/'
 /** Resolved id prefix. The leading null byte marks it virtual so other plugins ignore it. */
-export const RESOLVED_PREFIX = '\0kubb:'
+export const RESOLVED_PREFIX = '\0kubb:gen/'
 
 /**
  * The in-memory generated output served as virtual modules. `map` is keyed by path relative to the
- * output root (POSIX). `barrelRelPath` is the root barrel that the bare `kubb` import maps to, or
+ * output root (POSIX). `barrelRelPath` is the root barrel that the `kubb:gen` import maps to, or
  * `null` when no barrel was generated.
  */
 export type VirtualStore = {
@@ -52,9 +52,9 @@ function resolveKey(relativePath: string, store: VirtualStore): string | null {
 }
 
 /**
- * Maps an import specifier to a resolved virtual id, or `null` when it isn't ours. Handles the bare
- * `kubb` entry, explicit `kubb:<file>` ids, and relative imports between already-virtual modules
- * (how Kubb's generated files reference each other).
+ * Maps an import specifier to a resolved virtual id, or `null` when it isn't ours. Handles the
+ * `kubb:gen` entry, explicit `kubb:gen/<file>` ids, and relative imports between already-virtual
+ * modules (how Kubb's generated files reference each other).
  */
 export function resolveVirtual({ id, importer, store }: { id: string; importer: string | undefined; store: VirtualStore }): string | null {
   if (id === VIRTUAL_ENTRY) {
@@ -78,17 +78,12 @@ export function loadVirtual({ id, store }: { id: string; store: VirtualStore }):
   return store.map.get(relativePath) ?? null
 }
 
-/** Relative paths whose content changed or vanished between two stores, for targeted HMR. */
-export function diffStores(prev: VirtualStore | null, next: VirtualStore): { changed: Array<string>; removed: Array<string> } {
-  const changed: Array<string> = []
-  const removed: Array<string> = []
-  for (const [relativePath, source] of next.map) {
-    if (!prev || prev.map.get(relativePath) !== source) changed.push(relativePath)
+/** Relative paths whose content changed, appeared, or vanished between two stores, for targeted HMR. */
+export function diffStores(prev: VirtualStore | null, next: VirtualStore): Set<string> {
+  const affected = new Set<string>()
+  const keys = new Set([...(prev?.map.keys() ?? []), ...next.map.keys()])
+  for (const key of keys) {
+    if (prev?.map.get(key) !== next.map.get(key)) affected.add(key)
   }
-  if (prev) {
-    for (const relativePath of prev.map.keys()) {
-      if (!next.map.has(relativePath)) removed.push(relativePath)
-    }
-  }
-  return { changed, removed }
+  return affected
 }

--- a/packages/unplugin-kubb/tsdown.config.ts
+++ b/packages/unplugin-kubb/tsdown.config.ts
@@ -1,12 +1,13 @@
 import { defineConfig, type UserConfig } from 'tsdown'
 
-const entry = ['src/*.ts', '!src/*.test.ts']
+// `virtual.ts` is internal plumbing bundled into the factory; `./virtual` is reserved for the
+// ambient `kubb:` module declarations shipped as `virtual.d.ts`.
+const entry = ['src/*.ts', '!src/*.test.ts', '!src/virtual.ts']
 
 const shared: Partial<UserConfig> = {
   platform: 'node',
   sourcemap: true,
   shims: true,
-  exports: true,
   deps: {
     neverBundle: [/^@kubb\//],
     alwaysBundle: [/@internals/],
@@ -14,6 +15,14 @@ const shared: Partial<UserConfig> = {
   fixedExtension: false,
   outputOptions: {
     keepNames: true,
+  },
+  exports: {
+    // `./virtual` ships only the ambient `kubb:` module declarations, so keep it after tsdown
+    // regenerates the exports map from the build entries.
+    customExports(exports: Record<string, unknown>) {
+      exports['./virtual'] = { types: './virtual.d.ts' }
+      return exports
+    },
   },
 }
 

--- a/packages/unplugin-kubb/virtual.d.ts
+++ b/packages/unplugin-kubb/virtual.d.ts
@@ -1,0 +1,28 @@
+/**
+ * Ambient declarations for the `kubb:` virtual modules that `unplugin-kubb` serves when
+ * `virtual: true` is set. Generation runs in memory, so there is no file on disk to type against
+ * and the modules are typed loosely as `any`. Import the generated symbols by the names Kubb emits.
+ *
+ * Reference this file once in your project so the editor stops flagging the imports, either with a
+ * triple-slash directive in any source or `.d.ts` file:
+ *
+ * ```ts
+ * /// <reference types="unplugin-kubb/virtual" />
+ * ```
+ *
+ * or by adding it to `compilerOptions.types` in your tsconfig:
+ *
+ * ```json
+ * { "compilerOptions": { "types": ["unplugin-kubb/virtual"] } }
+ * ```
+ *
+ * @example
+ * ```ts
+ * import { getPets } from 'kubb'
+ * import { getPetById } from 'kubb:client/getPetById.ts'
+ * ```
+ */
+
+declare module 'kubb'
+
+declare module 'kubb:*'

--- a/packages/unplugin-kubb/virtual.d.ts
+++ b/packages/unplugin-kubb/virtual.d.ts
@@ -1,5 +1,5 @@
 /**
- * Ambient declarations for the `kubb:` virtual modules that `unplugin-kubb` serves when
+ * Ambient declarations for the `kubb:gen` virtual modules that `unplugin-kubb` serves when
  * `virtual: true` is set. Generation runs in memory, so there is no file on disk to type against
  * and the modules are typed loosely as `any`. Import the generated symbols by the names Kubb emits.
  *
@@ -18,11 +18,11 @@
  *
  * @example
  * ```ts
- * import { getPets } from 'kubb'
- * import { getPetById } from 'kubb:client/getPetById.ts'
+ * import { getPets } from 'kubb:gen'
+ * import { getPetById } from 'kubb:gen/client/getPetById.ts'
  * ```
  */
 
-declare module 'kubb'
+declare module 'kubb:gen'
 
-declare module 'kubb:*'
+declare module 'kubb:gen/*'


### PR DESCRIPTION
## What

Adds an opt-in `virtual` option to `unplugin-kubb` ([ClickUp 869cv8mv3](https://app.clickup.com/t/869cv8mv3)). With `virtual: true`, generation runs into `memoryStorage` instead of writing files to disk, so the output directory stays empty and the source tree keeps no generated code.

```ts
import kubb from 'unplugin-kubb/vite'

export default defineConfig({
  plugins: [kubb({ virtual: true, config: { input: { path: './petstore.yaml' }, output: { path: './gen' } } })],
})
```

```ts
import { getPets } from 'kubb:gen'
import { getPetById } from 'kubb:gen/client/getPetById.ts'
```

## How

- Import the root barrel from `kubb:gen`, or a single file with `kubb:gen/<path>` relative to the output path. The `kubb:gen` namespace (Astro-style, like `astro:content`) keeps these imports separate from the real published `kubb` package. Relative cross-imports between generated modules resolve against the candidate extensions Kubb emits.
- On Vite, editing the input spec regenerates and pushes a targeted HMR update for only the modules that changed (via `configureServer` + `hotUpdate`), with no page reload. Other bundlers still resolve the virtual modules but do not hot-reload them.
- The modules are typed loosely as `any` through the ambient `unplugin-kubb/virtual` declarations, since there is no file on disk to type against. Reference them once with `/// <reference types="unplugin-kubb/virtual" />`.

## Stacked on the cache PR

This builds on #3469 — virtual mode wires the `fsCache()` default and forces `memoryStorage`, so it imports `fsCache` from `@kubb/core` added there. The base of this PR is the cache branch; retarget to `main` once #3469 merges.

## Testing

- `virtual.test.ts` — store building, specifier resolution (bare entry, explicit file, relative cross-import, miss), load round-trip, and the HMR diff.
- `unpluginFactory.test.ts` — virtual `buildStart` + `resolveId`/`load`, and that virtual resolution stays off by default.

Typecheck, lint, 23 tests, build, oxfmt, and cspell all clean. A changeset is included (`minor` for `unplugin-kubb`).

https://claude.ai/code/session_01A1c14qUv6dU2KFPd6JTEzi

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1c14qUv6dU2KFPd6JTEzi)_