### PR TITLE
feat(core)!: remove 'group' output mode

### DIFF
--- a/.changeset/remove-group-output-mode.md
+++ b/.changeset/remove-group-output-mode.md
@@ -1,0 +1,11 @@
+---
+'@kubb/core': major
+---
+
+Remove the `'group'` output mode. `output.mode` now accepts `'directory' | 'file'`.
+
+`'directory'` (the default) writes one file per operation or schema, and `'file'` writes everything into a single file. The per-group consolidation mode is gone.
+
+The `group` option stays and keeps organizing `'directory'` output into per-tag or per-path subdirectories. It remains invalid with `'file'`, and pairing the two now fails the build with a `KUBB_INVALID_PLUGIN_OPTIONS` diagnostic.
+
+Migrate any plugin set to `output.mode: 'group'` to `'directory'` (keep the `group` option for subdirectories) or `'file'` (drop the `group` option for a single file).

--- a/packages/ast/src/factory.test.ts
+++ b/packages/ast/src/factory.test.ts
@@ -562,8 +562,8 @@ describe('createFile', () => {
     expect(paths).toContain('zod')
   })
 
-  it('drops imports of names defined locally even when the path differs (group mode)', () => {
-    // In `mode: 'group'` the grouped file lives at the tag path while the import for `Pet`
+  it('drops imports of names defined locally even when the path differs', () => {
+    // When output is consolidated the file can live at one path while the import for `Pet`
     // resolves to the per-schema path, so the strings differ and the path filter cannot match.
     const selfNamedImport = createImport({ name: ['Pet'], path: 'src/models/Pet.ts' })
     const crossFileImport = createImport({ name: ['Order'], path: 'src/models/Order.ts' })

--- a/packages/ast/src/factory.ts
+++ b/packages/ast/src/factory.ts
@@ -670,10 +670,10 @@ export function createFile<TMeta extends object = object>(input: UserFileNode<TM
   const combinedImports = input.imports?.length ? combineImports(input.imports, resolvedExports, source || undefined) : []
   const localNames = new Set((input.sources ?? []).map((item) => item.name).filter((name): name is string => Boolean(name)))
   const nameOf = (item: string | { propertyName: string; name?: string }): string => (typeof item === 'string' ? item : (item.name ?? item.propertyName))
-  // Drop self-imports. Consolidating output (`mode: 'group'`/`mode: 'file'`) can place a symbol's
+  // Drop self-imports. Consolidating output (`mode: 'file'`) can place a symbol's
   // definition and a cross-file import of it in the same file. The first pass catches imports that
   // resolve to this file's own path. The second drops imports of names the file already defines,
-  // the case `mode: 'group'` produces when the import path no longer matches `input.path`. Sources
+  // the case consolidation produces when the import path no longer matches `input.path`. Sources
   // stay intact, so the local definition remains. Bare specifiers like `'zod'` never match a path.
   const resolvedImports = combinedImports
     .filter((imp) => imp.path !== input.path)

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -100,7 +100,7 @@ export const diagnosticCode = {
    */
   pathTraversal: 'KUBB_PATH_TRAVERSAL',
   /**
-   * A plugin's options are invalid, for example `output.mode: 'group'` without a `group` option.
+   * A plugin's options are invalid, for example `output.mode: 'file'` paired with a `group` option.
    */
   invalidPluginOptions: 'KUBB_INVALID_PLUGIN_OPTIONS',
   /**

--- a/packages/core/src/definePlugin.test.ts
+++ b/packages/core/src/definePlugin.test.ts
@@ -519,20 +519,22 @@ describe('normalizeOutput', () => {
     expect(result).toStrictEqual({ path: 'models.ts', mode: 'file' })
   })
 
-  it('passes through group mode when a group is configured', () => {
-    const result = normalizeOutput({ output: { path: 'clients', mode: 'group' }, group: { type: 'tag' }, pluginName: 'plugin-client' })
+  it('passes through directory mode when a group is configured', () => {
+    const result = normalizeOutput({ output: { path: 'clients', mode: 'directory' }, group: { type: 'tag' }, pluginName: 'plugin-client' })
 
-    expect(result).toStrictEqual({ path: 'clients', mode: 'group' })
+    expect(result).toStrictEqual({ path: 'clients', mode: 'directory' })
   })
 
-  it('throws KUBB_INVALID_PLUGIN_OPTIONS for group mode without a group', () => {
-    expect(() => normalizeOutput({ output: { path: 'clients', mode: 'group' }, pluginName: 'plugin-client' })).toThrowError(/output\.mode: 'group'/)
+  it('throws KUBB_INVALID_PLUGIN_OPTIONS for file mode paired with a group', () => {
+    expect(() => normalizeOutput({ output: { path: 'models.ts', mode: 'file' }, group: { type: 'tag' }, pluginName: 'plugin-ts' })).toThrowError(
+      /output\.mode: 'file'/,
+    )
   })
 
-  it('throws when group is null in group mode', () => {
+  it('throws a Diagnostics error when file mode is paired with a group', () => {
     let thrown: unknown
     try {
-      normalizeOutput({ output: { path: 'clients', mode: 'group' }, group: null, pluginName: 'plugin-client' })
+      normalizeOutput({ output: { path: 'models.ts', mode: 'file' }, group: { type: 'tag' }, pluginName: 'plugin-ts' })
     } catch (error) {
       thrown = error
     }

--- a/packages/core/src/definePlugin.ts
+++ b/packages/core/src/definePlugin.ts
@@ -17,10 +17,9 @@ type ExtractRegistryKey<T, K extends PropertyKey> = K extends keyof T ? T[K] : {
 /**
  * How a plugin consolidates its generated code into files.
  * - `'directory'` writes one file per operation or schema under `path`.
- * - `'group'` writes one file per resolved group, and requires the plugin's `group` option.
  * - `'file'` writes everything into a single file.
  */
-export type OutputMode = 'directory' | 'group' | 'file'
+export type OutputMode = 'directory' | 'file'
 
 /**
  * Output configuration shared by every plugin. Each plugin extends this with
@@ -36,7 +35,6 @@ export type Output<_TOptions = unknown> = {
   /**
    * How generated code is consolidated into files.
    * - `'directory'` writes one file per operation or schema under `path`.
-   * - `'group'` writes one file per resolved group, and requires the plugin's `group` option.
    * - `'file'` writes everything into a single file. The `path` must include the file extension.
    *
    * @default 'directory'
@@ -89,9 +87,9 @@ export type Group = {
 
 /**
  * Couples `output.mode` with the plugin's `group` option at the type level.
- * - `mode: 'group'` requires `group`.
  * - `mode: 'file'` forbids `group` (a single file has nothing to group).
- * - `mode: 'directory'` (or no mode) allows an optional `group`.
+ * - `mode: 'directory'` (or no mode) allows an optional `group` to organize
+ *   files into per-group subdirectories.
  *
  * Intersect into a plugin's `Options` type instead of declaring `output` and
  * `group` directly — `mode` lives inside `output` while `group` is its sibling.
@@ -113,25 +111,21 @@ export type OutputOptions<TOutput extends Output = Output> =
       output: TOutput & { mode: 'file' }
       group?: never
     }
-  | {
-      output: TOutput & { mode: 'group' }
-      group: Group
-    }
 
 /**
  * Merges the `output.mode` default into the output config and validates the combination.
- * Throws `KUBB_INVALID_PLUGIN_OPTIONS` when `mode: 'group'` is set without a `group` option,
- * failing the build at setup time instead of silently producing wrong files.
+ * Throws `KUBB_INVALID_PLUGIN_OPTIONS` when `mode: 'file'` is paired with a `group` option,
+ * since a single-file output has nothing to group.
  */
 export function normalizeOutput({ output, group, pluginName }: { output: Output; group?: Group | null; pluginName: string }): Output {
   const mode = output.mode ?? 'directory'
 
-  if (mode === 'group' && !group) {
+  if (mode === 'file' && group) {
     throw new Diagnostics.Error({
       code: diagnosticCode.invalidPluginOptions,
       severity: 'error',
-      message: `Plugin "${pluginName}" sets \`output.mode: 'group'\` but has no \`group\` option configured.`,
-      help: "Add `group: { type: 'tag' }` (or `{ type: 'path' }`) to the plugin options, or use `output.mode: 'directory'` or `'file'`.",
+      message: `Plugin "${pluginName}" sets \`output.mode: 'file'\` but also configures a \`group\` option.`,
+      help: "A single-file output has nothing to group. Remove the `group` option, or use `output.mode: 'directory'` to organize files into subdirectories.",
       location: { kind: 'config' },
       plugin: pluginName,
     })

--- a/packages/core/src/defineResolver.test.ts
+++ b/packages/core/src/defineResolver.test.ts
@@ -232,7 +232,6 @@ describe('defaultResolveFile', () => {
 
     expect(file.path).toBe('/root/types/pets/pet.ts')
   })
-
 })
 
 const mockConfig = {

--- a/packages/core/src/defineResolver.test.ts
+++ b/packages/core/src/defineResolver.test.ts
@@ -78,39 +78,6 @@ describe('defaultResolvePath', () => {
     expect(result).toBe('/root/types.ts')
   })
 
-  it('consolidates a tag group into one file in group mode', () => {
-    const result = defaultResolvePath(
-      { baseName: 'listPets.ts', tag: 'pet store' },
-      { root: '/root', output: { path: 'clients', mode: 'group' }, group: { type: 'tag' } },
-    )
-
-    expect(result).toBe('/root/clients/petStore.ts')
-  })
-
-  it('consolidates a path group into one file in group mode', () => {
-    const result = defaultResolvePath(
-      { baseName: 'listPets.ts', path: '/pets/list' },
-      { root: '/root', output: { path: 'clients', mode: 'group' }, group: { type: 'path' } },
-    )
-
-    expect(result).toBe('/root/clients/pets.ts')
-  })
-
-  it('uses custom group.name for the file name in group mode', () => {
-    const result = defaultResolvePath(
-      { baseName: 'listPets.ts', tag: 'pets' },
-      { root: '/root', output: { path: 'clients', mode: 'group' }, group: { type: 'tag', name: ({ group }) => `custom_${group}` } },
-    )
-
-    expect(result).toBe('/root/clients/custom_pets.ts')
-  })
-
-  it('falls back to one file per schema in group mode when no tag or path is given', () => {
-    const result = defaultResolvePath({ baseName: 'Pet.ts' }, { root: '/root', output: { path: 'types', mode: 'group' }, group: { type: 'tag' } })
-
-    expect(result).toBe('/root/types/Pet.ts')
-  })
-
   it('groups by tag using the plain camelCased tag by default', () => {
     const result = defaultResolvePath(
       { baseName: 'petTypes.ts', tag: 'pet store' },
@@ -266,20 +233,6 @@ describe('defaultResolveFile', () => {
     expect(file.path).toBe('/root/types/pets/pet.ts')
   })
 
-  it('consolidates operations into one file per group in group mode', () => {
-    const file = defaultResolveFile.call(
-      resolver,
-      { name: 'list pets', extname: '.ts', tag: 'pets' },
-      {
-        root: '/root',
-        output: { path: 'clients', mode: 'group' },
-        group: { type: 'tag' },
-      },
-    )
-
-    expect(file.path).toBe('/root/clients/pets.ts')
-    expect(file.baseName).toBe('pets.ts')
-  })
 })
 
 const mockConfig = {

--- a/packages/core/src/defineResolver.ts
+++ b/packages/core/src/defineResolver.ts
@@ -380,7 +380,6 @@ export function defaultResolveOptions<TOptions>(
  * Default path resolver used by `defineResolver`.
  *
  * - `mode: 'file'` — resolves directly to `output.path` (the full file path, extension included).
- * - `mode: 'group'` with a tag or path — resolves to `output.path/{groupName}{ext}`.
  * - `mode: 'directory'` (default) — resolves to `output.path/{baseName}`, or into a
  *   subdirectory when `group` and a `tag`/`path` value are provided.
  *
@@ -420,15 +419,6 @@ export function defaultResolveOptions<TOptions>(
  * )
  * // → '/src/types.ts'
  * ```
- *
- * @example One file per group (`mode: 'group'`)
- * ```ts
- * defaultResolvePath(
- *   { baseName: 'listPets.ts', tag: 'pets' },
- *   { root: '/src', output: { path: 'clients', mode: 'group' }, group: { type: 'tag' } },
- * )
- * // → '/src/clients/pets.ts'
- * ```
  */
 export function defaultResolvePath({ baseName, tag, path: groupPath }: ResolverPathParams, { root, output, group }: ResolverContext): string {
   const mode = output.mode ?? 'directory'
@@ -453,11 +443,6 @@ export function defaultResolvePath({ baseName, tag, path: groupPath }: ResolverP
       const resolveName = group.name ?? defaultName
       const groupName = resolveName({ group: groupValue })
 
-      // `mode: 'group'` consolidates every operation in a group into one file named after the group,
-      // while the default places each file inside a per-group subdirectory.
-      if (mode === 'group') {
-        return path.resolve(root, output.path, `${groupName}${path.extname(baseName) || '.ts'}`)
-      }
       return path.resolve(root, output.path, groupName, baseName)
     }
     return path.resolve(root, output.path, baseName)

--- a/packages/core/src/diagnostics.ts
+++ b/packages/core/src/diagnostics.ts
@@ -325,8 +325,8 @@ const diagnosticCatalog: Record<DiagnosticCode, DiagnosticDoc> = {
   },
   [diagnosticCode.invalidPluginOptions]: {
     title: 'Invalid plugin options',
-    cause: "A plugin was configured with options that cannot be honored, for example `output.mode: 'group'` without a `group` option.",
-    fix: "Fix the plugin options. For `output.mode: 'group'`, add a `group` option; otherwise use `output.mode: 'directory'` or `'file'`.",
+    cause: "A plugin was configured with options that cannot be honored, for example `output.mode: 'file'` paired with a `group` option.",
+    fix: "Fix the plugin options. A single-file output has nothing to group, so remove the `group` option or use `output.mode: 'directory'`.",
   },
   [diagnosticCode.hookFailed]: {
     title: 'Hook failed',

--- a/packages/middleware-barrel/src/middleware.ts
+++ b/packages/middleware-barrel/src/middleware.ts
@@ -77,9 +77,7 @@ export const middlewareBarrelName = 'middleware-barrel' satisfies Middleware['na
  * its barrel and also exclude its files from the root barrel.
  *
  * A plugin with `output.mode: 'file'` gets no per-plugin barrel, since its output
- * is a single file. The root barrel re-exports that file directly. A plugin with
- * `output.mode: 'group'` writes one file per group, which the per-plugin barrel
- * re-exports like any other flat layout.
+ * is a single file. The root barrel re-exports that file directly.
  *
  * @example
  * ```ts


### PR DESCRIPTION
## Summary

Removes the `'group'` value from `output.mode`. `output.mode` now accepts `'directory' | 'file'`:

- `'directory'` (default) writes one file per operation or schema under `output.path`.
- `'file'` writes everything into a single file.

The per-group consolidation mode (one file per resolved group) is gone. The `group` **option** stays and keeps organizing `'directory'` output into per-tag or per-path subdirectories.

## Changes

- `OutputMode` is now `'directory' | 'file'`.
- `OutputOptions` drops the `mode: 'group'` union branch. `'file'` still forbids `group`; `'directory'` still allows it.
- `normalizeOutput` now validates the remaining invalid combination, `mode: 'file'` paired with a `group` option, and throws `KUBB_INVALID_PLUGIN_OPTIONS`.
- `defaultResolvePath` drops the group-mode branch and keeps directory (flat or per-group subdirectory) and file resolution.
- Updated the `KUBB_INVALID_PLUGIN_OPTIONS` diagnostic copy, the barrel middleware docstring, and the `@kubb/ast` self-import comment to stop referencing group mode.
- Updated and pruned the affected unit tests.

## Migration

Plugins set to `output.mode: 'group'` move to `'directory'` (keep the `group` option for subdirectories) or `'file'` (drop the `group` option for a single file).

A `@kubb/core` major changeset is included.

## Verification

- `vitest run` for `@kubb/core` (`definePlugin`, `defineResolver`), `@kubb/ast` (`factory`), and `@kubb/middleware-barrel` pass.
- `tsc --noEmit` on `@kubb/core` passes.
- `oxlint` on the changed files is clean.

https://claude.ai/code/session_01SkCPtvjwHxDJVJTzW3aoNi

---
_Generated by [Claude Code](https://claude.ai/code/session_01SkCPtvjwHxDJVJTzW3aoNi)_