### PR TITLE
docs: sync integerType default and renderer-jsx API docs with code

### DIFF
--- a/.changeset/sync-docs-with-code-defaults.md
+++ b/.changeset/sync-docs-with-code-defaults.md
@@ -1,0 +1,7 @@
+---
+"@kubb/adapter-oas": patch
+"@kubb/ast": patch
+"@kubb/renderer-jsx": patch
+---
+
+Sync option docs with the actual v5 defaults and APIs. The `integerType` docs in `@kubb/adapter-oas` (extension.yaml) and `@kubb/ast` (JSDoc) now state the real default `'bigint'` instead of `'number'`. The `@kubb/renderer-jsx` README drops the removed `createRenderer` and `renderer.unmount()` APIs in favor of `jsxRenderer()` with `render`, `files`, and `stream`, and lists the markdown components (`Callout`, `Frontmatter`, `Heading`, `List`, `Paragraph`).

--- a/.changeset/sync-docs-with-code-defaults.md
+++ b/.changeset/sync-docs-with-code-defaults.md
@@ -1,7 +1,8 @@
 ---
 "@kubb/adapter-oas": patch
 "@kubb/ast": patch
+"@kubb/core": patch
 "@kubb/renderer-jsx": patch
 ---
 
-Sync option docs with the actual v5 defaults and APIs. The `integerType` docs in `@kubb/adapter-oas` (extension.yaml) and `@kubb/ast` (JSDoc) now state the real default `'bigint'` instead of `'number'`. The `@kubb/renderer-jsx` README drops the removed `createRenderer` and `renderer.unmount()` APIs in favor of `jsxRenderer()` with `render`, `files`, and `stream`, and lists the markdown components (`Callout`, `Frontmatter`, `Heading`, `List`, `Paragraph`).
+Sync option docs with the actual v5 defaults and APIs. The `integerType` docs in `@kubb/adapter-oas` (extension.yaml) and `@kubb/ast` (JSDoc) now state the real default `'bigint'` instead of `'number'`. The `@kubb/core` JSDoc for build diagnostics names the per-plugin timing kind `performance` instead of the removed `timing`. The `@kubb/renderer-jsx` README drops the removed `createRenderer` and `renderer.unmount()` APIs in favor of `jsxRenderer()` with `render`, `files`, and `stream`, and lists the markdown components (`Callout`, `Frontmatter`, `Heading`, `List`, `Paragraph`).

--- a/packages/adapter-oas/extension.yaml
+++ b/packages/adapter-oas/extension.yaml
@@ -295,14 +295,14 @@ options:
   - name: integerType
     type: "'number' | 'bigint'"
     required: false
-    default: "'number'"
+    default: "'bigint'"
     description: |
       How `type: integer` (and `format: int64`) maps to TypeScript.
 
-      - `'number'` (default) — fits most JSON APIs; loses precision above `Number.MAX_SAFE_INTEGER`.
-      - `'bigint'` — exact for 64-bit IDs, but `JSON.stringify`/`JSON.parse` cannot round-trip it. Use only when you also handle bigint serialization explicitly.
+      - `'bigint'` (default) — exact for 64-bit IDs, but `JSON.stringify`/`JSON.parse` cannot round-trip it. Use only when you also handle bigint serialization explicitly.
+      - `'number'` — fits most JSON APIs; loses precision above `Number.MAX_SAFE_INTEGER`.
     examples:
-      - name: "'number' (default)"
+      - name: "'number'"
         files:
           - lang: typescript
             twoslash: false
@@ -310,7 +310,7 @@ options:
               type Pet = {
                 id: number
               }
-      - name: "'bigint'"
+      - name: "'bigint' (default)"
         files:
           - lang: typescript
             twoslash: false

--- a/packages/ast/src/infer.ts
+++ b/packages/ast/src/infer.ts
@@ -30,10 +30,10 @@ export type ParserOptions = {
   dateType: false | 'string' | 'stringOffset' | 'stringLocal' | 'date'
   /**
    * How `type: 'integer'` (and `format: 'int64'`) maps to TypeScript.
-   * - `'number'` fits most JSON APIs. Loses precision above `Number.MAX_SAFE_INTEGER`.
    * - `'bigint'` is exact for 64-bit IDs, but does not round-trip through JSON.
+   * - `'number'` fits most JSON APIs. Loses precision above `Number.MAX_SAFE_INTEGER`.
    *
-   * @default 'number'
+   * @default 'bigint'
    */
   integerType?: 'number' | 'bigint'
   /**

--- a/packages/core/src/createKubb.ts
+++ b/packages/core/src/createKubb.ts
@@ -613,7 +613,7 @@ export type KubbGenerationEndContext = {
   storage: Storage
   /**
    * Diagnostics collected during the build: error/warning/info problems plus a
-   * `timing` diagnostic per plugin. The end-of-run summary derives its failure counts
+   * `performance` diagnostic per plugin. The end-of-run summary derives its failure counts
    * and per-plugin timings from these. Set by the CLI runner, omitted by other callers.
    */
   diagnostics?: Array<Diagnostic>
@@ -835,7 +835,7 @@ export type BuildOutput = {
   /**
    * Structured diagnostics collected during the build: error/warning/info problems
    * (each with a code, severity, and where known a JSON-pointer location) plus a
-   * `timing` diagnostic per plugin. Includes a top-level diagnostic when the build
+   * `performance` diagnostic per plugin. Includes a top-level diagnostic when the build
    * threw before completing. Use {@link Diagnostics.hasError} to test for failure.
    */
   diagnostics: Array<Diagnostic>

--- a/packages/renderer-jsx/README.md
+++ b/packages/renderer-jsx/README.md
@@ -24,7 +24,7 @@
 
 ### JSX-based renderer for Kubb
 
-Provides a custom React runtime, reconciler, and built-in components (`File`, `Function`, `Type`, `Const`) for component-based, type-safe code generation inside Kubb plugins.
+Provides a React-free JSX runtime and built-in components (`File`, `Function`, `Type`, `Const`) for component-based, type-safe code generation inside Kubb plugins.
 
 ## Installation
 
@@ -41,10 +41,10 @@ npm install @kubb/renderer-jsx
 Use the built-in components inside a Kubb plugin to emit generated files:
 
 ```tsx
-import { createRenderer } from '@kubb/renderer-jsx'
+import { jsxRenderer } from '@kubb/renderer-jsx'
 import { File, Function, Type } from '@kubb/renderer-jsx'
 
-const renderer = createRenderer()
+const renderer = jsxRenderer()
 
 await renderer.render(
   <File baseName="petStore.ts" path="src/gen/petStore.ts">
@@ -58,7 +58,6 @@ await renderer.render(
 )
 
 const files = renderer.files
-renderer.unmount()
 ```
 
 ## Built-in Components
@@ -71,24 +70,25 @@ renderer.unmount()
 | `<Type>`        | Generates a TypeScript type alias                                           |
 | `<Const>`       | Generates a `const` variable declaration                                    |
 | `<Jsx>`         | Renders JSX expressions inside generated output                             |
-| `<Root>`        | Root container for the renderer tree                                        |
+| `<Callout>`     | Generates a callout block in markdown output                                |
+| `<Frontmatter>` | Generates a frontmatter block in markdown output                            |
+| `<Heading>`     | Generates a heading in markdown output                                      |
+| `<List>`        | Generates a list in markdown output                                         |
+| `<Paragraph>`   | Generates a paragraph in markdown output                                    |
 
 ## API
 
-### `createRenderer(options?)`
+### `jsxRenderer()`
 
-Creates a new renderer instance.
+Creates a renderer instance with `render`, `files`, and `stream`:
 
 ```typescript
-const renderer = createRenderer({ debug: false })
+const renderer = jsxRenderer()
 await renderer.render(<MyComponent />)
 const files = renderer.files  // FileNode[]
-renderer.unmount()
 ```
 
-### `jsxRenderer`
-
-Pre-built renderer instance for use directly in Kubb plugins as the `jsxRenderer` plugin option.
+Use `stream(element)` instead of `render` to consume files one at a time as they are produced.
 
 ## JSX Runtime
 


### PR DESCRIPTION
## What changed

Docs-only fixes found while auditing the four hand-maintained `extension.yaml` files and package READMEs against the v5.0.0-beta.44 code:

- `packages/adapter-oas/extension.yaml` documented the `integerType` default as `'number'`, but `DEFAULT_PARSER_OPTIONS` in `src/constants.ts` defaults to `'bigint'` (the intentional v5 change called out in the kubb.dev migration guide). The YAML now states `'bigint'` and reorders the option bullets and example labels to match.
- The matching JSDoc `@default` on `ParserOptions.integerType` in `packages/ast/src/infer.ts` had the same stale `'number'` value.
- `packages/renderer-jsx/README.md` still showed the removed `createRenderer(options?)` factory and `renderer.unmount()` calls. It now documents `jsxRenderer()` with `render`, `files`, and `stream`, describes the runtime as React-free, and lists the markdown components (`Callout`, `Frontmatter`, `Heading`, `List`, `Paragraph`) that were missing from the components table.

`middleware-barrel`, `parser-ts`, and `parser-md` extension.yaml files were audited and are in sync. Patch changeset included since extension.yaml and the JSDoc ship with the published packages.

## Verification

- `pnpm lint` clean
- `pnpm --filter @kubb/ast typecheck` passes (the only source file touched is a JSDoc comment)

Part of a docs-sync effort across kubb, plugins, and platform (matching branches in each repo, see kubb-labs/plugins#328).

https://claude.ai/code/session_013F9Ew8dgT5FMzsgGPrma71

---
_Generated by [Claude Code](https://claude.ai/code/session_013F9Ew8dgT5FMzsgGPrma71)_