### PR TITLE
feat(adapter-oas): drop dead exports and lazy-load heavy deps

### DIFF
--- a/.changeset/adapter-oas-lazy-load-heavy-deps.md
+++ b/.changeset/adapter-oas-lazy-load-heavy-deps.md
@@ -1,0 +1,11 @@
+---
+'@kubb/adapter-oas': minor
+---
+
+Drop dead exports and lazy-load heavy deps.
+
+Remove `mergeDocuments`, `ValidateDocumentOptions`, and `HttpMethods` from the public API (`src/index.ts`). These symbols had no consumers across the kubb, plugins, or platform repos. They remain in their source files for internal use.
+
+Replace `@redocly/openapi-core` (8–10 MB) with `@apidevtools/json-schema-ref-parser` (~100 KB) for external `$ref` bundling. The library was already a transitive dependency and exposes the same `bundle()` behavior. `@redocly/openapi-core` is removed from `dependencies`.
+
+Lazy-load `swagger2openapi` with a dynamic `import()` so it only loads when the input is a Swagger 2.0 document.

--- a/packages/adapter-oas/mocks/external/pet.yaml
+++ b/packages/adapter-oas/mocks/external/pet.yaml
@@ -1,0 +1,8 @@
+type: object
+required:
+  - name
+properties:
+  name:
+    type: string
+  tag:
+    type: string

--- a/packages/adapter-oas/mocks/withExternalFileRef.yaml
+++ b/packages/adapter-oas/mocks/withExternalFileRef.yaml
@@ -1,0 +1,19 @@
+openapi: '3.0.3'
+info:
+  title: External Ref API
+  version: 1.0.0
+paths:
+  /pets:
+    get:
+      operationId: listPets
+      responses:
+        '200':
+          description: A list of pets
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+components:
+  schemas:
+    Pet:
+      $ref: './external/pet.yaml'

--- a/packages/adapter-oas/package.json
+++ b/packages/adapter-oas/package.json
@@ -56,9 +56,9 @@
     "typecheck": "tsc -p ./tsconfig.json --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
+    "@apidevtools/json-schema-ref-parser": "^14.2.1",
     "@kubb/ast": "workspace:*",
     "@kubb/core": "workspace:*",
-    "@redocly/openapi-core": "^2.31.6",
     "oas": "^32.1.18",
     "oas-normalize": "^16.0.5",
     "swagger2openapi": "^7.0.8"

--- a/packages/adapter-oas/src/factory.test.ts
+++ b/packages/adapter-oas/src/factory.test.ts
@@ -1,6 +1,10 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { mergeDocuments, parseDocument, parseFromConfig, validateDocument } from './factory.ts'
 import type { Document } from './types.ts'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const petSchema: Document = {
   openapi: '3.0.3',
@@ -42,6 +46,16 @@ describe('parseDocument', () => {
     const doc = await parseDocument(swagger2)
 
     expect(doc.openapi).toMatch(/^3\./)
+  })
+
+  it('resolves external file $refs when given a file path', async () => {
+    const docPath = path.resolve(__dirname, '../mocks/withExternalFileRef.yaml')
+    const doc = await parseDocument(docPath)
+
+    expect(doc.openapi).toMatch(/^3\./)
+    const pet = doc.components?.schemas?.['Pet'] as Document
+    expect(pet).toBeDefined()
+    expect(pet).toMatchObject({ type: 'object', properties: { name: { type: 'string' } } })
   })
 })
 

--- a/packages/adapter-oas/src/factory.ts
+++ b/packages/adapter-oas/src/factory.ts
@@ -2,9 +2,7 @@ import path from 'node:path'
 import { exists, mergeDeep, URLPath } from '@internals/utils'
 import { Diagnostics } from '@kubb/core'
 import type { AdapterSource } from '@kubb/core'
-import { bundle, loadConfig } from '@redocly/openapi-core'
 import OASNormalize from 'oas-normalize'
-import swagger2openapi from 'swagger2openapi'
 import { MERGE_DEFAULT_TITLE, MERGE_DEFAULT_VERSION, MERGE_OPENAPI_VERSION } from './constants.ts'
 import { isOpenApiV2Document } from './guards.ts'
 import type { Document } from './types.ts'
@@ -22,8 +20,8 @@ export type ValidateDocumentOptions = {
  * Loads and dereferences an OpenAPI document, returning the raw `Document`.
  *
  * Accepts a file path string or an already-parsed document object. File paths are bundled via
- * Redocly to resolve external `$ref`s. Swagger 2.0 documents are automatically up-converted
- * to OpenAPI 3.0 via `swagger2openapi`.
+ * `@apidevtools/json-schema-ref-parser` to resolve external `$ref`s. Swagger 2.0 documents are
+ * automatically up-converted to OpenAPI 3.0 via `swagger2openapi`.
  *
  * @example
  * ```ts
@@ -33,17 +31,10 @@ export type ValidateDocumentOptions = {
  */
 export async function parseDocument(pathOrApi: string | Document, { canBundle = true, enablePaths = true }: ParseOptions = {}): Promise<Document> {
   if (typeof pathOrApi === 'string' && canBundle) {
-    const config = await loadConfig()
-    const bundleResults = await bundle({
-      ref: pathOrApi,
-      config,
-      base: pathOrApi,
-    })
+    const { $RefParser } = await import('@apidevtools/json-schema-ref-parser')
+    const bundled = await $RefParser.bundle(pathOrApi)
 
-    return parseDocument(bundleResults.bundle.parsed as string, {
-      canBundle,
-      enablePaths,
-    })
+    return parseDocument(bundled as Document, { canBundle: false, enablePaths })
   }
 
   const oasNormalize = new OASNormalize(pathOrApi, {
@@ -53,6 +44,7 @@ export async function parseDocument(pathOrApi: string | Document, { canBundle = 
   const document = (await oasNormalize.load()) as Document
 
   if (isOpenApiV2Document(document)) {
+    const { default: swagger2openapi } = await import('swagger2openapi')
     const { openapi } = await swagger2openapi.convertObj(document, {
       anchors: true,
     })

--- a/packages/adapter-oas/src/index.ts
+++ b/packages/adapter-oas/src/index.ts
@@ -1,6 +1,4 @@
 export { adapterOas, adapterOasName } from './adapter.ts'
-export type { ValidateDocumentOptions } from './factory.ts'
-export { mergeDocuments } from './factory.ts'
 export type {
   AdapterOas,
   AdapterOasOptions,
@@ -15,4 +13,3 @@ export type {
   ResponseObject,
   SchemaObject,
 } from './types.ts'
-export { HttpMethods } from './types.ts'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,15 +98,15 @@ importers:
 
   packages/adapter-oas:
     dependencies:
+      '@apidevtools/json-schema-ref-parser':
+        specifier: ^14.2.1
+        version: 14.2.1(@types/json-schema@7.0.15)
       '@kubb/ast':
         specifier: workspace:*
         version: link:../ast
       '@kubb/core':
         specifier: workspace:*
         version: link:../core
-      '@redocly/openapi-core':
-        specifier: ^2.31.6
-        version: 2.31.6
       oas:
         specifier: ^32.1.18
         version: 32.1.18
@@ -1182,19 +1182,6 @@ packages:
     resolution: {integrity: sha512-VvV2Hzjskz01m8doSn7Ypt6cSZzgjnypVqXy1ipThbyYD6SGiM74VSePXykOODj/43Y2m6zeYedPk/ZLts/HvQ==}
     engines: {node: '>=14'}
 
-  '@redocly/ajv@8.18.1':
-    resolution: {integrity: sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==}
-
-  '@redocly/ajv@8.18.3':
-    resolution: {integrity: sha512-l42u0of3hY98sN2A+M4qTX1O/KrpgGH32Hu9kP2GtHyD5Dfqq86PKFLe5dwaD8DEnNmlOlll2BAmeEtf0DaySg==}
-
-  '@redocly/config@0.49.0':
-    resolution: {integrity: sha512-OI/rpEffX3fKUuy+OuBHPRspRI/S30b9aiqxfZLMpSWZzDncEGPxSEP1O2LrBVshnDX4hLjVjLvCZ4YT85+1rw==}
-
-  '@redocly/openapi-core@2.31.6':
-    resolution: {integrity: sha512-h+zh6UQ4e5oRspUZUaNl1XRXwMf0ENHbGLKIDFAjhV6JACpqUrcBxkPKHY/uCXGdJSCzxVP3twCrnOWB0iMVuw==}
-    engines: {node: '>=22.12.0 || >=20.19.0 <21.0.0', npm: '>=10'}
-
   '@remix-run/node-fetch-server@0.13.3':
     resolution: {integrity: sha512-UfjOXed/DQteaM5VyTfqTeGpHwyL2J5aoRGY6cydip4tt1ehNNeSwuXCC7AEGE0RWBs/7bgKxYkL/B/+UDe4AA==}
 
@@ -1787,14 +1774,6 @@ packages:
       ajv:
         optional: true
 
-  ajv-formats@3.0.1:
-    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-
   ajv-keywords@5.1.0:
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==}
     peerDependencies:
@@ -1972,9 +1951,6 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  colorette@1.4.0:
-    resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -2678,10 +2654,6 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
-  js-levenshtein@1.1.6:
-    resolution: {integrity: sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g==}
-    engines: {node: '>=0.10.0'}
-
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -2721,10 +2693,6 @@ packages:
   json-schema-merge-allof@0.8.1:
     resolution: {integrity: sha512-CTUKmIlPJbsWfzRRnOXz+0MjIqvnleIXwFTzz+t9T86HnYX/Rozria6ZVGLktAU9e+NygNljveP+yxqtQp/Q4w==}
     engines: {node: '>=12.0.0'}
-
-  json-schema-to-ts@2.7.2:
-    resolution: {integrity: sha512-R1JfqKqbBR4qE8UyBR56Ms30LL62/nlhoz+1UkfI/VE7p54Awu919FZ6ZUPG8zIa3XB65usPJgr1ONVncUGSaQ==}
-    engines: {node: '>=16'}
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
@@ -3229,10 +3197,6 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
-  pluralize@8.0.0:
-    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
-    engines: {node: '>=4'}
-
   pnpm-workspace-yaml@1.6.1:
     resolution: {integrity: sha512-yTeZntGWi8m9WNuhoVsP0DpFc4sC1U0+rr/qR6Zi9n2g3sxXY+JfccjXjjruNz96tM8I09yaJUA86doRnNLkbg==}
 
@@ -3637,9 +3601,6 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
-  ts-algebra@1.2.2:
-    resolution: {integrity: sha512-kloPhf1hq3JbCPOTYoOWDKxebWjNb2o/LKnNfkWhxVVisFFmMJPPdJeGoGmM+iRLyoXAR61e08Pb+vUXINg8aA==}
-
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
@@ -3944,9 +3905,6 @@ packages:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
 
-  yaml-ast-parser@0.0.43:
-    resolution: {integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==}
-
   yaml@1.10.3:
     resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
     engines: {node: '>= 6'}
@@ -3993,7 +3951,7 @@ snapshots:
   '@apidevtools/json-schema-ref-parser@14.2.1(@types/json-schema@7.0.15)':
     dependencies:
       '@types/json-schema': 7.0.15
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -4207,7 +4165,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -4789,42 +4747,11 @@ snapshots:
   '@readme/postman-to-openapi@4.1.0':
     dependencies:
       '@readme/http-status-codes': 7.2.0
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       jsonc-parser: 3.2.0
       lodash.camelcase: 4.3.0
       marked: 4.3.0
       mustache: 4.2.0
-
-  '@redocly/ajv@8.18.1':
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
-
-  '@redocly/ajv@8.18.3':
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
-
-  '@redocly/config@0.49.0':
-    dependencies:
-      json-schema-to-ts: 2.7.2
-
-  '@redocly/openapi-core@2.31.6':
-    dependencies:
-      '@redocly/ajv': 8.18.3
-      '@redocly/config': 0.49.0
-      ajv: '@redocly/ajv@8.18.1'
-      ajv-formats: 3.0.1(@redocly/ajv@8.18.1)
-      colorette: 1.4.0
-      js-levenshtein: 1.1.6
-      js-yaml: 4.1.1
-      picomatch: 4.0.4
-      pluralize: 8.0.0
-      yaml-ast-parser: 0.0.43
 
   '@remix-run/node-fetch-server@0.13.3': {}
 
@@ -5283,10 +5210,6 @@ snapshots:
     optionalDependencies:
       ajv: 8.20.0
 
-  ajv-formats@3.0.1(@redocly/ajv@8.18.1):
-    optionalDependencies:
-      ajv: '@redocly/ajv@8.18.1'
-
   ajv-keywords@5.1.0(ajv@8.20.0):
     dependencies:
       ajv: 8.20.0
@@ -5462,8 +5385,6 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
-
-  colorette@1.4.0: {}
 
   commander@2.20.3: {}
 
@@ -6134,8 +6055,6 @@ snapshots:
 
   jiti@2.7.0: {}
 
-  js-levenshtein@1.1.6: {}
-
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
@@ -6170,12 +6089,6 @@ snapshots:
       compute-lcm: 1.1.2
       json-schema-compare: 0.2.2
       lodash: 4.18.1
-
-  json-schema-to-ts@2.7.2:
-    dependencies:
-      '@babel/runtime': 7.29.2
-      '@types/json-schema': 7.0.15
-      ts-algebra: 1.2.2
 
   json-schema-traverse@1.0.0: {}
 
@@ -6696,8 +6609,6 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  pluralize@8.0.0: {}
-
   pnpm-workspace-yaml@1.6.1:
     dependencies:
       yaml: 2.9.0
@@ -7110,8 +7021,6 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  ts-algebra@1.2.2: {}
-
   ts-node@10.9.2(@types/node@22.19.20)(typescript@6.0.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -7403,8 +7312,6 @@ snapshots:
   ws@8.21.0: {}
 
   y18n@5.0.8: {}
-
-  yaml-ast-parser@0.0.43: {}
 
   yaml@1.10.3: {}
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Closes #3533.

- Remove `mergeDocuments`, `ValidateDocumentOptions`, and `HttpMethods` from `src/index.ts` — no consumer across the kubb, plugins, or platform repos imports them; all three remain in their source files for internal use
- Replace `@redocly/openapi-core` (8–10 MB) with `@apidevtools/json-schema-ref-parser` (~100 KB) for external `$ref` bundling — same `bundle()` behavior, already a transitive dep, removed from `dependencies`
- Lazy-load `swagger2openapi` with a dynamic `import()` so it only runs when the input is a Swagger 2.0 document

All options on `AdapterOasOptions` are unchanged — external consumers outside the tracked repos rely on them.

## Test plan

- [ ] All 9 test suites in `packages/adapter-oas` pass (465 tests), including the Swagger 2.0 up-conversion path in `factory.test.ts`
- [ ] `pnpm typecheck` in `packages/adapter-oas` is clean
- [ ] `plugin-redoc` still imports `adapterOasName` without issue

https://claude.ai/code/session_01RyiDwC84vQTzLfp5C7pzwE
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RyiDwC84vQTzLfp5C7pzwE)_