### PR TITLE
fix(ast): drop self-imports of locally-defined symbols in grouped output

### DIFF
--- a/.changeset/ast-drop-grouped-self-import.md
+++ b/.changeset/ast-drop-grouped-self-import.md
@@ -1,0 +1,7 @@
+---
+'@kubb/ast': patch
+---
+
+Drop self-imports of locally-defined symbols in consolidated output (`mode: 'group'`/`mode: 'file'`).
+
+A grouped file that defines a type (e.g. `Pet`) no longer also imports that same type. In group mode the import for a referenced schema resolves to the per-schema path while the file lives at the group path, so the existing path-based filter could not match. `createFile` now also drops any import whose binding is defined locally by one of the file's own sources, keeping the local definition intact.

--- a/.changeset/ast-drop-grouped-self-import.md
+++ b/.changeset/ast-drop-grouped-self-import.md
@@ -4,4 +4,4 @@
 
 Drop self-imports of locally-defined symbols in consolidated output (`mode: 'group'`/`mode: 'file'`).
 
-A grouped file that defines a type (e.g. `Pet`) no longer also imports that same type. In group mode the import for a referenced schema resolves to the per-schema path while the file lives at the group path, so the existing path-based filter could not match. `createFile` now also drops any import whose binding is defined locally by one of the file's own sources, keeping the local definition intact.
+A grouped file that defines a type (e.g. `Pet`) no longer also imports that same type. In group mode the import for a referenced schema resolves to the per-schema path while the file lives at the group path, so the existing path-based filter could not match. `createFile` now also drops any import whose binding is defined locally by one of the file's own sources. The local definition stays in place.

--- a/packages/ast/src/factory.test.ts
+++ b/packages/ast/src/factory.test.ts
@@ -562,6 +562,40 @@ describe('createFile', () => {
     expect(paths).toContain('zod')
   })
 
+  it('drops imports of names defined locally even when the path differs (group mode)', () => {
+    // In `mode: 'group'` the grouped file lives at the tag path while the import for `Pet`
+    // resolves to the per-schema path, so the strings differ and the path filter cannot match.
+    const selfNamedImport = createImport({ name: ['Pet'], path: 'src/models/Pet.ts' })
+    const crossFileImport = createImport({ name: ['Order'], path: 'src/models/Order.ts' })
+    const petSource = createSource({ name: 'Pet', nodes: [createText('export type Pet = { order: Order }')], isExportable: true })
+    const file = createFile({
+      baseName: 'pet.ts',
+      path: 'src/models/pet.ts',
+      sources: [petSource],
+      imports: [selfNamedImport, crossFileImport],
+    })
+
+    const names = file.imports.flatMap((i) => (Array.isArray(i.name) ? i.name : [i.name]))
+    expect(names).not.toContain('Pet')
+    expect(names).toContain('Order')
+    expect(file.sources.some((s) => s.name === 'Pet')).toBe(true)
+  })
+
+  it('keeps non-local names when a grouped import mixes local and cross-file bindings', () => {
+    const mixedImport = createImport({ name: ['Pet', 'Order'], path: 'src/models/Pet.ts' })
+    const petSource = createSource({ name: 'Pet', nodes: [createText('export type Pet = { order: Order }')], isExportable: true })
+    const file = createFile({
+      baseName: 'pet.ts',
+      path: 'src/models/pet.ts',
+      sources: [petSource],
+      imports: [mixedImport],
+    })
+
+    const names = file.imports.flatMap((i) => (Array.isArray(i.name) ? i.name : [i.name]))
+    expect(names).not.toContain('Pet')
+    expect(names).toContain('Order')
+  })
+
   it('carries through meta, banner and footer', () => {
     const file = createFile({
       baseName: 'pet.ts',

--- a/packages/ast/src/factory.ts
+++ b/packages/ast/src/factory.ts
@@ -668,15 +668,13 @@ export function createFile<TMeta extends object = object>(input: UserFileNode<TM
     .join('\n\n')
   const resolvedExports = input.exports?.length ? combineExports(input.exports) : []
   const combinedImports = input.imports?.length ? combineImports(input.imports, resolvedExports, source || undefined) : []
-  // Names this file defines locally. Consolidated output (`mode: 'group'`/`mode: 'file'`) can land a
-  // symbol's own definition and a cross-file import of it in the same file; in group mode the import
-  // path no longer matches `input.path`, so also drop imports whose binding is defined here. Sources
-  // are left intact, so the local definition stays.
   const localNames = new Set((input.sources ?? []).map((item) => item.name).filter((name): name is string => Boolean(name)))
   const nameOf = (item: string | { propertyName: string; name?: string }): string => (typeof item === 'string' ? item : (item.name ?? item.propertyName))
-  // Drop imports that resolve to the containing file itself. Consolidated output
-  // (`mode: 'group'` and `mode: 'file'`) turns former cross-file imports into self-imports.
-  // Bare module specifiers (`'zod'`, `'@faker-js/faker'`) never equal an absolute file path.
+  // Drop self-imports. Consolidating output (`mode: 'group'`/`mode: 'file'`) can place a symbol's
+  // definition and a cross-file import of it in the same file. The first pass catches imports that
+  // resolve to this file's own path. The second drops imports of names the file already defines,
+  // the case `mode: 'group'` produces when the import path no longer matches `input.path`. Sources
+  // stay intact, so the local definition remains. Bare specifiers like `'zod'` never match a path.
   const resolvedImports = combinedImports
     .filter((imp) => imp.path !== input.path)
     .flatMap((imp) => {

--- a/packages/ast/src/factory.ts
+++ b/packages/ast/src/factory.ts
@@ -668,10 +668,25 @@ export function createFile<TMeta extends object = object>(input: UserFileNode<TM
     .join('\n\n')
   const resolvedExports = input.exports?.length ? combineExports(input.exports) : []
   const combinedImports = input.imports?.length ? combineImports(input.imports, resolvedExports, source || undefined) : []
+  // Names this file defines locally. Consolidated output (`mode: 'group'`/`mode: 'file'`) can land a
+  // symbol's own definition and a cross-file import of it in the same file; in group mode the import
+  // path no longer matches `input.path`, so also drop imports whose binding is defined here. Sources
+  // are left intact, so the local definition stays.
+  const localNames = new Set((input.sources ?? []).map((item) => item.name).filter((name): name is string => Boolean(name)))
+  const nameOf = (item: string | { propertyName: string; name?: string }): string => (typeof item === 'string' ? item : (item.name ?? item.propertyName))
   // Drop imports that resolve to the containing file itself. Consolidated output
   // (`mode: 'group'` and `mode: 'file'`) turns former cross-file imports into self-imports.
   // Bare module specifiers (`'zod'`, `'@faker-js/faker'`) never equal an absolute file path.
-  const resolvedImports = combinedImports.filter((imp) => imp.path !== input.path)
+  const resolvedImports = combinedImports
+    .filter((imp) => imp.path !== input.path)
+    .flatMap((imp) => {
+      if (!Array.isArray(imp.name)) {
+        return typeof imp.name === 'string' && localNames.has(imp.name) ? [] : [imp]
+      }
+      const kept = imp.name.filter((item) => !localNames.has(nameOf(item)))
+      if (!kept.length) return []
+      return [kept.length === imp.name.length ? imp : { ...imp, name: kept }]
+    })
   const resolvedSources = input.sources?.length ? combineSources(input.sources) : []
 
   return {


### PR DESCRIPTION
## Problem

With `pluginTs({ output: { path: 'models', mode: 'group' }, group: { type: 'tag' } })`, a consolidated file that **defines** a type (e.g. `Pet`) was also **importing** that same type into itself:

```ts
import type { Pet } from './Pet.ts'   // ❌ self-import
export type Pet = { ... }             // local definition
```

`createFile` in `@kubb/ast` already drops self-imports, but only by comparing `imp.path !== input.path`. In `mode: 'group'` the import for a referenced schema resolves to the **per-schema** path (`…/models/Pet.ts`) while the consolidated file lives at the **group** path (`…/models/<tag>.ts`). The two strings differ, so the path filter missed and the self-import survived.

## Fix

`createFile` now also drops any import whose binding is **defined locally** by one of the file's own `SourceNode`s (matched by `source.name`). For multi-name imports, only the locally-defined names are removed; the rest are kept. The `sources` are left untouched, so the local definition stays in the file.

- Keeps the existing path-based drop as the first pass.
- Bare/default/namespace imports are unaffected unless their single name collides with a local definition (a genuine duplicate-binding error in generated code, so dropping is correct).

## Tests

Added two cases to `packages/ast/src/factory.test.ts`:
- A grouped self-import where the import path differs from the file path but the name is defined locally → import dropped, local definition preserved.
- A mixed import (`['Pet', 'Order']`) where only `Pet` is local → keeps `Order`, drops `Pet`.

`@kubb/ast` (340) and `@kubb/core` (258) test suites pass; lint and typecheck clean.

https://claude.ai/code/session_01Ty1kTTkfd46kKdK4UH7Emr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ty1kTTkfd46kKdK4UH7Emr)_