### PR TITLE
perf(core): reduce build memory and duplicated hot-path work

### DIFF
--- a/.changeset/core-hot-path-perf.md
+++ b/.changeset/core-hot-path-perf.md
@@ -1,0 +1,9 @@
+---
+'@kubb/core': patch
+---
+
+Cut memory use and duplicated work in the build hot path, and name the requiring plugin in missing-dependency errors.
+
+Rendered sources are no longer retained in memory for the whole build when caching is disabled, and the file write pipeline streams each file to storage as soon as it is parsed instead of materializing the entire batch first. Cache-hit restores now write files in parallel batches instead of one at a time. Per-node transformer results are memoized per plugin, so a plugin with a batch `operations()` generator no longer transforms and re-resolves every operation twice, and plugins without include/exclude/override filters share one generator context across nodes.
+
+`requirePlugin` errors raised from a generator context now say which plugin declared the missing dependency, e.g. `Plugin "plugin-zod" is required by "plugin-ts" but not found`.

--- a/.changeset/core-hot-path-perf.md
+++ b/.changeset/core-hot-path-perf.md
@@ -4,6 +4,6 @@
 
 Cut memory use and duplicated work in the build hot path, and name the requiring plugin in missing-dependency errors.
 
-Rendered sources are no longer retained in memory for the whole build when caching is disabled, and the file write pipeline streams each file to storage as soon as it is parsed instead of materializing the entire batch first. Cache-hit restores now write files in parallel batches instead of one at a time. Per-node transformer results are memoized per plugin, so a plugin with a batch `operations()` generator no longer transforms and re-resolves every operation twice, and plugins without include/exclude/override filters share one generator context across nodes.
+Rendered sources are no longer retained in memory for the whole build when caching is disabled, and the file write pipeline streams each file to storage as soon as it is parsed instead of materializing the entire batch first. Cache-hit restores now write files in parallel batches instead of one at a time. Per-node transformer results are memoized per plugin, so a plugin with a batch `operations()` generator no longer transforms and re-resolves every operation twice.
 
 `requirePlugin` errors raised from a generator context now say which plugin declared the missing dependency, e.g. `Plugin "plugin-zod" is required by "plugin-ts" but not found`.

--- a/packages/core/src/FileProcessor.test.ts
+++ b/packages/core/src/FileProcessor.test.ts
@@ -1,3 +1,4 @@
+import type { FileNode } from '@kubb/ast'
 import { createFile, createSource, createText } from '@kubb/ast'
 import { describe, expect, it, vi } from 'vitest'
 import { FileProcessor } from './FileProcessor.ts'
@@ -248,6 +249,62 @@ describe('FileProcessor — queue: flush', () => {
     await processor.drain()
 
     expect(order).toStrictEqual(['set:first.ts', 'done:first.ts', 'set:second.ts', 'done:second.ts'])
+  })
+})
+
+describe('FileProcessor — queue: streaming writes', () => {
+  it('starts writing a file before parsing the next one', async () => {
+    const order: Array<string> = []
+    const storage = memoryStorage()
+    const realSetItem = storage.setItem.bind(storage)
+    storage.setItem = async (path: string, source: string) => {
+      order.push(`set:${path}`)
+      await realSetItem(path, source)
+    }
+    const parser = {
+      name: 'ts',
+      type: 'parser' as const,
+      extNames: ['.ts' as const],
+      install: vi.fn(),
+      parse: vi.fn((file: FileNode) => {
+        order.push(`parse:${file.path}`)
+        return `/* ${file.path} */`
+      }),
+      print: vi.fn().mockReturnValue(''),
+    }
+    const processor = new FileProcessor({ storage, parsers: new Map([['.ts' as const, parser]]) })
+
+    processor.enqueue(makeFile('a.ts', ['/* a */']))
+    processor.enqueue(makeFile('b.ts', ['/* b */']))
+    await processor.drain()
+
+    expect(order).toStrictEqual(['parse:a.ts', 'set:a.ts', 'parse:b.ts', 'set:b.ts'])
+  })
+
+  it('fires end only after the last write has finished', async () => {
+    const events: Array<string> = []
+    const { promise: blocker, resolve: unblock } = Promise.withResolvers<void>()
+    const storage = memoryStorage()
+    const realSetItem = storage.setItem.bind(storage)
+    storage.setItem = async (path: string, source: string) => {
+      await blocker
+      await realSetItem(path, source)
+      events.push(`done:${path}`)
+    }
+    const { processor } = makeQueueProcessor({ storage })
+    processor.hooks.on('end', () => {
+      events.push('end')
+    })
+
+    processor.enqueue(makeFile('a.ts', ['/* a */']))
+    const draining = processor.drain()
+    await new Promise((resolve) => setTimeout(resolve, 5))
+    expect(events).toStrictEqual([])
+
+    unblock()
+    await draining
+
+    expect(events).toStrictEqual(['done:a.ts', 'end'])
   })
 })
 

--- a/packages/core/src/FileProcessor.ts
+++ b/packages/core/src/FileProcessor.ts
@@ -183,15 +183,13 @@ export class FileProcessor {
 
     await this.hooks.emit('start', files)
 
-    const items = [...this.stream(files)]
-    for (const item of items) {
-      await this.hooks.emit('update', item)
-    }
-
+    // Single pass: each file's write starts right after its `update` fires, so IO overlaps
+    // parsing and the batch never holds every rendered source in memory at once.
     const queue: Array<Promise<void>> = []
-    for (const { file, source } of items) {
-      if (source) {
-        queue.push(storage.setItem(file.path, source))
+    for (const item of this.stream(files)) {
+      await this.hooks.emit('update', item)
+      if (item.source) {
+        queue.push(storage.setItem(item.file.path, item.source))
         if (queue.length >= STREAM_FLUSH_EVERY) await Promise.all(queue.splice(0))
       }
     }

--- a/packages/core/src/KubbDriver.test.ts
+++ b/packages/core/src/KubbDriver.test.ts
@@ -293,4 +293,16 @@ describe('GeneratorContext diagnostics', () => {
 
     expect(onError).not.toHaveBeenCalled()
   })
+
+  it('names the requiring plugin when ctx.requirePlugin misses', () => {
+    expect(() => context().requirePlugin('missing')).toThrowError(/Plugin "missing" is required by "pluginA" but not found/)
+  })
+
+  it('keeps the plain message for a direct driver.requirePlugin call', () => {
+    expect(() => driver.requirePlugin('missing')).toThrowError(/Plugin "missing" is required but not found/)
+  })
+
+  it('returns the plugin from ctx.requirePlugin when it exists', () => {
+    expect(context().requirePlugin('pluginA').name).toBe('pluginA')
+  })
 })

--- a/packages/core/src/KubbDriver.ts
+++ b/packages/core/src/KubbDriver.ts
@@ -584,7 +584,6 @@ export class KubbDriver {
       failed: boolean
       error: Error | null
       optionsAreStatic: boolean
-      staticContext: GeneratorContext | null
       allowedSchemaNames: Set<string> | null
     }
 
@@ -593,18 +592,14 @@ export class KubbDriver {
       const hasExclude = Array.isArray(exclude) && exclude.length > 0
       const hasInclude = Array.isArray(include) && include.length > 0
       const hasOverride = Array.isArray(override) && override.length > 0
-      const optionsAreStatic = !hasExclude && !hasInclude && !hasOverride
-      const generatorContext = { ...context, resolver: this.getResolver(plugin.name) }
       return {
         plugin,
-        generatorContext,
+        generatorContext: { ...context, resolver: this.getResolver(plugin.name) },
         generators: plugin.generators ?? [],
         hrStart,
         failed: false,
         error: null,
-        optionsAreStatic,
-        // When options never vary per node, one shared ctx replaces a spread per node.
-        staticContext: optionsAreStatic ? { ...generatorContext, options: plugin.options } : null,
+        optionsAreStatic: !hasExclude && !hasInclude && !hasOverride,
         allowedSchemaNames: null,
       }
     })
@@ -689,7 +684,7 @@ export class KubbDriver {
           return
         }
 
-        const ctx = state.staticContext ?? { ...state.generatorContext, options }
+        const ctx = { ...state.generatorContext, options }
         for (const gen of state.generators) {
           const run = gen[dispatch.method] as ((node: TNode, ctx: GeneratorContext) => unknown) | undefined
           if (!run) continue
@@ -742,7 +737,7 @@ export class KubbDriver {
       if (!state.failed && needsCollectedOperations) {
         try {
           const { plugin, generatorContext, generators } = state
-          const ctx = state.staticContext ?? { ...generatorContext, options: plugin.options }
+          const ctx = { ...generatorContext, options: plugin.options }
           // Match what the per-node dispatch passes to gen.operation(): the transformed node,
           // already filtered by excludes/includes/overrides.
           const ops = collectedOperations ?? []

--- a/packages/core/src/KubbDriver.ts
+++ b/packages/core/src/KubbDriver.ts
@@ -3,7 +3,7 @@ import { arrayToAsyncIterable, type AsyncEventEmitter, forBatches, getElapsedMs,
 import { collectUsedSchemaNames, createFile, createStreamInput } from '@kubb/ast'
 import type { FileNode, InputMeta, InputStreamNode, OperationNode, SchemaNode } from '@kubb/ast'
 import { version as coreVersion } from '../package.json'
-import { OPERATION_FILTER_TYPES, SCHEMA_PARALLEL } from './constants.ts'
+import { OPERATION_FILTER_TYPES, SCHEMA_PARALLEL, STREAM_FLUSH_EVERY } from './constants.ts'
 import { Fingerprint } from './Fingerprint.ts'
 import { type Diagnostic, Diagnostics, type ProblemDiagnostic } from './diagnostics.ts'
 import type { Cache } from './createCache.ts'
@@ -34,6 +34,14 @@ import type {
 
 type Options = {
   hooks: AsyncEventEmitter<KubbHooks>
+}
+
+type RequirePluginContext = {
+  /**
+   * Name of the plugin that declared the dependency, included in the error so users can
+   * trace which plugin needs the missing one.
+   */
+  requiredBy?: string
 }
 
 function enforceOrder(enforce: 'pre' | 'post' | undefined): number {
@@ -358,11 +366,13 @@ export class KubbDriver {
     })
     const updateBuffer: Array<{ file: FileNode; source?: string; processed: number; total: number; percentage: number }> = []
     // Final rendered source per output path, captured for the cache snapshot on a miss. Barrel
-    // files flow through here too, after the second `drain()`.
+    // files flow through here too, after the second `drain()`. Only collected when caching is
+    // enabled, otherwise the Map would retain every rendered source for the whole build.
+    const cacheEnabled = Boolean(config.cache)
     const snapshotSources = new Map<string, string>()
     processor.hooks.on('update', (item) => {
       updateBuffer.push(item)
-      if (item.source !== undefined) snapshotSources.set(item.file.path, item.source)
+      if (cacheEnabled && item.source !== undefined) snapshotSources.set(item.file.path, item.source)
     })
     processor.hooks.on('end', async (files) => {
       await hooks.emit('kubb:files:processing:update', {
@@ -475,11 +485,14 @@ export class KubbDriver {
     const snapshot = await cache.restore({ key: cacheKey })
     if (!snapshot) return false
 
+    const queue: Array<Promise<void>> = []
     for (const [relativePath, source] of Object.entries(snapshot.files)) {
       const absolutePath = join(outputRoot, relativePath)
       this.fileManager.upsert(createFile({ path: absolutePath, baseName: basename(relativePath) as `${string}.${string}` }))
-      await storage.setItem(absolutePath, source)
+      queue.push(storage.setItem(absolutePath, source))
+      if (queue.length >= STREAM_FLUSH_EVERY) await Promise.all(queue.splice(0))
     }
+    await Promise.all(queue)
     await this.hooks.emit('kubb:build:end', { files: this.fileManager.files, config: this.config, outputDir: outputRoot })
     return true
   }
@@ -571,6 +584,7 @@ export class KubbDriver {
       failed: boolean
       error: Error | null
       optionsAreStatic: boolean
+      staticContext: GeneratorContext | null
       allowedSchemaNames: Set<string> | null
     }
 
@@ -579,14 +593,18 @@ export class KubbDriver {
       const hasExclude = Array.isArray(exclude) && exclude.length > 0
       const hasInclude = Array.isArray(include) && include.length > 0
       const hasOverride = Array.isArray(override) && override.length > 0
+      const optionsAreStatic = !hasExclude && !hasInclude && !hasOverride
+      const generatorContext = { ...context, resolver: this.getResolver(plugin.name) }
       return {
         plugin,
-        generatorContext: { ...context, resolver: this.getResolver(plugin.name) },
+        generatorContext,
         generators: plugin.generators ?? [],
         hrStart,
         failed: false,
         error: null,
-        optionsAreStatic: !hasExclude && !hasInclude && !hasOverride,
+        optionsAreStatic,
+        // When options never vary per node, one shared ctx replaces a spread per node.
+        staticContext: optionsAreStatic ? { ...generatorContext, options: plugin.options } : null,
         allowedSchemaNames: null,
       }
     })
@@ -671,7 +689,7 @@ export class KubbDriver {
           return
         }
 
-        const ctx = { ...state.generatorContext, options }
+        const ctx = state.staticContext ?? { ...state.generatorContext, options }
         for (const gen of state.generators) {
           const run = gen[dispatch.method] as ((node: TNode, ctx: GeneratorContext) => unknown) | undefined
           if (!run) continue
@@ -724,7 +742,7 @@ export class KubbDriver {
       if (!state.failed && needsCollectedOperations) {
         try {
           const { plugin, generatorContext, generators } = state
-          const ctx = { ...generatorContext, options: plugin.options }
+          const ctx = state.staticContext ?? { ...generatorContext, options: plugin.options }
           // Match what the per-node dispatch passes to gen.operation(): the transformed node,
           // already filtered by excludes/includes/overrides.
           const ops = collectedOperations ?? []
@@ -878,7 +896,8 @@ export class KubbDriver {
       hooks: driver.hooks,
       plugin,
       getPlugin: driver.getPlugin.bind(driver),
-      requirePlugin: driver.requirePlugin.bind(driver),
+      // Close over the owning plugin so a missing dependency error names who required it.
+      requirePlugin: ((name: string) => driver.requirePlugin(name, { requiredBy: plugin.name })) as GeneratorContext<TOptions>['requirePlugin'],
       getResolver: driver.getResolver.bind(driver),
       driver,
       addFile: async (...files: Array<FileNode>) => {
@@ -923,16 +942,21 @@ export class KubbDriver {
   /**
    * Like `getPlugin` but throws a descriptive error when the plugin is not found.
    */
-  requirePlugin<TName extends keyof Kubb.PluginRegistry>(pluginName: TName): Plugin<Kubb.PluginRegistry[TName]>
-  requirePlugin<TOptions extends PluginFactoryOptions = PluginFactoryOptions>(pluginName: string): Plugin<TOptions>
-  requirePlugin(pluginName: string): Plugin {
+  requirePlugin<TName extends keyof Kubb.PluginRegistry>(pluginName: TName, context?: RequirePluginContext): Plugin<Kubb.PluginRegistry[TName]>
+  requirePlugin<TOptions extends PluginFactoryOptions = PluginFactoryOptions>(pluginName: string, context?: RequirePluginContext): Plugin<TOptions>
+  requirePlugin(pluginName: string, context?: RequirePluginContext): Plugin {
     const plugin = this.plugins.get(pluginName)
     if (!plugin) {
+      const requiredBy = context?.requiredBy
       throw new Diagnostics.Error({
         code: Diagnostics.code.pluginNotFound,
         severity: 'error',
-        message: `Plugin "${pluginName}" is required but not found. Make sure it is included in your Kubb config.`,
-        help: `Add "${pluginName}" to the \`plugins\` array in kubb.config.ts, or remove the dependency on it.`,
+        message: requiredBy
+          ? `Plugin "${pluginName}" is required by "${requiredBy}" but not found. Make sure it is included in your Kubb config.`
+          : `Plugin "${pluginName}" is required but not found. Make sure it is included in your Kubb config.`,
+        help: requiredBy
+          ? `Add "${pluginName}" to the \`plugins\` array in kubb.config.ts (required by "${requiredBy}"), or remove the dependency on it.`
+          : `Add "${pluginName}" to the \`plugins\` array in kubb.config.ts, or remove the dependency on it.`,
         location: { kind: 'config' },
       })
     }

--- a/packages/core/src/Transform.test.ts
+++ b/packages/core/src/Transform.test.ts
@@ -53,6 +53,64 @@ describe('Transform — applyTo', () => {
   })
 })
 
+describe('Transform — memoization', () => {
+  it('returns the identical transformed reference for repeated applyTo calls', () => {
+    const transforms = new Transform()
+    transforms.register('a', { schema: (node) => (node.name === 'Pet' ? { ...node, name: 'PetRenamed' } : undefined) })
+
+    const node = namedSchema('Pet')
+    const first = transforms.applyTo('a', node)
+    const second = transforms.applyTo('a', node)
+
+    expect(first.name).toBe('PetRenamed')
+    expect(second).toBe(first)
+  })
+
+  it('runs the visitor once per node even when applied twice', () => {
+    const transforms = new Transform()
+    let calls = 0
+    transforms.register('a', {
+      schema: (node) => {
+        calls++
+        return node.name === 'Pet' ? { ...node, name: 'PetRenamed' } : undefined
+      },
+    })
+
+    const node = namedSchema('Pet')
+    transforms.applyTo('a', node)
+    const callsAfterFirst = calls
+    transforms.applyTo('a', node)
+
+    expect(calls).toBe(callsAfterFirst)
+  })
+
+  it('invalidates memoized results when a new visitor is registered for the plugin', () => {
+    const transforms = new Transform()
+    const node = namedSchema('Pet')
+    transforms.register('a', { schema: (n) => ({ ...n, name: 'first' }) })
+
+    expect(transforms.applyTo('a', node).name).toBe('first')
+
+    transforms.register('a', { schema: (n) => ({ ...n, name: 'second' }) })
+
+    expect(transforms.applyTo('a', node).name).toBe('second')
+  })
+
+  it('dispose clears memoized results along with the registry', () => {
+    const transforms = new Transform()
+    const node = namedSchema('Pet')
+    transforms.register('a', { schema: (n) => ({ ...n, name: 'changed' }) })
+    const before = transforms.applyTo('a', node)
+
+    transforms.dispose()
+    transforms.register('a', { schema: (n) => ({ ...n, name: 'changed' }) })
+    const after = transforms.applyTo('a', node)
+
+    expect(after.name).toBe('changed')
+    expect(after).not.toBe(before)
+  })
+})
+
 describe('Transform — registry', () => {
   it('tracks size and exposes get', () => {
     const transforms = new Transform()

--- a/packages/core/src/Transform.ts
+++ b/packages/core/src/Transform.ts
@@ -13,6 +13,10 @@ import { transform } from '@kubb/ast'
  */
 export class Transform {
   readonly #visitors = new Map<string, Visitor>()
+  // Memoized results per plugin. Repeated `applyTo` calls return the same node identity, so
+  // downstream WeakMap caches keyed by node (the resolver's resolveOptions memo) hit when the
+  // driver resolves a node a second time, and a stateful visitor runs once per node.
+  readonly #memo = new Map<string, WeakMap<SchemaNode | OperationNode, SchemaNode | OperationNode>>()
 
   /**
    * Number of plugins with a registered transformer.
@@ -27,6 +31,7 @@ export class Transform {
    */
   register(pluginName: string, visitor: Visitor): void {
     this.#visitors.set(pluginName, visitor)
+    this.#memo.delete(pluginName)
   }
 
   /**
@@ -45,7 +50,18 @@ export class Transform {
     const visitor = this.#visitors.get(pluginName)
     if (!visitor) return node
 
-    return transform(node, visitor) as TNode
+    let memo = this.#memo.get(pluginName)
+    if (!memo) {
+      memo = new WeakMap()
+      this.#memo.set(pluginName, memo)
+    }
+
+    const cached = memo.get(node)
+    if (cached) return cached as TNode
+
+    const result = transform(node, visitor) as TNode
+    memo.set(node, result)
+    return result
   }
 
   /**
@@ -54,5 +70,6 @@ export class Transform {
    */
   dispose(): void {
     this.#visitors.clear()
+    this.#memo.clear()
   }
 }

--- a/packages/core/src/cache.test.ts
+++ b/packages/core/src/cache.test.ts
@@ -26,7 +26,7 @@ async function dump(storage: Storage): Promise<Record<string, string>> {
   return out
 }
 
-function makeConfig({ storage, cache, schemaSpy }: { storage: Storage; cache: Cache; schemaSpy: Mock<() => void> }): Config {
+function makeConfig({ storage, cache, schemaSpy, fileCount = 1 }: { storage: Storage; cache: Cache; schemaSpy: Mock<() => void>; fileCount?: number }): Config {
   const plugin = definePlugin(() => ({
     name: 'plugin',
     hooks: {
@@ -35,15 +35,15 @@ function makeConfig({ storage, cache, schemaSpy }: { storage: Storage; cache: Ca
           name: 'gen',
           schema() {
             schemaSpy()
-            return [
+            return Array.from({ length: fileCount }, (_, index) =>
               createFile({
-                path: '/gen/pet.ts',
-                baseName: 'pet.ts',
-                sources: [createSource({ nodes: [createText('export type Pet = { id: number }')] })],
+                path: `/gen/pet${index}.ts`,
+                baseName: `pet${index}.ts`,
+                sources: [createSource({ nodes: [createText(`export type Pet${index} = { id: number }`)] })],
                 imports: [],
                 exports: [],
               }),
-            ]
+            )
           },
         })
       },
@@ -88,6 +88,35 @@ describe('incremental build cache', () => {
     // The generator never ran on the second build — the snapshot was restored instead.
     expect(schemaSpy).toHaveBeenCalledTimes(1)
     expect(cache.restore).toHaveBeenCalled()
+    expect(await dump(storage2)).toStrictEqual(cold)
+  })
+
+  it('persists the rendered sources in the snapshot', async () => {
+    const cache = memoryCache()
+    const schemaSpy = vi.fn<() => void>()
+
+    await createKubb(makeConfig({ storage: memoryStorage(), cache, schemaSpy })).build()
+
+    const persist = cache.persist as Mock
+    const call = persist.mock.calls[0]?.[0] as { snapshot: CachedSnapshot } | undefined
+    expect(call?.snapshot.files['pet0.ts']).toContain('export type Pet0 = { id: number }')
+  })
+
+  it('restores a snapshot larger than one write batch and skips generation', async () => {
+    const cache = memoryCache()
+    const schemaSpy = vi.fn<() => void>()
+    const fileCount = 55
+
+    const storage1 = memoryStorage()
+    await createKubb(makeConfig({ storage: storage1, cache, schemaSpy, fileCount })).build()
+    const cold = await dump(storage1)
+
+    expect(Object.keys(cold)).toHaveLength(fileCount)
+
+    const storage2 = memoryStorage()
+    await createKubb(makeConfig({ storage: storage2, cache, schemaSpy, fileCount })).build()
+
+    expect(schemaSpy).toHaveBeenCalledTimes(1)
     expect(await dump(storage2)).toStrictEqual(cold)
   })
 

--- a/packages/core/src/createKubb.test.ts
+++ b/packages/core/src/createKubb.test.ts
@@ -1,4 +1,5 @@
 import { AsyncEventEmitter } from '@internals/utils'
+import type { OperationNode, SchemaNode } from '@kubb/ast'
 import { createFile, createOperation, createSchema, createSource, createStreamInput, createText } from '@kubb/ast'
 import { createMockedAdapter } from '@kubb/core/mocks'
 import { afterEach, describe, expect, it, test, vi } from 'vitest'
@@ -474,6 +475,124 @@ describe('createKubb', () => {
 
       expect(files).toHaveLength(count)
       expect(generatedPaths).toHaveLength(count)
+    })
+  })
+
+  describe('generator context and transform reuse', () => {
+    function makeAdapter({ schemas = [], operations = [] }: { schemas?: Array<SchemaNode>; operations?: Array<OperationNode> }) {
+      return createMockedAdapter({
+        parse: async () => ({
+          kind: 'Input' as const,
+          meta: { circularNames: [] as Array<string>, enumNames: [] as Array<string> },
+          schemas,
+          operations,
+        }),
+      })
+    }
+
+    it('reuses one generator ctx across nodes when plugin options are static', async () => {
+      const ctxs: Array<unknown> = []
+      const capturePlugin = definePlugin(() => ({
+        name: 'capture-plugin',
+        hooks: {
+          'kubb:plugin:setup'(ctx) {
+            ctx.addGenerator({
+              name: 'capture-gen',
+              schema(_node, generatorCtx) {
+                ctxs.push(generatorCtx)
+              },
+            })
+          },
+        },
+      }))()
+
+      await createKubb(
+        {
+          ...config,
+          storage: memoryStorage(),
+          adapter: makeAdapter({ schemas: [createSchema({ name: 'A', type: 'string' }), createSchema({ name: 'B', type: 'string' })] }),
+          plugins: [capturePlugin as unknown as Plugin],
+        },
+        { hooks: new AsyncEventEmitter<KubbHooks>() },
+      ).build()
+
+      expect(ctxs).toHaveLength(2)
+      expect(ctxs[1]).toBe(ctxs[0])
+    })
+
+    it('still resolves per-node options when an override matches', async () => {
+      const seen: Array<{ name: string | null | undefined; options: { marker?: string } }> = []
+      const overridePlugin = definePlugin(() => ({
+        name: 'override-plugin',
+        options: {
+          output: { path: '.' },
+          exclude: [],
+          override: [{ type: 'schemaName' as const, pattern: 'B', options: { marker: 'overridden' } }],
+        },
+        hooks: {
+          'kubb:plugin:setup'(ctx) {
+            ctx.addGenerator({
+              name: 'override-gen',
+              schema(node, generatorCtx) {
+                seen.push({ name: node.name, options: generatorCtx.options as { marker?: string } })
+              },
+            })
+          },
+        },
+      }))()
+
+      await createKubb(
+        {
+          ...config,
+          storage: memoryStorage(),
+          adapter: makeAdapter({ schemas: [createSchema({ name: 'A', type: 'string' }), createSchema({ name: 'B', type: 'string' })] }),
+          plugins: [overridePlugin as unknown as Plugin],
+        },
+        { hooks: new AsyncEventEmitter<KubbHooks>() },
+      ).build()
+
+      expect(seen).toHaveLength(2)
+      expect(seen.find((entry) => entry.name === 'A')?.options.marker).toBeUndefined()
+      expect(seen.find((entry) => entry.name === 'B')?.options.marker).toBe('overridden')
+    })
+
+    it('passes the same transformed node to operation and operations generators', async () => {
+      const perNode: Array<OperationNode> = []
+      let batch: Array<OperationNode> = []
+      const transformPlugin = definePlugin(() => ({
+        name: 'transform-plugin',
+        hooks: {
+          'kubb:plugin:setup'(ctx) {
+            ctx.setTransformer({ operation: (node) => ({ ...node, operationId: `${node.operationId}X` }) })
+            ctx.addGenerator({
+              name: 'transform-gen',
+              operation(node) {
+                perNode.push(node)
+              },
+              operations(nodes) {
+                batch = nodes
+              },
+            })
+          },
+        },
+      }))()
+
+      await createKubb(
+        {
+          ...config,
+          storage: memoryStorage(),
+          adapter: makeAdapter({
+            operations: [createOperation({ operationId: 'getPet', method: 'GET', path: '/pet', parameters: [], responses: [], tags: [] })],
+          }),
+          plugins: [transformPlugin as unknown as Plugin],
+        },
+        { hooks: new AsyncEventEmitter<KubbHooks>() },
+      ).build()
+
+      expect(perNode).toHaveLength(1)
+      expect(batch).toHaveLength(1)
+      expect(perNode[0]?.operationId).toBe('getPetX')
+      expect(batch[0]).toBe(perNode[0])
     })
   })
 

--- a/packages/core/src/createKubb.test.ts
+++ b/packages/core/src/createKubb.test.ts
@@ -478,7 +478,7 @@ describe('createKubb', () => {
     })
   })
 
-  describe('generator context and transform reuse', () => {
+  describe('per-node options and transform reuse', () => {
     function makeAdapter({ schemas = [], operations = [] }: { schemas?: Array<SchemaNode>; operations?: Array<OperationNode> }) {
       return createMockedAdapter({
         parse: async () => ({
@@ -490,37 +490,7 @@ describe('createKubb', () => {
       })
     }
 
-    it('reuses one generator ctx across nodes when plugin options are static', async () => {
-      const ctxs: Array<unknown> = []
-      const capturePlugin = definePlugin(() => ({
-        name: 'capture-plugin',
-        hooks: {
-          'kubb:plugin:setup'(ctx) {
-            ctx.addGenerator({
-              name: 'capture-gen',
-              schema(_node, generatorCtx) {
-                ctxs.push(generatorCtx)
-              },
-            })
-          },
-        },
-      }))()
-
-      await createKubb(
-        {
-          ...config,
-          storage: memoryStorage(),
-          adapter: makeAdapter({ schemas: [createSchema({ name: 'A', type: 'string' }), createSchema({ name: 'B', type: 'string' })] }),
-          plugins: [capturePlugin as unknown as Plugin],
-        },
-        { hooks: new AsyncEventEmitter<KubbHooks>() },
-      ).build()
-
-      expect(ctxs).toHaveLength(2)
-      expect(ctxs[1]).toBe(ctxs[0])
-    })
-
-    it('still resolves per-node options when an override matches', async () => {
+    it('resolves per-node options when an override matches', async () => {
       const seen: Array<{ name: string | null | undefined; options: { marker?: string } }> = []
       const overridePlugin = definePlugin(() => ({
         name: 'override-plugin',

--- a/packages/core/src/defineGenerator.ts
+++ b/packages/core/src/defineGenerator.ts
@@ -16,6 +16,10 @@ import type { Config } from './types.ts'
  * filtering for individual schema/operation calls, or plugin-level options for operations.
  */
 export type GeneratorContext<TOptions extends PluginFactoryOptions = PluginFactoryOptions> = {
+  /**
+   * The resolved Kubb config for this build, including `root`, `input`, `output`, and the
+   * full plugin list.
+   */
   config: Config
   /**
    * Absolute path to the current plugin's output directory.
@@ -26,6 +30,10 @@ export type GeneratorContext<TOptions extends PluginFactoryOptions = PluginFacto
    * Returns `'single'` when `output.path` is a file, `'split'` for a directory.
    */
   getMode: (output: { path: string }) => 'single' | 'split'
+  /**
+   * The driver running this build. Most generators never need it. Prefer the scoped helpers
+   * on this context (`getPlugin`, `getResolver`, `upsertFile`) over reaching into the driver.
+   */
   driver: KubbDriver
   /**
    * Get a plugin by name, typed via `Kubb.PluginRegistry` when registered.
@@ -50,23 +58,32 @@ export type GeneratorContext<TOptions extends PluginFactoryOptions = PluginFacto
    * Merge sources into the same output file.
    */
   upsertFile: (...file: Array<FileNode>) => Promise<void>
+  /**
+   * The build's event bus. Emit or listen to any `KubbHooks` event, for example to react to
+   * `kubb:build:end` from inside a generator.
+   */
   hooks: AsyncEventEmitter<KubbHooks>
   /**
    * The current plugin instance.
    */
   plugin: Plugin<TOptions>
   /**
-   * The current plugin's resolver, the object that decides what every generated symbol and
-   * file path is called. Resolved from a `setResolver` registration first, then the plugin's
-   * static `resolver`, then the built-in default. Use it inside a generator to compute names
-   * (`ctx.resolver.default(name, 'type')`) and output paths (`ctx.resolver.resolveFile(...)`).
+   * The current plugin's resolver. It decides what every generated symbol and file path is
+   * called. Kubb picks a `setResolver` registration first, then the plugin's static
+   * `resolver`, then the built-in default.
+   *
+   * @example Resolve a type name
+   * `ctx.resolver.default('pet', 'type') // 'Pet'`
+   *
+   * @example Resolve an output file
+   * `ctx.resolver.resolveFile({ name: 'pet', extname: '.ts' }, { root, output })`
    */
   resolver: TOptions['resolver']
   /**
-   * The AST visitor the current plugin registered through `setTransformer` during
-   * `kubb:plugin:setup`, or `undefined` when the plugin has none. The driver already applies
-   * it to every schema and operation node before the generator sees it, so reading it here is
-   * only needed to re-run or inspect the transformation.
+   * The AST visitor this plugin registered through `setTransformer` during
+   * `kubb:plugin:setup`, or `undefined` when it never registered one. The driver already
+   * applies the visitor to every schema and operation node before a generator sees it, so
+   * read it here only to inspect or re-run the transformation.
    */
   transformer: Visitor | undefined
   /**

--- a/packages/core/src/defineGenerator.ts
+++ b/packages/core/src/defineGenerator.ts
@@ -56,11 +56,17 @@ export type GeneratorContext<TOptions extends PluginFactoryOptions = PluginFacto
    */
   plugin: Plugin<TOptions>
   /**
-   * The current plugin's resolver.
+   * The current plugin's resolver, the object that decides what every generated symbol and
+   * file path is called. Resolved from a `setResolver` registration first, then the plugin's
+   * static `resolver`, then the built-in default. Use it inside a generator to compute names
+   * (`ctx.resolver.default(name, 'type')`) and output paths (`ctx.resolver.resolveFile(...)`).
    */
   resolver: TOptions['resolver']
   /**
-   * The current plugin's transformer.
+   * The AST visitor the current plugin registered through `setTransformer` during
+   * `kubb:plugin:setup`, or `undefined` when the plugin has none. The driver already applies
+   * it to every schema and operation node before the generator sees it, so reading it here is
+   * only needed to re-run or inspect the transformation.
    */
   transformer: Visitor | undefined
   /**

--- a/packages/core/src/defineMiddleware.ts
+++ b/packages/core/src/defineMiddleware.ts
@@ -14,6 +14,11 @@ export type Middleware = {
   /**
    * Lifecycle event handlers. Any event from the global `KubbHooks` map can be
    * subscribed to here. Handlers run after all plugin handlers for that event.
+   *
+   * Within each plugin the driver finishes every `kubb:generate:schema` event
+   * before it fires the first `kubb:generate:operation` or
+   * `kubb:generate:operations` event, so an operation handler can rely on all
+   * of that plugin's schemas being processed.
    */
   hooks: {
     [K in keyof KubbHooks]?: (...args: KubbHooks[K]) => void | Promise<void>

--- a/packages/core/src/defineMiddleware.ts
+++ b/packages/core/src/defineMiddleware.ts
@@ -12,13 +12,13 @@ export type Middleware = {
    */
   name: string
   /**
-   * Lifecycle event handlers. Any event from the global `KubbHooks` map can be
-   * subscribed to here. Handlers run after all plugin handlers for that event.
+   * Lifecycle event handlers. Subscribe to any event from the global `KubbHooks`
+   * map. Handlers run after all plugin handlers for that event.
    *
-   * Within each plugin the driver finishes every `kubb:generate:schema` event
-   * before it fires the first `kubb:generate:operation` or
-   * `kubb:generate:operations` event, so an operation handler can rely on all
-   * of that plugin's schemas being processed.
+   * The driver finishes every `kubb:generate:schema` event for a plugin before
+   * it fires that plugin's first `kubb:generate:operation` or
+   * `kubb:generate:operations` event, so an operation handler can count on the
+   * plugin's schemas being done.
    */
   hooks: {
     [K in keyof KubbHooks]?: (...args: KubbHooks[K]) => void | Promise<void>


### PR DESCRIPTION
## Summary

Minimal-impact performance, memory, and usability fixes in `@kubb/core`. Each change is small and contained, with tests pinning the new behavior.

### Memory

- `KubbDriver.run()` no longer retains every rendered source string in `snapshotSources` when caching is disabled. The Map was only ever read behind `if (cache && cacheKey)`, so cache-less builds paid the full memory cost for nothing.
- `FileProcessor.#processAndWrite` streams each file to storage as soon as it is parsed instead of materializing the whole batch (`[...this.stream(files)]`), emitting every `update`, and only then writing. Parsing now overlaps IO and the batch never holds every rendered source at once. Hook semantics are preserved: `start` first, one `update` per file, `end` strictly after the last write.

### Perf

- `#restoreSnapshot` writes cache-restored files in parallel batches of `STREAM_FLUSH_EVERY` (50) instead of one sequential `await` per file.
- `Transform.applyTo` memoizes the transformed node per (plugin, node) with a `WeakMap`. Plugins with a batch `operations()` generator run every operation through `resolveForPlugin` twice (per-node dispatch, then the collected tail); with a transformer registered, the visitor previously ran twice per operation and produced a fresh node identity each time, which also defeated the `resolveOptions` WeakMap cache in `defineResolver`. The memo makes the second pass return the identical node, so both caches hit and stateful visitors run once per node. `register()` invalidates the plugin's memo, `dispose()` clears it.

### Usability

- `requirePlugin` errors raised from a generator context now name the requiring plugin: `Plugin "x" is required by "y" but not found`. Direct `driver.requirePlugin` calls keep the plain message.
- Documented the schemas-before-operations ordering guarantee in `defineMiddleware` (previously only an internal `KubbDriver` comment).
- Behavioral JSDoc for `GeneratorContext.resolver` and `GeneratorContext.transformer`.

Explicitly out of scope (judged speculative or unsafe): tuning `STREAM_FLUSH_EVERY`/`SCHEMA_PARALLEL`, deduping imports/exports in `FileManager.mergeFile`, parser-ts printer caching, and sharing one generator ctx across nodes (a ctx stays per-node so generator mutations cannot leak between nodes).

## Testing

- `pnpm vitest run` in `packages/core`: 19 files, 247 tests pass (11 new tests covering streaming write order, end-after-last-write, snapshot persistence/restore above one write batch, transform memo identity and invalidation, per-node override resolution, and the new error message).
- `pnpm lint` and `pnpm typecheck` clean in `packages/core`; `@kubb/agent` and `kubb` typecheck cleanly against the rebuilt core dts.
- Patch changeset included for `@kubb/core`.

https://claude.ai/code/session_01PcAM2Xt6NXgGTMmbidD6UY