### PR TITLE
refactor(ast): remove unused type exports

### DIFF
--- a/.changeset/ast-trim-unused-type-exports.md
+++ b/.changeset/ast-trim-unused-type-exports.md
@@ -1,0 +1,7 @@
+---
+"@kubb/ast": patch
+---
+
+Trim type exports that no package in the kubb or plugins ecosystem consumes. The public barrel no
+longer re-exports node and helper types that were never imported, two unused node aliases are
+removed, and several internal-only types drop their `export`. Runtime behavior is unchanged.

--- a/packages/ast/src/nodes/code.ts
+++ b/packages/ast/src/nodes/code.ts
@@ -96,12 +96,6 @@ export type TypeNode = BaseNode & {
 }
 
 /**
- * Convenience alias for {@link TypeNode}.
- * @deprecated Use `TypeNode` directly.
- */
-export type TypeDeclarationNode = TypeNode
-
-/**
  * AST node representing a TypeScript `function` declaration.
  *
  * Mirrors the props of the `Function` component from `@kubb/renderer-jsx`.

--- a/packages/ast/src/nodes/file.ts
+++ b/packages/ast/src/nodes/file.ts
@@ -4,7 +4,7 @@ import type { CodeNode } from './code.ts'
 /**
  * Supported file extensions.
  */
-export type Extname = '.ts' | '.js' | '.tsx' | '.json' | `.${string}`
+type Extname = '.ts' | '.js' | '.tsx' | '.json' | `.${string}`
 
 type ImportName = string | Array<string | { propertyName: string; name?: string }>
 

--- a/packages/ast/src/nodes/http.ts
+++ b/packages/ast/src/nodes/http.ts
@@ -2,7 +2,7 @@
  * All supported HTTP status code literals as strings, as used in API specs
  * (for example, `"200"` and `"404"`).
  */
-export type HttpStatusCode =
+type HttpStatusCode =
   // 1xx Informational
   | '100'
   | '101'
@@ -83,37 +83,3 @@ export type HttpStatusCode =
  * ```
  */
 export type StatusCode = HttpStatusCode | 'default'
-
-/**
- * Supported media type strings used in request and response bodies.
- *
- * @example
- * ```ts
- * const mediaType: MediaType = 'application/json'
- * ```
- */
-export type MediaType =
-  // Application
-  | 'application/json'
-  | 'application/xml'
-  | 'application/x-www-form-urlencoded'
-  | 'application/octet-stream'
-  | 'application/pdf'
-  | 'application/zip'
-  | 'application/graphql'
-  // Multipart
-  | 'multipart/form-data'
-  // Text
-  | 'text/plain'
-  | 'text/html'
-  | 'text/csv'
-  | 'text/xml'
-  // Image
-  | 'image/png'
-  | 'image/jpeg'
-  | 'image/gif'
-  | 'image/webp'
-  | 'image/svg+xml'
-  // Audio / Video
-  | 'audio/mpeg'
-  | 'video/mp4'

--- a/packages/ast/src/nodes/index.ts
+++ b/packages/ast/src/nodes/index.ts
@@ -10,13 +10,13 @@ import type { ResponseNode } from './response.ts'
 import type { InputNode } from './root.ts'
 import type { SchemaNode } from './schema.ts'
 
-export type { BaseNode, NodeKind } from './base.ts'
-export type { ArrowFunctionNode, BreakNode, CodeNode, ConstNode, FunctionNode, JSDocNode, JsxNode, TextNode, TypeDeclarationNode, TypeNode } from './code.ts'
+export type { NodeKind } from './base.ts'
+export type { ArrowFunctionNode, BreakNode, CodeNode, ConstNode, FunctionNode, JSDocNode, JsxNode, TextNode, TypeNode } from './code.ts'
 export type { ContentNode } from './content.ts'
 export type { ExportNode, FileNode, ImportNode, SourceNode } from './file.ts'
 export type { FunctionNodeType, FunctionParameterNode, FunctionParametersNode, FunctionParamNode, ParameterGroupNode, ParamsTypeNode } from './function.ts'
-export type { HttpStatusCode, MediaType, StatusCode } from './http.ts'
-export type { GenericOperationNode, HttpMethod, HttpOperationNode, OperationNode, OperationNodeBase, OperationProtocol, RequestBodyNode } from './operation.ts'
+export type { StatusCode } from './http.ts'
+export type { GenericOperationNode, HttpMethod, HttpOperationNode, OperationNode, RequestBodyNode } from './operation.ts'
 export type { OutputNode } from './output.ts'
 export type { ParameterLocation, ParameterNode } from './parameter.ts'
 export type { PropertyNode } from './property.ts'
@@ -24,15 +24,10 @@ export type { ResponseNode } from './response.ts'
 export type { InputMeta, InputNode, InputStreamNode } from './root.ts'
 export type {
   ArraySchemaNode,
-  ComplexSchemaType,
   DateSchemaNode,
   DatetimeSchemaNode,
   EnumSchemaNode,
-  EnumValueNode,
-  FormatStringSchemaNode,
   IntersectionSchemaNode,
-  Ipv4SchemaNode,
-  Ipv6SchemaNode,
   NumberSchemaNode,
   ObjectSchemaNode,
   PrimitiveSchemaType,
@@ -42,7 +37,6 @@ export type {
   SchemaNode,
   SchemaNodeByType,
   SchemaType,
-  SpecialSchemaType,
   StringSchemaNode,
   TimeSchemaNode,
   UnionSchemaNode,

--- a/packages/ast/src/nodes/operation.ts
+++ b/packages/ast/src/nodes/operation.ts
@@ -8,7 +8,7 @@ export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 
 /**
  * Transport an operation belongs to.
  */
-export type OperationProtocol = 'http'
+type OperationProtocol = 'http'
 
 /**
  * AST node representing an operation request body.
@@ -53,7 +53,7 @@ export type RequestBodyNode = BaseNode & {
 /**
  * Fields shared by every operation, regardless of transport.
  */
-export type OperationNodeBase = BaseNode & {
+type OperationNodeBase = BaseNode & {
   /**
    * Node kind.
    */

--- a/packages/ast/src/nodes/schema.ts
+++ b/packages/ast/src/nodes/schema.ts
@@ -58,12 +58,12 @@ export type PrimitiveSchemaType =
 /**
  * Composite schema types.
  */
-export type ComplexSchemaType = 'tuple' | 'union' | 'intersection' | 'enum'
+type ComplexSchemaType = 'tuple' | 'union' | 'intersection' | 'enum'
 
 /**
  * Schema types that need special handling in generators.
  */
-export type SpecialSchemaType = 'ref' | 'datetime' | 'time' | 'uuid' | 'email' | 'url' | 'ipv4' | 'ipv6' | 'blob'
+type SpecialSchemaType = 'ref' | 'datetime' | 'time' | 'uuid' | 'email' | 'url' | 'ipv4' | 'ipv6' | 'blob'
 
 /**
  * All schema type strings.
@@ -306,7 +306,7 @@ export type IntersectionSchemaNode = CompositeSchemaNodeBase & {
 /**
  * One named enum item.
  */
-export type EnumValueNode = {
+type EnumValueNode = {
   /**
    * Enum item name.
    */
@@ -559,7 +559,7 @@ export type UrlSchemaNode = SchemaNodeBase & {
  * const uuidSchema: FormatStringSchemaNode = { kind: 'Schema', type: 'uuid', min: 36, max: 36 }
  * ```
  */
-export type FormatStringSchemaNode = SchemaNodeBase & {
+type FormatStringSchemaNode = SchemaNodeBase & {
   /**
    * Schema type discriminator.
    */
@@ -582,7 +582,7 @@ export type FormatStringSchemaNode = SchemaNodeBase & {
  * const ipv4Schema: Ipv4SchemaNode = { kind: 'Schema', type: 'ipv4' }
  * ```
  */
-export type Ipv4SchemaNode = SchemaNodeBase & {
+type Ipv4SchemaNode = SchemaNodeBase & {
   /**
    * Schema type discriminator.
    */
@@ -597,7 +597,7 @@ export type Ipv4SchemaNode = SchemaNodeBase & {
  * const ipv6Schema: Ipv6SchemaNode = { kind: 'Schema', type: 'ipv6' }
  * ```
  */
-export type Ipv6SchemaNode = SchemaNodeBase & {
+type Ipv6SchemaNode = SchemaNodeBase & {
   /**
    * Schema type discriminator.
    */

--- a/packages/ast/src/printer.ts
+++ b/packages/ast/src/printer.ts
@@ -13,7 +13,7 @@ import type { SchemaNode, SchemaNodeByType, SchemaType } from './nodes/index.ts'
  * }
  * ```
  */
-export type PrinterHandlerContext<TOutput, TOptions extends object> = {
+type PrinterHandlerContext<TOutput, TOptions extends object> = {
   /**
    * Recursively transform a nested `SchemaNode` to `TOutput` using the node-level handlers.
    * Use `this.transform` inside `nodes` handlers and inside the `print` override.
@@ -37,7 +37,7 @@ export type PrinterHandlerContext<TOutput, TOptions extends object> = {
  * }
  * ```
  */
-export type PrinterHandler<TOutput, TOptions extends object, T extends SchemaType = SchemaType> = (
+type PrinterHandler<TOutput, TOptions extends object, T extends SchemaType = SchemaType> = (
   this: PrinterHandlerContext<TOutput, TOptions>,
   node: SchemaNodeByType[T],
 ) => TOutput | null

--- a/packages/ast/src/types.ts
+++ b/packages/ast/src/types.ts
@@ -1,5 +1,4 @@
-export type { VisitorDepth } from './constants.ts'
-export type { BuildDedupePlanOptions, DedupeCanonical, DedupePlan } from './dedupe.ts'
+export type { DedupePlan } from './dedupe.ts'
 export type { SchemaDialect } from './dialect.ts'
 export type { DispatchRule } from './dispatch.ts'
 export type { DistributiveOmit } from './factory.ts'
@@ -7,44 +6,32 @@ export type { InferSchemaNode, ParserOptions } from './infer.ts'
 export type {
   ArraySchemaNode,
   ArrowFunctionNode,
-  BaseNode,
-  BreakNode,
   CodeNode,
-  ComplexSchemaType,
   ConstNode,
   DateSchemaNode,
   DatetimeSchemaNode,
   EnumSchemaNode,
-  EnumValueNode,
   ExportNode,
   FileNode,
-  FormatStringSchemaNode,
   FunctionNode,
   FunctionNodeType,
   FunctionParameterNode,
   FunctionParametersNode,
   FunctionParamNode,
-  GenericOperationNode,
   HttpMethod,
   HttpOperationNode,
-  HttpStatusCode,
   ImportNode,
   InputMeta,
   InputNode,
   InputStreamNode,
   IntersectionSchemaNode,
-  Ipv4SchemaNode,
-  Ipv6SchemaNode,
   JSDocNode,
   JsxNode,
-  MediaType,
   Node,
   NodeKind,
   NumberSchemaNode,
   ObjectSchemaNode,
   OperationNode,
-  OperationNodeBase,
-  OperationProtocol,
   OutputNode,
   ParameterGroupNode,
   ParameterLocation,
@@ -54,24 +41,20 @@ export type {
   PropertyNode,
   RefSchemaNode,
   ResponseNode,
-  ScalarSchemaNode,
   ScalarSchemaType,
   SchemaNode,
   SchemaNodeByType,
   SchemaType,
   SourceNode,
-  SpecialSchemaType,
   StatusCode,
   StringSchemaNode,
   TextNode,
   TimeSchemaNode,
-  TypeDeclarationNode,
   TypeNode,
   UnionSchemaNode,
   UrlSchemaNode,
 } from './nodes/index.ts'
-export type { AsyncVisitor, CollectOptions, CollectVisitor, ParentOf, TransformOptions, Visitor, VisitorContext, WalkOptions } from './visitor.ts'
+export type { ParentOf, Visitor, VisitorContext } from './visitor.ts'
 export type { Printer, PrinterFactoryOptions, PrinterPartial } from './printer.ts'
-export type { ScalarPrimitive } from './constants.ts'
 export type { OperationParamsResolver } from './utils/ast.ts'
 export type { UserFileNode } from './factory.ts'

--- a/packages/ast/src/utils/ast.ts
+++ b/packages/ast/src/utils/ast.ts
@@ -118,7 +118,7 @@ export function createDiscriminantNode({ propertyName, value }: { propertyName: 
 /**
  * Named type for a group of parameters (query or header) emitted as a single typed parameter.
  */
-export type ParamGroupType = {
+type ParamGroupType = {
   /**
    * TypeNode for the group type.
    */

--- a/packages/ast/src/visitor.ts
+++ b/packages/ast/src/visitor.ts
@@ -182,7 +182,7 @@ type MaybePromise<T> = T | Promise<T>
  * }
  * ```
  */
-export type AsyncVisitor = {
+type AsyncVisitor = {
   input?(node: InputNode, context: VisitorContext<InputNode>): MaybePromise<undefined | null | InputNode>
   output?(node: OutputNode, context: VisitorContext<OutputNode>): MaybePromise<undefined | null | OutputNode>
   operation?(node: OperationNode, context: VisitorContext<OperationNode>): MaybePromise<undefined | null | OperationNode>
@@ -204,7 +204,7 @@ export type AsyncVisitor = {
  * }
  * ```
  */
-export type CollectVisitor<T> = {
+type CollectVisitor<T> = {
   input?(node: InputNode, context: VisitorContext<InputNode>): T | null | undefined
   output?(node: OutputNode, context: VisitorContext<OutputNode>): T | null | undefined
   operation?(node: OperationNode, context: VisitorContext<OperationNode>): T | null | undefined


### PR DESCRIPTION
## What

Trims the `@kubb/ast` type surface to what the kubb and plugins repos actually use. The candidates came from knip (run with `--include-entry-exports`, no config committed) and were then cross-checked against both whole repos so nothing consumed externally gets dropped.

The public types barrel (`src/types.ts`) stops re-exporting 24 node and helper types that no consumer imported: `VisitorDepth`, `ScalarPrimitive`, `BuildDedupePlanOptions`, `DedupeCanonical`, `BaseNode`, `BreakNode`, `ComplexSchemaType`, `EnumValueNode`, `FormatStringSchemaNode`, `GenericOperationNode`, `HttpStatusCode`, `Ipv4SchemaNode`, `Ipv6SchemaNode`, `MediaType`, `OperationNodeBase`, `OperationProtocol`, `ScalarSchemaNode`, `SpecialSchemaType`, `TypeDeclarationNode`, `AsyncVisitor`, `CollectOptions`, `CollectVisitor`, `TransformOptions`, and `WalkOptions`.

The internal `nodes/index.ts` barrel stops re-exporting the orphaned ones. The unused `MediaType` union and the deprecated `TypeDeclarationNode` alias are deleted. Internal-only types that are only used to compose other types lose their `export` keyword (`PrinterHandler`, `PrinterHandlerContext`, `ParamGroupType`, `Extname`, plus `HttpStatusCode`, `OperationNodeBase`, `OperationProtocol`, `ComplexSchemaType`, `SpecialSchemaType`, `EnumValueNode`, `FormatStringSchemaNode`, `Ipv4SchemaNode`, `Ipv6SchemaNode`, `AsyncVisitor`, `CollectVisitor`).

Types that are still consumed stay put. `BaseNode` keeps its source export because sibling node files extend it; `SchemaNode`, `ParserOptions`, `DispatchRule`, `PrinterPartial`, and the rest stay because adapter-oas and the plugins use them.

## Why

The type barrel had grown a set of exports that nothing in the ecosystem imported. Trimming them keeps the public surface honest and matches the actual consumers.

## Tests

`@kubb/ast` builds with 337 tests, typecheck, and lint green. `@kubb/adapter-oas` and `@kubb/core` typecheck clean, and adapter-oas keeps its 465 tests green. No runtime behavior changes, since this only touches type exports.

https://claude.ai/code/session_01RxNTbFy19J9AZnDzQ4raP3

---
_Generated by [Claude Code](https://claude.ai/code/session_01RxNTbFy19J9AZnDzQ4raP3)_