### PR TITLE
fix(plugin-ts): quote enum keys that parse as private identifiers

### DIFF
--- a/.changeset/plugin-ts-quote-private-identifier-enum-keys.md
+++ b/.changeset/plugin-ts-quote-private-identifier-enum-keys.md
@@ -1,0 +1,7 @@
+---
+"@kubb/plugin-ts": patch
+---
+
+Fix `asConst`/`asPascalConst` enums emitting `#`-prefixed values (e.g. hex colours like `#ccff9a`) as unquoted object keys.
+
+`isValidIdentifier` accepted `#`-prefixed names because `ts.parseIsolatedEntityName` parses them as private identifiers. Private identifiers are only valid inside a class body, so using one as an object/property key produced invalid output (`TS18016: Private identifiers are not allowed outside class bodies`). `#`-prefixed names are now treated as non-identifiers and quoted.

--- a/packages/plugin-ts/src/factory.test.ts
+++ b/packages/plugin-ts/src/factory.test.ts
@@ -431,6 +431,28 @@ describe('Code Generation', () => {
       ),
     ).toMatchSnapshot()
   })
+
+  it('should quote enum keys that parse as private identifiers (#-prefixed)', async () => {
+    // A `#`-prefixed name (e.g. a hex colour like `#ccff9a`) parses as a TypeScript
+    // private identifier, which is only valid inside a class body. As an object key it
+    // must be quoted, otherwise the generated `as const` map is a syntax error (TS18016).
+    const output = await formatTS(
+      createEnumDeclaration({
+        type: 'asConst',
+        name: 'labelsColor',
+        typeName: 'LabelsColor',
+        enums: [
+          ['#0099ff', '#0099ff'],
+          ['#ccff9a', '#ccff9a'],
+        ],
+      }),
+    )
+
+    expect(output).toContain("'#0099ff': '#0099ff'")
+    expect(output).toContain("'#ccff9a': '#ccff9a'")
+    // Must not emit a bare `#ccff9a:` key (invalid outside a class body).
+    expect(output).not.toMatch(/(^|[^'])#ccff9a:/)
+  })
 })
 
 describe('Import/Export Sorting Consistency', () => {

--- a/packages/plugin-ts/src/factory.ts
+++ b/packages/plugin-ts/src/factory.ts
@@ -31,6 +31,11 @@ function isValidIdentifier(str: string): boolean {
   if (!str.length || str.trim() !== str) {
     return false
   }
+  // `#`-prefixed names parse as private identifiers, which are only valid inside a class
+  // body. As an object/property key they must be quoted, so treat them as non-identifiers.
+  if (str.startsWith('#')) {
+    return false
+  }
   const node = ts.parseIsolatedEntityName(str, ts.ScriptTarget.Latest)
 
   return !!node && node.kind === ts.SyntaxKind.Identifier && ts.identifierToKeywordKind(node.kind as unknown as ts.Identifier) === undefined


### PR DESCRIPTION
## Summary

`asConst`/`asPascalConst` enums whose values start with `#` (e.g. hex colours like `#ccff9a`) are emitted as **unquoted** object keys, producing invalid TypeScript.

`isValidIdentifier` (in `packages/plugin-ts/src/factory.ts`) treats `#ccff9a` as valid because `ts.parseIsolatedEntityName` parses it as a **private identifier**. Private identifiers are only legal inside a class body, so as an object key it triggers:

```
TS18016: Private identifiers are not allowed outside class bodies.
```

Curiously, `#` + digit (e.g. `#0099ff`) was already quoted (it fails to parse as an identifier), so only `#` + letter regressed — which makes it easy to miss.

## Reproduction

```yaml
LabelsColor:
  type: string
  enum: ["#0099ff", "#ccff9a"]
```

**Before** (`enumType: 'asConst'`):

```ts
export const labelsColor = {
  '#0099ff': '#0099ff',
  #ccff9a: '#ccff9a', // ❌ TS18016
} as const
```

**After:** both keys quoted.

## Fix

Treat `#`-prefixed names as non-identifiers in `isValidIdentifier`, so they are always quoted:

```ts
if (str.startsWith('#')) {
  return false
}
```

## Test

Added a regression test to `factory.test.ts` asserting `#`-prefixed enum keys are quoted. Full suite (`pnpm --filter @kubb/plugin-ts test`) passes.

Targets the `v4` branch (4.37.9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
