### PR TITLE
feat(parser-ts): dedent generated declarations for clean output

### DIFF
--- a/.changeset/parser-ts-dedent-output.md
+++ b/.changeset/parser-ts-dedent-output.md
@@ -1,0 +1,5 @@
+---
+"@kubb/parser-ts": minor
+---
+
+Normalize the indentation of generated declarations so the output reads cleanly before any formatter runs. Raw text and JSX nodes are now dedented to a column-zero baseline when printed, which removes the source indentation that template literals bake into multi-line `const`, `type`, `function`, and arrow-function bodies and stops it from compounding under the structural indent. Top-level declarations in a source are separated by a blank line, and an explicit `<br/>` no longer doubles that gap. A `dedent` helper sits next to `indentLines` for this.

--- a/packages/parser-ts/src/constants.ts
+++ b/packages/parser-ts/src/constants.ts
@@ -1,7 +1,17 @@
 /**
- * Number of spaces used to indent a nested block when pretty-printing.
+ * Character used for a single indent step. Set to `'\t'` to emit tab-indented output.
+ */
+export const INDENT_CHAR = ' '
+
+/**
+ * Number of {@link INDENT_CHAR} repeats that make up one nesting level.
  */
 export const INDENT_SIZE = 2 as const
+
+/**
+ * Indentation unit prepended once per nesting level when pretty-printing.
+ */
+export const INDENT = INDENT_CHAR.repeat(INDENT_SIZE)
 
 /**
  * Matches the trailing `.<ext>` segment of a path (keeps segments like `foo.bar.ts`

--- a/packages/parser-ts/src/utils.test.ts
+++ b/packages/parser-ts/src/utils.test.ts
@@ -88,35 +88,51 @@ describe('indentLines', () => {
 
 describe('dedent', () => {
   it('strips the common leading whitespace shared by every line', () => {
-    expect(dedent('    foo\n      bar')).toBe('foo\n  bar')
+    expect(dedent('    foo\n      bar')).toMatchInlineSnapshot(`
+      "foo
+        bar"
+    `)
   })
 
   it('trims leading and trailing blank lines', () => {
-    expect(dedent('\n\n  foo\n  bar\n\n')).toBe('foo\nbar')
+    expect(dedent('\n\n  foo\n  bar\n\n')).toMatchInlineSnapshot(`
+      "foo
+      bar"
+    `)
   })
 
   it('outdents a single line', () => {
-    expect(dedent('   x')).toBe('x')
+    expect(dedent('   x')).toMatchInlineSnapshot(`"x"`)
   })
 
   it('leaves already-baselined content unchanged', () => {
-    expect(dedent('foo\n  bar')).toBe('foo\n  bar')
+    expect(dedent('foo\n  bar')).toMatchInlineSnapshot(`
+      "foo
+        bar"
+    `)
   })
 
   it('keeps interior blank lines empty', () => {
-    expect(dedent('  foo\n\n  bar')).toBe('foo\n\nbar')
+    expect(dedent('  foo\n\n  bar')).toMatchInlineSnapshot(`
+      "foo
+
+      bar"
+    `)
   })
 
   it('returns empty string for empty input', () => {
-    expect(dedent('')).toBe('')
+    expect(dedent('')).toMatchInlineSnapshot(`""`)
   })
 
   it('returns empty string for whitespace-only input', () => {
-    expect(dedent('   \n  ')).toBe('')
+    expect(dedent('   \n  ')).toMatchInlineSnapshot(`""`)
   })
 
   it('counts a tab as a single indent unit', () => {
-    expect(dedent('\t\tfoo\n\t\t\tbar')).toBe('foo\n\tbar')
+    expect(dedent('\t\tfoo\n\t\t\tbar')).toMatchInlineSnapshot(`
+      "foo
+      	bar"
+    `)
   })
 })
 
@@ -574,7 +590,7 @@ describe('printSource', () => {
 
   it('normalizes a top-level text node with baked-in indentation to column zero', () => {
     const node = createSource({ nodes: [createText('    const x = 1')] })
-    expect(printSource(node)).toBe('const x = 1')
+    expect(printSource(node)).toMatchInlineSnapshot(`"const x = 1"`)
   })
 
   it('does not add an extra blank line for an explicit break', () => {

--- a/packages/parser-ts/src/utils.test.ts
+++ b/packages/parser-ts/src/utils.test.ts
@@ -1,6 +1,7 @@
-import { createArrowFunction, createConst, createFunction, createSource, createText, createType } from '@kubb/ast'
+import { createArrowFunction, createBreak, createConst, createFunction, createSource, createText, createType } from '@kubb/ast'
 import { describe, expect, it } from 'vitest'
 import {
+  dedent,
   formatGenerics,
   formatReturnType,
   getRelativePath,
@@ -82,6 +83,40 @@ describe('indentLines', () => {
 
   it('returns empty string for empty input', () => {
     expect(indentLines('')).toBe('')
+  })
+})
+
+describe('dedent', () => {
+  it('strips the common leading whitespace shared by every line', () => {
+    expect(dedent('    foo\n      bar')).toBe('foo\n  bar')
+  })
+
+  it('trims leading and trailing blank lines', () => {
+    expect(dedent('\n\n  foo\n  bar\n\n')).toBe('foo\nbar')
+  })
+
+  it('outdents a single line', () => {
+    expect(dedent('   x')).toBe('x')
+  })
+
+  it('leaves already-baselined content unchanged', () => {
+    expect(dedent('foo\n  bar')).toBe('foo\n  bar')
+  })
+
+  it('keeps interior blank lines empty', () => {
+    expect(dedent('  foo\n\n  bar')).toBe('foo\n\nbar')
+  })
+
+  it('returns empty string for empty input', () => {
+    expect(dedent('')).toBe('')
+  })
+
+  it('returns empty string for whitespace-only input', () => {
+    expect(dedent('   \n  ')).toBe('')
+  })
+
+  it('counts a tab as a single indent unit', () => {
+    expect(dedent('\t\tfoo\n\t\t\tbar')).toBe('foo\n\tbar')
   })
 })
 
@@ -199,6 +234,24 @@ describe('printConst', () => {
     })
     expect(printConst(node)).toBe('/**\n * @description A pet\n */\nconst pet = {}')
   })
+
+  it('normalizes a multi-line value authored with baked-in indentation', () => {
+    const node = createConst({
+      name: 'pet',
+      export: true,
+      nodes: [createText('\n    {\n      foo: 1,\n      bar: 2,\n    }\n  ')],
+    })
+    expect(printConst(node)).toBe('export const pet = {\n  foo: 1,\n  bar: 2,\n}')
+  })
+
+  it('preserves a correctly authored multi-line value', () => {
+    const node = createConst({
+      name: 'pet',
+      export: true,
+      nodes: [createText('{\n  foo: 1,\n  bar: 2,\n}')],
+    })
+    expect(printConst(node)).toBe('export const pet = {\n  foo: 1,\n  bar: 2,\n}')
+  })
 })
 
 describe('printType', () => {
@@ -232,6 +285,15 @@ describe('printType', () => {
   it('handles empty nodes', () => {
     const node = createType({ name: 'Pet' })
     expect(printType(node)).toBe('type Pet = ')
+  })
+
+  it('normalizes a multi-line object type authored with baked-in indentation', () => {
+    const node = createType({
+      name: 'Pet',
+      export: true,
+      nodes: [createText('\n    {\n      id: number\n      name: string\n    }\n  ')],
+    })
+    expect(printType(node)).toBe('export type Pet = {\n  id: number\n  name: string\n}')
   })
 })
 
@@ -310,6 +372,20 @@ describe('printFunction', () => {
     })
     expect(printFunction(node)).toBe('/**\n * @description Fetch a pet\n */\nfunction getPet() {}')
   })
+
+  it('normalizes a body authored with baked-in indentation to a single level', () => {
+    const node = createFunction({
+      name: 'getPet',
+      nodes: [createText('      const a = 1\n      const b = 2')],
+    })
+    expect(printFunction(node)).toBe('function getPet() {\n  const a = 1\n  const b = 2\n}')
+  })
+
+  it('indents a nested function cumulatively', () => {
+    const inner = createFunction({ name: 'inner', nodes: [createText('return 1')] })
+    const node = createFunction({ name: 'outer', nodes: [inner] })
+    expect(printFunction(node)).toBe('function outer() {\n  function inner() {\n    return 1\n  }\n}')
+  })
 })
 
 describe('printArrowFunction', () => {
@@ -381,6 +457,14 @@ describe('printArrowFunction', () => {
     })
     expect(printArrowFunction(node)).toBe('/**\n * @description Fetch a pet\n */\nconst getPet = () => {}')
   })
+
+  it('normalizes a body authored with baked-in indentation to a single level', () => {
+    const node = createArrowFunction({
+      name: 'getPet',
+      nodes: [createText('      const a = 1\n      const b = 2')],
+    })
+    expect(printArrowFunction(node)).toBe('const getPet = () => {\n  const a = 1\n  const b = 2\n}')
+  })
 })
 
 describe('printCodeNode', () => {
@@ -421,11 +505,11 @@ describe('printSource', () => {
     expect(printSource(node)).toBe('const x = 1')
   })
 
-  it('converts multiple nodes joining with newline', () => {
+  it('separates multiple top-level declarations with a blank line', () => {
     const node = createSource({
       nodes: [createConst({ name: 'x', nodes: [createText('1')] }), createType({ name: 'Pet', nodes: [createText('{ id: number }')] })],
     })
-    expect(printSource(node)).toBe('const x = 1\ntype Pet = { id: number }')
+    expect(printSource(node)).toBe('const x = 1\n\ntype Pet = { id: number }')
   })
 
   it('preserves DOM order when JSX elements and text nodes are interleaved', () => {
@@ -436,7 +520,19 @@ describe('printSource', () => {
         createConst({ name: 'x', nodes: [createText('1')] }),
       ],
     })
-    expect(printSource(node)).toBe('const server = new McpServer()\nserver.registerTool("foo", {})\nconst x = 1')
+    expect(printSource(node)).toBe('const server = new McpServer()\n\nserver.registerTool("foo", {})\n\nconst x = 1')
+  })
+
+  it('normalizes a top-level text node with baked-in indentation to column zero', () => {
+    const node = createSource({ nodes: [createText('    const x = 1')] })
+    expect(printSource(node)).toBe('const x = 1')
+  })
+
+  it('does not add an extra blank line for an explicit break', () => {
+    const node = createSource({
+      nodes: [createConst({ name: 'x', nodes: [createText('1')] }), createBreak(), createConst({ name: 'y', nodes: [createText('2')] })],
+    })
+    expect(printSource(node)).toBe('const x = 1\n\nconst y = 2')
   })
 
   it('returns empty string when source has no nodes', () => {

--- a/packages/parser-ts/src/utils.test.ts
+++ b/packages/parser-ts/src/utils.test.ts
@@ -241,7 +241,12 @@ describe('printConst', () => {
       export: true,
       nodes: [createText('\n    {\n      foo: 1,\n      bar: 2,\n    }\n  ')],
     })
-    expect(printConst(node)).toBe('export const pet = {\n  foo: 1,\n  bar: 2,\n}')
+    expect(printConst(node)).toMatchInlineSnapshot(`
+      "export const pet = {
+        foo: 1,
+        bar: 2,
+      }"
+    `)
   })
 
   it('preserves a correctly authored multi-line value', () => {
@@ -250,7 +255,12 @@ describe('printConst', () => {
       export: true,
       nodes: [createText('{\n  foo: 1,\n  bar: 2,\n}')],
     })
-    expect(printConst(node)).toBe('export const pet = {\n  foo: 1,\n  bar: 2,\n}')
+    expect(printConst(node)).toMatchInlineSnapshot(`
+      "export const pet = {
+        foo: 1,
+        bar: 2,
+      }"
+    `)
   })
 })
 
@@ -293,7 +303,12 @@ describe('printType', () => {
       export: true,
       nodes: [createText('\n    {\n      id: number\n      name: string\n    }\n  ')],
     })
-    expect(printType(node)).toBe('export type Pet = {\n  id: number\n  name: string\n}')
+    expect(printType(node)).toMatchInlineSnapshot(`
+      "export type Pet = {
+        id: number
+        name: string
+      }"
+    `)
   })
 })
 
@@ -362,7 +377,11 @@ describe('printFunction', () => {
       name: 'getPet',
       nodes: [createText('return fetch("/pets")')],
     })
-    expect(printFunction(node)).toBe('function getPet() {\n  return fetch("/pets")\n}')
+    expect(printFunction(node)).toMatchInlineSnapshot(`
+      "function getPet() {
+        return fetch("/pets")
+      }"
+    `)
   })
 
   it('includes JSDoc when provided', () => {
@@ -378,13 +397,24 @@ describe('printFunction', () => {
       name: 'getPet',
       nodes: [createText('      const a = 1\n      const b = 2')],
     })
-    expect(printFunction(node)).toBe('function getPet() {\n  const a = 1\n  const b = 2\n}')
+    expect(printFunction(node)).toMatchInlineSnapshot(`
+      "function getPet() {
+        const a = 1
+        const b = 2
+      }"
+    `)
   })
 
   it('indents a nested function cumulatively', () => {
     const inner = createFunction({ name: 'inner', nodes: [createText('return 1')] })
     const node = createFunction({ name: 'outer', nodes: [inner] })
-    expect(printFunction(node)).toBe('function outer() {\n  function inner() {\n    return 1\n  }\n}')
+    expect(printFunction(node)).toMatchInlineSnapshot(`
+      "function outer() {
+        function inner() {
+          return 1
+        }
+      }"
+    `)
   })
 })
 
@@ -424,7 +454,11 @@ describe('printArrowFunction', () => {
       name: 'getPet',
       nodes: [createText('return fetch("/pets")')],
     })
-    expect(printArrowFunction(node)).toBe('const getPet = () => {\n  return fetch("/pets")\n}')
+    expect(printArrowFunction(node)).toMatchInlineSnapshot(`
+      "const getPet = () => {
+        return fetch("/pets")
+      }"
+    `)
   })
 
   it('generates an arrow function with generics', () => {
@@ -463,7 +497,12 @@ describe('printArrowFunction', () => {
       name: 'getPet',
       nodes: [createText('      const a = 1\n      const b = 2')],
     })
-    expect(printArrowFunction(node)).toBe('const getPet = () => {\n  const a = 1\n  const b = 2\n}')
+    expect(printArrowFunction(node)).toMatchInlineSnapshot(`
+      "const getPet = () => {
+        const a = 1
+        const b = 2
+      }"
+    `)
   })
 })
 
@@ -509,7 +548,11 @@ describe('printSource', () => {
     const node = createSource({
       nodes: [createConst({ name: 'x', nodes: [createText('1')] }), createType({ name: 'Pet', nodes: [createText('{ id: number }')] })],
     })
-    expect(printSource(node)).toBe('const x = 1\n\ntype Pet = { id: number }')
+    expect(printSource(node)).toMatchInlineSnapshot(`
+      "const x = 1
+
+      type Pet = { id: number }"
+    `)
   })
 
   it('preserves DOM order when JSX elements and text nodes are interleaved', () => {
@@ -520,7 +563,13 @@ describe('printSource', () => {
         createConst({ name: 'x', nodes: [createText('1')] }),
       ],
     })
-    expect(printSource(node)).toBe('const server = new McpServer()\n\nserver.registerTool("foo", {})\n\nconst x = 1')
+    expect(printSource(node)).toMatchInlineSnapshot(`
+      "const server = new McpServer()
+
+      server.registerTool("foo", {})
+
+      const x = 1"
+    `)
   })
 
   it('normalizes a top-level text node with baked-in indentation to column zero', () => {
@@ -532,7 +581,11 @@ describe('printSource', () => {
     const node = createSource({
       nodes: [createConst({ name: 'x', nodes: [createText('1')] }), createBreak(), createConst({ name: 'y', nodes: [createText('2')] })],
     })
-    expect(printSource(node)).toBe('const x = 1\n\nconst y = 2')
+    expect(printSource(node)).toMatchInlineSnapshot(`
+      "const x = 1
+
+      const y = 2"
+    `)
   })
 
   it('returns empty string when source has no nodes', () => {

--- a/packages/parser-ts/src/utils.ts
+++ b/packages/parser-ts/src/utils.ts
@@ -109,7 +109,7 @@ export function dedent(text: string): string {
   const trimmed = lines.slice(start, end)
   if (trimmed.length === 0) return ''
 
-  const indents = trimmed.filter((line) => line.trim() !== '').map((line) => (line.match(/^\s*/)?.[0].length ?? 0))
+  const indents = trimmed.filter((line) => line.trim() !== '').map((line) => line.match(/^\s*/)?.[0].length ?? 0)
   const min = indents.length ? Math.min(...indents) : 0
 
   return trimmed.map((line) => (line.trim() === '' ? '' : line.slice(min))).join('\n')

--- a/packages/parser-ts/src/utils.ts
+++ b/packages/parser-ts/src/utils.ts
@@ -6,7 +6,8 @@ import {
   CRLF_PATTERN,
   CURRENT_DIRECTORY_PREFIX,
   FILE_EXTENSION_PATTERN,
-  INDENT_SIZE,
+  INDENT,
+  INDENT_CHAR,
   JSDOC_TERMINATOR_PATTERN,
   LEADING_DIGIT_PATTERN,
   PARENT_DIRECTORY_PREFIX,
@@ -73,11 +74,12 @@ export function printNodes(nodes: Array<CodeNode> | undefined): string {
 }
 
 /**
- * Indents every non-empty line of `text` by `spaces` spaces.
+ * Indents every non-empty line of `text` by one indent unit. Pass a number to repeat
+ * {@link INDENT_CHAR} that many times, or a string to use as the indent verbatim.
  */
-export function indentLines(text: string, spaces: number = INDENT_SIZE): string {
+export function indentLines(text: string, indent: number | string = INDENT): string {
   if (!text) return ''
-  const pad = ' '.repeat(spaces)
+  const pad = typeof indent === 'string' ? indent : INDENT_CHAR.repeat(indent)
   return text
     .split('\n')
     .map((line) => (line.trim() ? `${pad}${line}` : ''))

--- a/packages/parser-ts/src/utils.ts
+++ b/packages/parser-ts/src/utils.ts
@@ -102,19 +102,17 @@ export function dedent(text: string): string {
   if (!text) return ''
 
   const lines = text.split('\n')
+  const isBlank = (line: string) => line.trim() === ''
 
-  let start = 0
-  let end = lines.length
-  while (start < end && lines[start]!.trim() === '') start++
-  while (end > start && lines[end - 1]!.trim() === '') end--
+  const start = lines.findIndex((line) => !isBlank(line))
+  if (start === -1) return ''
+  const end = lines.findLastIndex((line) => !isBlank(line))
 
-  const trimmed = lines.slice(start, end)
-  if (trimmed.length === 0) return ''
-
-  const indents = trimmed.filter((line) => line.trim() !== '').map((line) => line.match(/^\s*/)?.[0].length ?? 0)
+  const trimmed = lines.slice(start, end + 1)
+  const indents = trimmed.filter((line) => !isBlank(line)).map((line) => line.match(/^\s*/)?.[0].length ?? 0)
   const min = indents.length ? Math.min(...indents) : 0
 
-  return trimmed.map((line) => (line.trim() === '' ? '' : line.slice(min))).join('\n')
+  return trimmed.map((line) => (isBlank(line) ? '' : line.slice(min))).join('\n')
 }
 
 /**

--- a/packages/parser-ts/src/utils.ts
+++ b/packages/parser-ts/src/utils.ts
@@ -85,6 +85,37 @@ export function indentLines(text: string, spaces: number = INDENT_SIZE): string 
 }
 
 /**
+ * Removes the common leading whitespace shared by every non-blank line and trims
+ * surrounding blank lines, normalizing multi-line content authored inside an
+ * indented template literal back to a column-zero baseline. Leading whitespace is
+ * counted by character, so N tabs and N spaces are treated as the same depth.
+ *
+ * @example
+ * ```ts
+ * dedent('\n    foo\n      bar\n    ')
+ * // 'foo\n  bar'
+ * ```
+ */
+export function dedent(text: string): string {
+  if (!text) return ''
+
+  const lines = text.split('\n')
+
+  let start = 0
+  let end = lines.length
+  while (start < end && lines[start]!.trim() === '') start++
+  while (end > start && lines[end - 1]!.trim() === '') end--
+
+  const trimmed = lines.slice(start, end)
+  if (trimmed.length === 0) return ''
+
+  const indents = trimmed.filter((line) => line.trim() !== '').map((line) => (line.match(/^\s*/)?.[0].length ?? 0))
+  const min = indents.length ? Math.min(...indents) : 0
+
+  return trimmed.map((line) => (line.trim() === '' ? '' : line.slice(min))).join('\n')
+}
+
+/**
  * Renders the generic clause (`<T, U>`) shared by function and arrow-function nodes.
  * Accepts either a raw string (rendered verbatim) or an array of type-parameter names.
  */
@@ -326,8 +357,8 @@ export function printArrowFunction(node: ArrowFunctionNode): string {
  */
 export function printCodeNode(node: CodeNode): string {
   if (node.kind === 'Break') return ''
-  if (node.kind === 'Text') return (node as TextNode).value
-  if (node.kind === 'Jsx') return (node as JsxNode).value
+  if (node.kind === 'Text') return dedent((node as TextNode).value)
+  if (node.kind === 'Jsx') return dedent((node as JsxNode).value)
   if (node.kind === 'Const') return printConst(node)
   if (node.kind === 'Type') return printType(node)
   if (node.kind === 'Function') return printFunction(node)
@@ -341,23 +372,24 @@ export function printCodeNode(node: CodeNode): string {
  * Iterates `nodes` in DOM order, rendering each {@link CodeNode} via
  * {@link printCodeNode}.
  *
+ * Top-level declarations are separated by a blank line so the source reads
+ * cleanly without an external formatter.
+ *
  * @example From nodes
  * ```ts
  * printSource({ kind: 'Source', nodes: [createConst({ name: 'x', nodes: [createText('1')] }), createText('x.toString()')] })
- * // 'const x = 1\nx.toString()'
+ * // 'const x = 1\n\nx.toString()'
  * ```
  */
 export function printSource(node: SourceNode): string {
   const nodes = node.nodes
 
   if (!nodes || nodes.length === 0) return ''
-  const parts: Array<string> = []
 
-  for (const child of nodes) {
-    parts.push(printCodeNode(child as CodeNode))
-  }
-
-  return parts.join('\n')
+  return nodes
+    .map((child) => printCodeNode(child as CodeNode))
+    .filter(Boolean)
+    .join('\n\n')
 }
 
 export function createImport({


### PR DESCRIPTION
## What

Improve the indentation of generated `function`, `const`, `type`, arrow-function, and source output so it reads cleanly before any external formatter or linter runs.

## Why

The JSX-to-string pipeline emitted code that often needed `oxfmt`/`prettier` to look right. Two structural problems caused it:

1. **Compounding / baked-in indentation.** Multi-line content supplied through template-literal JSX children carries the source file's own indentation baked into the string. `printFunction`/`printArrowFunction` then indent on top of that, compounding the result. `Text`/`Jsx` nodes were emitted verbatim.
2. **No normalization for `const`/`type` values.** Multi-line object, array, and schema values kept whatever leading whitespace they were authored with.

## How

The serialization logic lives in `@kubb/parser-ts` (`packages/parser-ts/src/utils.ts`); `@kubb/ast` only carries raw strings and `@kubb/renderer-jsx` only collects them, so the fix sits in parser-ts.

- Add a `dedent` (outdent) helper next to `indentLines`: strip the common leading whitespace shared by every non-blank line and trim surrounding blank lines.
- Apply `dedent` per raw `Text`/`Jsx` node in `printCodeNode`. It removes only the *common* leading whitespace, so each block's relative structure is preserved and already-indented structured children (e.g. a nested `function`) keep the indentation their own printer added. Cumulative nesting still works.
- Once those nodes arrive at baseline, `printFunction`/`printArrowFunction` keep their single `indentLines` call (now non-compounding) and `printConst`/`printType` need no extra indent.
- `printSource` separates top-level declarations with a blank line and treats an explicit `<br/>` as a no-op rather than a double gap.

## Tests

- New `dedent` unit suite (common-whitespace strip, blank-line trim, single line, already-baseline, interior blanks, empty/whitespace-only, tab handling).
- New cases for multi-line `const`/`type` normalization, compounded-indentation `function`/arrow bodies, cumulative nested-function indentation, and `printSource` blank-line separation plus the `<br/>` no-op.

`pnpm --filter @kubb/parser-ts test`, `typecheck`, and `pnpm lint` are green. The full suite shows only pre-existing failures in unbuilt `agent`/`mcp` packages (missing `dist` entries), unrelated to this change.

## Note on downstream snapshots

This changes generated-output whitespace. Snapshots in the separate `kubb-labs/plugins` repo will need a coordinated refresh; they cannot be updated from here. A changeset (`@kubb/parser-ts` minor) is included.

https://claude.ai/code/session_01RxNTbFy19J9AZnDzQ4raP3

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxNTbFy19J9AZnDzQ4raP3)_