### PR TITLE
refactor: adopt native Node 22 / ES2024 features in core

### DIFF
--- a/.changeset/modernize-node-22-natives.md
+++ b/.changeset/modernize-node-22-natives.md
@@ -1,0 +1,5 @@
+---
+'@kubb/core': patch
+---
+
+Adopt native Node 22 / ES2024 features: order plugins through `Set`-based dependency lookups in `KubbDriver`, and replace `Promise` resolver boilerplate with `Promise.withResolvers()`. The shared TypeScript config moves to an ES2024 target with the ES2025 collection and iterator libraries to match the Node 22 baseline.

--- a/configs/base.json
+++ b/configs/base.json
@@ -5,7 +5,8 @@
     /* Base Options: */
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "target": "ES2022",
+    "target": "ES2024",
+    "lib": ["es2024", "ES2025.Collection", "ES2025.Iterator", "ESNext.Array", "DOM", "DOM.Iterable"],
     "verbatimModuleSyntax": true,
     "allowJs": true,
     "resolveJsonModule": true,

--- a/packages/adapter-oas/src/adapter.bench.ts
+++ b/packages/adapter-oas/src/adapter.bench.ts
@@ -1,6 +1,5 @@
 import path from 'node:path'
 import { existsSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
 import { bench, describe } from 'vitest'
 import { adapterOas } from './adapter.ts'
 import { parseDocument } from './factory.ts'
@@ -8,10 +7,7 @@ import { parseOas } from './parser.ts'
 import type { Document } from './types.ts'
 import type { AdapterSource } from '@kubb/core'
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
-
-const petStorePath = path.resolve(__dirname, '../mocks/petStore.yaml')
+const petStorePath = path.resolve(import.meta.dirname, '../mocks/petStore.yaml')
 const stripeSpecPath = '/tmp/kubb-stripe-spec3.json'
 const hasStripe = existsSync(stripeSpecPath)
 

--- a/packages/core/src/FileProcessor.test.ts
+++ b/packages/core/src/FileProcessor.test.ts
@@ -201,10 +201,7 @@ describe('FileProcessor — queue: flush', () => {
   })
 
   it('returns before the in-flight batch finishes so the caller can pipeline', async () => {
-    let resolveFirstWrite!: () => void
-    const firstWriteBlocker = new Promise<void>((resolve) => {
-      resolveFirstWrite = resolve
-    })
+    const { promise: firstWriteBlocker, resolve: resolveFirstWrite } = Promise.withResolvers<void>()
     const storage = memoryStorage()
     const realSetItem = storage.setItem.bind(storage)
     storage.setItem = async (path: string, source: string) => {
@@ -226,10 +223,7 @@ describe('FileProcessor — queue: flush', () => {
 
   it('runs in-flight batches one at a time: a second flush waits for the first', async () => {
     const order: Array<string> = []
-    let resolveFirst!: () => void
-    const firstBlocker = new Promise<void>((resolve) => {
-      resolveFirst = resolve
-    })
+    const { promise: firstBlocker, resolve: resolveFirst } = Promise.withResolvers<void>()
     const storage = memoryStorage()
     const realSetItem = storage.setItem.bind(storage)
     storage.setItem = async (path: string, source: string) => {

--- a/packages/core/src/KubbDriver.ts
+++ b/packages/core/src/KubbDriver.ts
@@ -108,9 +108,11 @@ export class KubbDriver {
   async setup() {
     const normalized: Array<NormalizedPlugin> = this.config.plugins.map((rawPlugin) => this.#normalizePlugin(rawPlugin as Plugin))
 
+    const dependenciesByName = new Map(normalized.map((plugin) => [plugin.name, new Set(plugin.dependencies ?? [])]))
+
     normalized.sort((a, b) => {
-      if (b.dependencies?.includes(a.name)) return -1
-      if (a.dependencies?.includes(b.name)) return 1
+      if (dependenciesByName.get(b.name)?.has(a.name)) return -1
+      if (dependenciesByName.get(a.name)?.has(b.name)) return 1
 
       return enforceOrder(a.enforce) - enforceOrder(b.enforce)
     })


### PR DESCRIPTION
## Summary

Modernizes `@kubb/core` to lean on native Node 22 / ES2024 APIs instead of boilerplate, and aligns the TypeScript config with the Node 22 baseline.

- **`KubbDriver`**: plugin ordering now resolves dependencies through `Set`-based lookups (built once) instead of repeated `Array.includes` scans in the sort comparator.
- **`FileProcessor` tests**: replaced the `let resolve` / `new Promise(...)` boilerplate with `Promise.withResolvers()`.
- **`adapter-oas` benchmark**: uses `import.meta.dirname` instead of reconstructing `__dirname` via `fileURLToPath`.
- **tsconfig**: `target` moves to `ES2024` with an explicit `lib` of `es2024` + `ES2025.Collection` / `ES2025.Iterator` / `ESNext.Array` (plus `DOM`). `ES2025.*` is used deliberately over `ESNext.*` so the types expose only collection/iterator APIs that actually ship in Node 22 (avoiding the `Map.getOrInsert` leak from `ESNext.Collection`).

The repo was already modern in most respects — native `node:fs` glob, no lodash — so this is a focused cleanup.

## Verification

- `pnpm build` then `pnpm typecheck` — all 12 packages pass.
- `pnpm test` for `FileProcessor` + `KubbDriver` — 33/33 pass.
- `pnpm lint` and `pnpm format` clean.

A patch changeset is included for `@kubb/core`.


---
_Generated by [Claude Code](https://claude.ai/code/session_0198D2QT3EzcrUtMhdH3zHr3)_