### PR TITLE
ci: dispatch changelog-sync to docs after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,3 +143,17 @@ jobs:
           repository: kubb-labs/platform
           event-type: content-updated
           client-payload: '{"source": "kubb", "tag": "${{ github.ref_name }}"}'
+
+  sync-changelog-docs:
+    name: Dispatch changelog-sync to docs
+    needs: [release]
+    if: ${{ needs.release.outputs.released == 'true' }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
+        with:
+          token: ${{ secrets.PLATFORM_DISPATCH_TOKEN }}
+          repository: kubb-labs/docs
+          event-type: changelog-sync
+          client-payload: '{"ref": "${{ github.ref_name }}"}'


### PR DESCRIPTION
## Summary

- Adds a new `sync-changelog-docs` job to `release.yml` that fires after a successful release
- Dispatches a `changelog-sync` repository_dispatch event to `kubb-labs/docs` using the existing `PLATFORM_DISPATCH_TOKEN` secret (no new secret needed)
- Passes `ref: github.ref_name` in the payload so the docs workflow checks out the exact branch that was released

## Part of a three-repo change

- **kubb** (this PR) — adds the dispatch trigger
- **docs** — adds `sync-changelog.yml` to receive the event and commit the updated changelog
- **platform** — removes the now-redundant `changelogPlugin` since `copyDocsPlugin` already vendors all content from `kubb-labs/docs`

## Test plan

- [ ] After merging all three PRs, trigger a test release (or use `workflow_dispatch` on `sync-changelog.yml` in docs directly) and confirm `docs/5.x/changelog.md` is updated automatically

https://claude.ai/code/session_01GfroxSa2vAJPtfVx5zEtPP

---
_Generated by [Claude Code](https://claude.ai/code/session_01GfroxSa2vAJPtfVx5zEtPP)_