### PR TITLE
fix(core): default tag group folder to the plain tag

### DIFF
--- a/.changeset/group-tag-default-plain-tag.md
+++ b/.changeset/group-tag-default-plain-tag.md
@@ -1,0 +1,7 @@
+---
+"@kubb/core": minor
+---
+
+Default the `tag` group folder name to the plain camelCased tag instead of `${tag}Controller`.
+
+With `group: { type: 'tag' }`, files now land in `pet/` rather than `petController/`. The `Controller` suffix was a leftover convention nothing else in the output referenced. To keep the old layout, set `group: { type: 'tag', name: ({ group }) => \`${group}Controller\` }`.

--- a/.changeset/remove-user-group-type.md
+++ b/.changeset/remove-user-group-type.md
@@ -6,4 +6,4 @@ Remove `UserGroup` type and make `Group.name` optional.
 
 `UserGroup` and `Group` were structurally identical after making `name` optional on `Group`, so `UserGroup` has been removed. Use `Group` everywhere.
 
-`defaultResolvePath` now supplies built-in defaults when `name` is omitted: `${camelCase(tag)}Controller` for tag groups and the first path segment for path groups.
+`defaultResolvePath` now supplies built-in defaults when `name` is omitted: the camelCased tag for tag groups and the first path segment for path groups.

--- a/packages/core/src/definePlugin.ts
+++ b/packages/core/src/definePlugin.ts
@@ -62,8 +62,8 @@ export type Group = {
    */
   type: 'tag' | 'path'
   /**
-   * Returns the subdirectory name from the group key. Defaults to
-   * `${camelCase(group)}Controller` for tags, or the first path segment.
+   * Returns the subdirectory name from the group key. Defaults to the
+   * camelCased tag for `tag` groups, or the first path segment for `path` groups.
    */
   name?: (context: { group: string }) => string
 }

--- a/packages/core/src/defineResolver.test.ts
+++ b/packages/core/src/defineResolver.test.ts
@@ -78,22 +78,17 @@ describe('defaultResolvePath', () => {
     expect(result).toBe('/root/types')
   })
 
-  it('groups by tag when group.type is tag', () => {
+  it('groups by tag using the plain camelCased tag by default', () => {
     const result = defaultResolvePath(
-      { baseName: 'petTypes.ts', tag: 'pets' },
+      { baseName: 'petTypes.ts', tag: 'pet store' },
       {
         root: '/root',
         output: { path: 'types' },
-        group: {
-          type: 'tag',
-          name: (ctx: { group: string }) => {
-            return `${camelCase(ctx.group)}Controller`
-          },
-        },
+        group: { type: 'tag' },
       },
     )
 
-    expect(result).toBe('/root/types/petsController/petTypes.ts')
+    expect(result).toBe('/root/types/petStore/petTypes.ts')
   })
 
   it('groups by path when group.type is path', () => {
@@ -230,16 +225,11 @@ describe('defaultResolveFile', () => {
       {
         root: '/root',
         output: { path: 'types' },
-        group: {
-          type: 'tag',
-          name: (ctx: { group: string }) => {
-            return `${camelCase(ctx.group)}Controller`
-          },
-        },
+        group: { type: 'tag' },
       },
     )
 
-    expect(file.path).toBe('/root/types/petsController/pet.ts')
+    expect(file.path).toBe('/root/types/pets/pet.ts')
   })
 })
 

--- a/packages/core/src/defineResolver.ts
+++ b/packages/core/src/defineResolver.ts
@@ -71,7 +71,7 @@ export type Resolver = {
  *   { baseName: 'petTypes.ts', tag: 'pets' },
  *   { root: '/src', output: { path: 'types' }, group: { type: 'tag' } },
  * )
- * // → '/src/types/petsController/petTypes.ts'
+ * // → '/src/types/pets/petTypes.ts'
  * ```
  */
 export type ResolverPathParams = {
@@ -124,7 +124,7 @@ export type ResolverContext = {
  *   { name: 'listPets', extname: '.ts', tag: 'pets' },
  *   { root: '/src', output: { path: 'types' }, group: { type: 'tag' } },
  * )
- * // → { baseName: 'listPets.ts', path: '/src/types/petsController/listPets.ts', ... }
+ * // → { baseName: 'listPets.ts', path: '/src/types/pets/listPets.ts', ... }
  * ```
  */
 export type ResolverFileParams = {
@@ -386,7 +386,7 @@ export function defaultResolveOptions<TOptions>(
  * - Falls back to a flat `output/baseName` path otherwise.
  *
  * A custom `group.name` function overrides the default subdirectory naming.
- * For `tag` groups the default is `${camelCase(tag)}Controller`.
+ * For `tag` groups the default is the camelCased tag.
  * For `path` groups the default is the first path segment after `/`.
  *
  * @example Flat output
@@ -401,7 +401,7 @@ export function defaultResolveOptions<TOptions>(
  *   { baseName: 'petTypes.ts', tag: 'pets' },
  *   { root: '/src', output: { path: 'types' }, group: { type: 'tag' } },
  * )
- * // → '/src/types/petsController/petTypes.ts'
+ * // → '/src/types/pets/petTypes.ts'
  * ```
  *
  * @example Path-based grouping
@@ -434,7 +434,7 @@ export function defaultResolvePath({ baseName, pathMode, tag, path: groupPath }:
       const groupValue = group.type === 'path' ? groupPath! : tag!
       const defaultName =
         group.type === 'tag'
-          ? ({ group: groupName }: { group: string }) => `${camelCase(groupName)}Controller`
+          ? ({ group: groupName }: { group: string }) => camelCase(groupName)
           : ({ group: groupName }: { group: string }) => {
               // Strip traversal components (empty, '.', '..') before taking the first meaningful segment.
               // When every segment is a traversal component (e.g. '../../') we fall back to '' so the
@@ -493,7 +493,7 @@ export function defaultResolvePath({ baseName, pathMode, tag, path: groupPath }:
  *   { name: 'listPets', extname: '.ts', tag: 'pets' },
  *   { root: '/src', output: { path: 'types' }, group: { type: 'tag' } },
  * )
- * // → { baseName: 'listPets.ts', path: '/src/types/petsController/listPets.ts', ... }
+ * // → { baseName: 'listPets.ts', path: '/src/types/pets/listPets.ts', ... }
  * ```
  */
 export function defaultResolveFile(this: Resolver, { name, extname, tag, path: groupPath }: ResolverFileParams, context: ResolverContext): FileNode {


### PR DESCRIPTION
## Summary

Fixes the `@kubb/core` half of #3506. With `group: { type: 'tag' }`, the default folder-name resolver appended `Controller` (`pets` → `petsController/`). This changes the default for tag groups to the plain camelCased tag, so files land in `pets/`. A user-supplied `group.name` still overrides the default.

The `Controller` suffix was a leftover convention nothing in the generated output referenced. v5 is still in beta, so this is the cheapest moment to change the default before it becomes a breaking layout change.

## Changes

- `defineResolver.ts`: tag default `({ group }) => \`${camelCase(group)}Controller\`` → `({ group }) => camelCase(group)`. The path branch and the output-directory boundary check are untouched.
- Updated the `defaultResolvePath` / `resolveFile` JSDoc examples (`petsController/` → `pets/`) and the `Group.name` JSDoc default note in `definePlugin.ts`.
- Tests now exercise the real default (no `name`) and assert the plain tag.
- Changeset added; corrected the stale default description in the unreleased `remove-user-group-type.md`.

## Note on plugin output

In practice every plugin in [`kubb-labs/plugins`](https://github.com/kubb-labs/plugins) overrides this default via `createGroupConfig(group, { suffix: 'Controller' })`, so this core change alone does not move plugin output. The matching plugins-repo change (drop the suffix everywhere, regenerate examples and snapshots) is in a companion PR on the same branch, and the kubb.dev migration guide is updated in a third.

Closes #3506

https://claude.ai/code/session_01Cg4YbQMxfq1FHbu1XjbWj4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg4YbQMxfq1FHbu1XjbWj4)_