### PR TITLE
feat(cli): add --no-cache flag to kubb generate

### DIFF
--- a/.changeset/cli-generate-no-cache.md
+++ b/.changeset/cli-generate-no-cache.md
@@ -1,0 +1,8 @@
+---
+'@kubb/cli': minor
+'@kubb/core': patch
+---
+
+Add a `--no-cache` flag to `kubb generate` that turns off the incremental build cache for a single run, forcing a full regeneration without editing the config.
+
+The flag overrides whatever cache the config resolved to (`fsCache()` by default), so it works for every config shape. `CLIOptions` now carries `noCache`, letting a `defineConfig` function read it too.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -111,6 +111,7 @@ npx kubb generate
 | `--verbose`          | `-v`  | boolean | `false` | Override log level to `verbose`                                                                     |
 | `--silent`           | `-s`  | boolean | `false` | Override log level to `silent`                                                                      |
 | `--reporter <names>` |       | string  | `cli`   | Reporters that render the run, comma-separated: `cli`, `json`, `file`. Overrides `config.reporters` |
+| `--no-cache`         |       | boolean | `false` | Disable the incremental build cache and regenerate everything                                       |
 
 #### Examples
 

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -45,6 +45,11 @@ export const command = defineCommand({
       hint: 'cli|json|file',
       enum: ['cli', 'json', 'file'],
     },
+    'no-cache': {
+      type: 'boolean',
+      description: 'Disable the incremental build cache and force a full regeneration',
+      default: false,
+    },
   },
   async run({ values, positionals }) {
     const logLevel = values.verbose ? 'verbose' : values.silent ? 'silent' : values.logLevel
@@ -60,6 +65,7 @@ export const command = defineCommand({
       logLevel,
       watch: values.watch,
       reporters,
+      noCache: values['no-cache'],
     })
   },
 })

--- a/packages/cli/src/runners/generate/run.ts
+++ b/packages/cli/src/runners/generate/run.ts
@@ -303,6 +303,7 @@ type GenerateCommandOptions = {
   logLevel: string
   watch: boolean
   reporters?: Array<ReporterName>
+  noCache?: boolean
 }
 
 async function checkForUpdate(hooks: AsyncEventEmitter<KubbHooks>): Promise<void> {
@@ -324,7 +325,7 @@ async function checkForUpdate(hooks: AsyncEventEmitter<KubbHooks>): Promise<void
  * Loads configs, sets up the selected reporters (CLI `--reporter` overrides `config.reporters`),
  * checks for a newer version, and calls `generate` for each config entry.
  */
-export async function run({ input, configPath, logLevel: logLevelKey, watch, reporters: cliReporters }: GenerateCommandOptions): Promise<void> {
+export async function run({ input, configPath, logLevel: logLevelKey, watch, reporters: cliReporters, noCache }: GenerateCommandOptions): Promise<void> {
   const logLevel = logLevelMap[logLevelKey as keyof typeof logLevelMap] ?? logLevelMap.info
   const hooks = new AsyncEventEmitterClass<KubbHooks>()
 
@@ -338,6 +339,7 @@ export async function run({ input, configPath, logLevel: logLevelKey, watch, rep
       input,
       watch,
       logLevel: logLevelKey as CLIOptions['logLevel'],
+      noCache,
     })
     configs = loaded.configs
     resolvedConfigPath = loaded.configPath

--- a/packages/cli/src/runners/generate/utils.ts
+++ b/packages/cli/src/runners/generate/utils.ts
@@ -83,6 +83,10 @@ type GetConfigsOptions = {
    * Log level forwarded to the user's `defineConfig` function.
    */
   logLevel?: CLIOptions['logLevel']
+  /**
+   * When set, turns off the incremental build cache for this run, forcing a full regeneration.
+   */
+  noCache?: boolean
 }
 
 type GetConfigsResult = {
@@ -100,15 +104,20 @@ type GetConfigsResult = {
  * Discovers the Kubb config via cosmiconfig and resolves it into a normalized array of configs.
  * Every config in the result is guaranteed to have a `plugins` array.
  */
-export async function getConfigs({ configPath, input, watch, logLevel }: GetConfigsOptions): Promise<GetConfigsResult> {
+export async function getConfigs({ configPath, input, watch, logLevel, noCache }: GetConfigsOptions): Promise<GetConfigsResult> {
   const result = await getCosmiConfig(configPath)
-  const cli: CLIOptions = { config: configPath, input, watch, logLevel }
+  const cli: CLIOptions = { config: configPath, input, watch, logLevel, noCache }
   const resolved = await (typeof result.config === 'function' ? result.config(cli) : result.config)
   const userConfigs = Array.isArray(resolved) ? resolved : [resolved]
 
   return {
     configPath: result.filepath,
-    configs: userConfigs.map((item) => ({ ...item, plugins: item.plugins ?? [] }) as Config),
+    configs: userConfigs.map((item) => {
+      const config = { ...item, plugins: item.plugins ?? [] } as Config
+      // `--no-cache` overrides whatever cache the config resolved to (fsCache by default), so the
+      // run regenerates everything instead of restoring a snapshot.
+      return noCache ? { ...config, cache: undefined } : config
+    }),
   }
 }
 

--- a/packages/core/src/createKubb.ts
+++ b/packages/core/src/createKubb.ts
@@ -818,6 +818,11 @@ export type CLIOptions = {
    * Reporters selected on the CLI via `--reporter`, overriding `config.reporters`.
    */
   reporters?: Array<ReporterName>
+  /**
+   * Turns off the incremental build cache for this run, forcing a full regeneration.
+   * Set by the `--no-cache` flag.
+   */
+  noCache?: boolean
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds a `--no-cache` flag to `kubb generate` that turns off the incremental build cache for a single run, forcing a full regeneration without editing the config.

Until now the only way to skip the cache (`fsCache()`, enabled by default through `defineConfig`) was to set `cache: false` in the config. This adds a one-off CLI escape hatch, useful when debugging stale output or in CI.

## How it works

- New boolean option `--no-cache` on the `generate` command (`packages/cli/src/commands/generate.ts`).
- The flag is threaded through `run` into `getConfigs`, where it overrides each resolved config's `cache` to `undefined`. Applying the override at config-resolution time means it works for every config shape (object, array, promise, or `defineConfig` function form) and does not depend on the user config reading the flag.
- `CLIOptions` gains a documented `noCache` field, so a `defineConfig` function can read it too.
- `KubbDriver` already short-circuits caching when `config.cache` is falsy, so no change to the caching engine was needed.

## Changes

- `packages/cli/src/commands/generate.ts` — register the `--no-cache` option and pass it to `run`.
- `packages/cli/src/runners/generate/run.ts` — thread `noCache` into `getConfigs`.
- `packages/cli/src/runners/generate/utils.ts` — override the resolved `cache` to `undefined` when `noCache` is set.
- `packages/core/src/createKubb.ts` — add `noCache` to `CLIOptions`.
- `packages/cli/README.md` — document the flag.

## Verification

- `pnpm exec turbo run typecheck --filter=@kubb/cli --filter=@kubb/core` passes.
- `oxlint` on `packages/cli` and `packages/core` is clean.
- `kubb generate --help` lists `--no-cache`.
- Exercised `getConfigs` against a config with a custom logging cache: a default run resolves `cache: logging-cache`, while `--no-cache` resolves `cache: undefined`.

Docs for kubb.dev are in a companion PR on `kubb-labs/platform`.

https://claude.ai/code/session_01F3ngauWKERJBozjgF4aBWt

---
_Generated by [Claude Code](https://claude.ai/code/session_01F3ngauWKERJBozjgF4aBWt)_