### PR TITLE
refactor(core): resolve config in the Kubb constructor

### DIFF
--- a/.changeset/simplify-kubb-class-resolve-config-in-constructor.md
+++ b/.changeset/simplify-kubb-class-resolve-config-in-constructor.md
@@ -1,0 +1,6 @@
+---
+"@kubb/core": patch
+"unplugin-kubb": patch
+---
+
+Resolve config in the `Kubb` constructor instead of `setup()`. `config` is now a plain readonly property available right after `createKubb`, so the getter no longer throws before `setup()`. `setup()` keeps the async work: sizing the hooks ceiling, the `output.clean` storage clear, and `driver.setup()`. The dead `kubb.config ?? userConfig` fallback in `unplugin-kubb` is removed.

--- a/packages/core/src/createKubb.test.ts
+++ b/packages/core/src/createKubb.test.ts
@@ -69,7 +69,7 @@ describe('createKubb', () => {
     expect(files.some((f) => f.baseName === file.baseName)).toBe(true)
   })
 
-  test('accepts a user config and resolves defaults during setup', async () => {
+  test('resolves config defaults in the constructor, before setup', () => {
     const userConfig = {
       input: {
         path: 'https://petstore3.swagger.io/api/v3/openapi.json',
@@ -85,10 +85,8 @@ describe('createKubb', () => {
       hooks: new AsyncEventEmitter<KubbHooks>(),
     })
 
-    await kubb.setup()
-
-    expect(kubb.config?.root).toBe(process.cwd())
-    expect(kubb.config?.parsers).toStrictEqual([])
+    expect(kubb.config.root).toBe(process.cwd())
+    expect(kubb.config.parsers).toStrictEqual([])
   })
 
   test('keeps the hooks ceiling at 10 for a single plugin', async () => {

--- a/packages/core/src/createKubb.ts
+++ b/packages/core/src/createKubb.ts
@@ -903,8 +903,12 @@ type CreateKubbOptions = {
 
 /**
  * Kubb code-generation instance bound to a single config entry. Resolves the user
- * config during `setup()` and shares `hooks`, `storage`, `driver`, and `config` across
- * the `setup → build` lifecycle.
+ * config in the constructor, so `config` is available right away, and shares `hooks`,
+ * `storage`, and `driver` across the `setup → build` lifecycle.
+ *
+ * `createKubb` takes a plain, serializable config object (the shape `defineConfig`
+ * produces), not a fluent builder. Config stays plain data so it can be cache
+ * fingerprinted and validated against the shipped JSON schema.
  *
  * Attach event listeners to `.hooks` before calling `setup()` or `build()`.
  *
@@ -917,13 +921,12 @@ type CreateKubbOptions = {
  */
 export class Kubb {
   readonly hooks: AsyncEventEmitter<KubbHooks>
-  readonly #userConfig: UserConfig
-  #config: Config | null = null
+  readonly config: Config
   #driver: KubbDriver | null = null
   #storage: Storage | null = null
 
   constructor(userConfig: UserConfig, options: CreateKubbOptions = {}) {
-    this.#userConfig = userConfig
+    this.config = resolveConfig(userConfig)
     this.hooks = options.hooks ?? new AsyncEventEmitter<KubbHooks>()
   }
 
@@ -937,16 +940,11 @@ export class Kubb {
     return this.#driver
   }
 
-  get config(): Config {
-    if (!this.#config) throw new Error('[kubb] setup() must be called before accessing config')
-    return this.#config
-  }
-
   /**
-   * Resolves config and initializes the driver. `build()` calls this automatically.
+   * Initializes the driver and storage. `build()` calls this automatically.
    */
   async setup(): Promise<void> {
-    const config = resolveConfig(this.#userConfig)
+    const config = this.config
     const driver = new KubbDriver(config, { hooks: this.hooks })
     const storage = createSourcesView(config.storage)
 
@@ -961,7 +959,6 @@ export class Kubb {
 
     await driver.setup()
 
-    this.#config = config
     this.#driver = driver
     this.#storage = storage
   }
@@ -984,7 +981,8 @@ export class Kubb {
 
   /**
    * Runs the full pipeline and captures errors in `BuildOutput` instead of throwing.
-   * Automatically calls `setup()` if needed.
+   * Automatically calls `setup()` if needed. This is the canonical call: it never throws on
+   * plugin errors, so callers stay in control of how failures surface.
    */
   async safeBuild(): Promise<BuildOutput> {
     if (!this.#driver) await this.setup()

--- a/packages/unplugin-kubb/src/unpluginFactory.ts
+++ b/packages/unplugin-kubb/src/unpluginFactory.ts
@@ -103,9 +103,7 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, m
     const kubb = createKubb(userConfig, { hooks })
     await kubb.setup()
 
-    const resolvedConfig = kubb.config ?? userConfig
-
-    await hooks.emit('kubb:generation:start', { config: resolvedConfig })
+    await hooks.emit('kubb:generation:start', { config: kubb.config })
 
     const { diagnostics, files, storage } = await kubb.safeBuild()
 
@@ -127,7 +125,7 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, m
     }
 
     await hooks.emit('kubb:generation:end', {
-      config: resolvedConfig,
+      config: kubb.config,
       storage,
       diagnostics,
       filesCreated: files.length,


### PR DESCRIPTION
## Summary

Implements #3532. `resolveConfig` is pure and synchronous, so it now runs in the `Kubb` constructor instead of `setup()`.

- `config` becomes a plain `readonly` property on `Kubb`, available right after `createKubb`. The nullable `#config` field and the throwing `config` getter are gone.
- `setup()` keeps only the async work: sizing the hooks ceiling, the `output.clean` storage clear, and `driver.setup()`. The `storage` and `driver` getters still throw before `setup()`.
- Removed the now-dead `kubb.config ?? userConfig` fallback in `packages/unplugin-kubb/src/unpluginFactory.ts`.
- Noted in the JSDoc that `safeBuild()` is the canonical call, and recorded the builder-pattern decision (createKubb takes plain serializable config, not a fluent builder) so the question stays settled.

The public surface is unchanged: `constructor`, `hooks`, `config`, `storage`, `driver`, `setup()`, `build()`, `safeBuild()`, `dispose()`.

## Tests

`createKubb.test.ts` now asserts config defaults resolve in the constructor before `setup()`. Verified locally:

- `@kubb/core`: 228 tests pass, typecheck clean, lint clean
- `unplugin-kubb`: 5 tests pass, typecheck clean, lint clean

A patch changeset for `@kubb/core` and `unplugin-kubb` is included.

The kubb.dev core API reference is updated in a companion PR on `kubb-labs/platform`.

Closes #3532

https://claude.ai/code/session_013UUJkdgrqkrFUD4x82tYpp

---
_Generated by [Claude Code](https://claude.ai/code/session_013UUJkdgrqkrFUD4x82tYpp)_