### PR TITLE
docs(kubb): humanize JSDoc prose across the core packages

### DIFF
--- a/.changeset/humanize-core-jsdoc.md
+++ b/.changeset/humanize-core-jsdoc.md
@@ -1,0 +1,12 @@
+---
+"@kubb/adapter-oas": patch
+"@kubb/cli": patch
+"@kubb/core": patch
+"@kubb/parser-md": patch
+"@kubb/parser-ts": patch
+"@kubb/plugin-barrel": patch
+"@kubb/renderer-jsx": patch
+"kubb": patch
+---
+
+Tighten the JSDoc prose across the core packages so the published types read naturally. This cuts rule-of-three filler, `-ing`-participle clauses, clause-joining semicolons, marketing words, and sentences that only restate the TypeScript type. The change is comment-only, so no API or behavior changes.

--- a/packages/adapter-oas/src/constants.ts
+++ b/packages/adapter-oas/src/constants.ts
@@ -73,7 +73,7 @@ export const structuralKeys = new Set(['properties', 'items', 'additionalPropert
  *
  * Only formats whose AST type differs from the OAS `type` field appear here.
  * Formats that depend on runtime options (`int64`, `date-time`, `date`, `time`) are handled separately
- * in the parser. `ipv4` and `ipv6` map to their own dedicated schema types; `hostname` and
+ * in the parser. `ipv4` and `ipv6` map to their own dedicated schema types. `hostname` and
  * `idn-hostname` map to `'url'` as the closest generic string-format type.
  *
  * @example
@@ -126,8 +126,8 @@ export const formatMap = {
 export const enumExtensionKeys = ['x-enumNames', 'x-enum-varnames'] as const
 
 /**
- * Maps `'any' | 'unknown' | 'void'` option strings to their `ScalarSchemaType` constant.
- * Replaces a plain object lookup with a `Map` for explicit key membership testing via `.has()`.
+ * Maps the `unknownType`/`emptySchemaType` option string to its `ScalarSchemaType` constant.
+ * A `Map` (over a plain object) lets callers test key membership with `.has()`.
  */
 export const typeOptionMap = new Map<'any' | 'unknown' | 'void', ast.ScalarSchemaType>([
   ['any', ast.schemaTypes.any],

--- a/packages/adapter-oas/src/parser.ts
+++ b/packages/adapter-oas/src/parser.ts
@@ -66,11 +66,17 @@ type SchemaContext = {
  * that is not convertible falls through to plain `type` handling).
  */
 type SchemaRule = {
-  /** Identifies the rule when reading the table or debugging which branch ran. */
+  /**
+   * Identifies the rule when reading the table or debugging which branch ran.
+   */
   name: string
-  /** Returns `true` when this rule is responsible for the given context. */
+  /**
+   * Returns `true` when this rule is responsible for the given context.
+   */
   match: (context: SchemaContext) => boolean
-  /** Produces a node for the context, or `null` to fall through to the next rule. */
+  /**
+   * Produces a node for the context, or `null` to fall through to the next rule.
+   */
   convert: (context: SchemaContext) => ast.SchemaNode | null
 }
 
@@ -78,9 +84,9 @@ type SchemaRule = {
  * Normalizes malformed `{ type: 'array', enum: [...] }` schemas by moving enum values into items.
  *
  * This pattern violates the OpenAPI spec but appears in real specs. The fix moves enum values
- * from the array to its items sub-schema, making them valid for downstream processing.
+ * from the array to its items sub-schema, so they are valid for downstream processing.
  *
- * @note This is a defensive measure for robustness with non-compliant specs.
+ * @note A defensive measure for non-compliant specs.
  */
 function normalizeArrayEnum(schema: SchemaObject): SchemaObject {
   const isItemsObject = typeof schema.items === 'object' && !Array.isArray(schema.items)
@@ -98,7 +104,7 @@ function normalizeArrayEnum(schema: SchemaObject): SchemaObject {
  *
  * Returns closures that share mutable state (`resolvingRefs` set for cycle detection).
  * Each converter branch (`convertRef`, `convertAllOf`, etc.) mutually recursively calls `parseSchema`,
- * made possible by hoisting of function declarations.
+ * which works because function declarations hoist.
  *
  * @internal
  */
@@ -1048,10 +1054,11 @@ export function createSchemaParser(ctx: OasParserContext, dialect: OasDialect = 
 /**
  * Parses a single OpenAPI `SchemaObject` into a `SchemaNode`.
  *
- * Use this for targeted schema parsing when you don't need the full spec.
- * For complete spec parsing, use `parseOas()` instead which handles operations and all schemas together.
+ * Reach for this when you only need one schema, not the whole spec. To parse a full spec
+ * with its operations and schemas, call `parseOas()`.
  *
- * @note Circular schema references are tracked via internal state and resolve appropriately.
+ * @note Internal state tracks `$ref` paths under resolution, so circular schemas stop
+ * recursing instead of looping.
  *
  * @example
  * ```ts
@@ -1072,7 +1079,8 @@ export function parseSchema(
  * Parses an OpenAPI specification into Kubb's universal `InputNode` AST.
  *
  * This is the main entry point for `@kubb/adapter-oas`. It converts OpenAPI/Swagger specs into a spec-agnostic tree
- * that downstream plugins (`plugin-ts`, `plugin-zod`, etc.) consume for code generation. No code is generated here,  * the tree is a pure data structure representing all schemas and operations.
+ * that downstream plugins (`plugin-ts`, `plugin-zod`, etc.) consume for code generation. No code is generated here.
+ * The tree is a pure data structure of all schemas and operations.
  *
  * Returns the AST root and a `nameMapping` for resolving schema references.
  *

--- a/packages/adapter-oas/src/resolvers.ts
+++ b/packages/adapter-oas/src/resolvers.ts
@@ -470,7 +470,7 @@ export function getSchemas(document: Document, { contentType }: GetSchemasOption
 
 /**
  * Resolves the AST type descriptor for a date/time format, honoring the `dateType` option.
- * Returns `null` when `dateType: false`, signalling the format should fall through to `string`.
+ * Returns `null` when `dateType: false`, so the format falls through to `string`.
  */
 export function getDateType(
   options: ast.ParserOptions,

--- a/packages/adapter-oas/src/stream.ts
+++ b/packages/adapter-oas/src/stream.ts
@@ -23,7 +23,7 @@ export type PreScanResult = {
  *
  * Only enums and objects are candidates, and object shapes that reference a circular schema are
  * rejected to avoid hoisting recursive structures. Inline shapes reuse their context-derived
- * name (collision-resolved against existing component names); shapes without a name stay inline.
+ * name (collision-resolved against existing component names). Shapes without a name stay inline.
  */
 function createDedupePlan({
   schemaNodes,
@@ -218,7 +218,7 @@ export function createInputStream({
   meta: ast.InputMeta
 }): ast.InputNode<true> {
   // Rewrites a top-level schema against the dedupe plan: a structurally identical sibling
-  // becomes a `ref` alias to the canonical one (keeping its own name); otherwise nested
+  // becomes a `ref` alias to the canonical one (keeping its own name). Otherwise nested
   // duplicates are collapsed while the schema's own root is preserved.
   const rewriteTopLevelSchema = (node: ast.SchemaNode): ast.SchemaNode => {
     if (!dedupePlan) return node

--- a/packages/adapter-oas/src/types.ts
+++ b/packages/adapter-oas/src/types.ts
@@ -7,8 +7,7 @@ import type { Operation } from './operation.ts'
 export type { Operation }
 
 /**
- * Content-type string for selecting request/response schemas from an OpenAPI spec.
- * Supports `'application/json'` or any other media type.
+ * Media type used to pick a schema from an operation's request or response.
  *
  * @example
  * ```ts
@@ -68,13 +67,13 @@ export type SchemaObject = {
    */
   items?: SchemaObject | ReferenceObject
   /**
-   * Enum values for this schema (narrowed from `unknown[]`).
+   * Allowed values for this schema.
    */
   enum?: Array<string | number | boolean | null>
 } & (OpenAPIV3.SchemaObject | OpenAPIV3_1.SchemaObject | JSONSchema4 | JSONSchema6 | JSONSchema7)
 
 /**
- * HTTP method as a lowercase string (`'get' | 'post' | ...`).
+ * HTTP method in the lowercase form an OpenAPI path item uses for its keys.
  */
 export type HttpMethod = Lowercase<ast.HttpMethod>
 
@@ -104,7 +103,7 @@ export type DiscriminatorObject = OpenAPIV3.DiscriminatorObject | OpenAPIV3_1.Di
 export type ReferenceObject = OpenAPIV3.ReferenceObject
 
 /**
- * OpenAPI response object from a spec that contains schema, status code, and headers.
+ * OpenAPI response object holding the content and headers for one status code.
  */
 export type ResponseObject = OpenAPIV3.ResponseObject | OpenAPIV3_1.ResponseObject
 
@@ -131,9 +130,8 @@ export type ParameterObject = {
 export type ServerObject = OpenAPIV3.ServerObject | OpenAPIV3_1.ServerObject
 
 /**
- * Configuration options for the OpenAPI adapter. Controls spec validation,
- * content-type selection, server URL resolution, and how types are derived
- * from the spec.
+ * Configuration for the OpenAPI adapter: spec validation, content-type selection,
+ * server URL resolution, and how schema types are derived.
  *
  * @example
  * ```ts
@@ -194,9 +192,9 @@ export type AdapterOasOptions = {
    *
    * Duplicated inline shapes (especially enums repeated across many properties) are hoisted
    * into one named schema. Every other occurrence, and any structurally identical top-level
-   * component, becomes a `ref` to it. Equality is shape-only: documentation such as
-   * `description` and `example` is ignored. Enabled by default. Set to `false` to keep every
-   * occurrence inline and produce byte-for-byte identical output to earlier versions.
+   * component, becomes a `ref` to it. Equality is shape-only, so documentation such as
+   * `description` and `example` is ignored. Set to `false` to keep every occurrence inline
+   * and produce byte-for-byte identical output to earlier versions.
    *
    * @default true
    */

--- a/packages/cli/src/Telemetry.ts
+++ b/packages/cli/src/Telemetry.ts
@@ -35,10 +35,17 @@ type OtlpInstrumentationScope = {
   droppedAttributesCount?: number
 }
 
-/** https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/trace/v1/trace.proto#L103 */
+/**
+ * @see https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/trace/v1/trace.proto#L103
+ */
 type OtlpSpanKind = 0 | 1 | 2 | 3 | 4 | 5
 
-/** 0 = STATUS_CODE_UNSET, 1 = STATUS_CODE_OK, 2 = STATUS_CODE_ERROR */
+/**
+ * Span status code.
+ * - `0` is unset
+ * - `1` is OK
+ * - `2` is error
+ */
 type OtlpStatusCode = 0 | 1 | 2
 
 type OtlpStatus = {
@@ -91,7 +98,9 @@ type OtlpResourceSpans = {
   schemaUrl?: string
 }
 
-/** Root payload sent to POST /v1/traces */
+/**
+ * Root payload sent to POST /v1/traces.
+ */
 type OtlpExportTraceServiceRequest = {
   resourceSpans: Array<OtlpResourceSpans>
 }
@@ -105,7 +114,7 @@ export type TelemetryPlugin = {
    */
   name: string
   /**
-   * anonymized plugin options snapshot, values are included but cannot be traced back to the user.
+   * Anonymized snapshot of the plugin options. Values are included but cannot be traced back to a user.
    */
   options: Record<string, unknown>
 }
@@ -131,9 +140,9 @@ export type TelemetryEvent = {
 }
 
 /**
- * Anonymous OTLP usage telemetry for the Kubb run. All methods are static, so call them as
- * `Telemetry.build(...)`, `Telemetry.send(...)`, and `Telemetry.isDisabled()`. No file paths,
- * OpenAPI specs, or secrets are ever included, and sending fails silently to never break a run.
+ * Anonymous OTLP usage telemetry for a Kubb run. The API is static, so call it as `Telemetry.build(...)`
+ * and `Telemetry.send(...)`. No file paths, OpenAPI specs, or secrets are sent, and sending fails
+ * silently so a failed request never breaks the run.
  */
 export class Telemetry {
   /**

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -14,6 +14,6 @@ export const OTLP_ENDPOINT = 'https://otlp.kubb.dev' as const
 export const WATCHER_IGNORED_PATHS = '**/{.git,node_modules}/**' as const
 
 /**
- * Flags that short-circuit execution (help/version), no telemetry notice is shown.
+ * Flags that short-circuit execution (help and version). The telemetry notice is suppressed for these.
  */
 export const QUIET_FLAGS = new Set<string>(['--help', '-h', '--version', '-v'])

--- a/packages/cli/src/loggers/clackLogger.ts
+++ b/packages/cli/src/loggers/clackLogger.ts
@@ -8,7 +8,7 @@ import { defineLogger } from './defineLogger.ts'
 import { buildProgressLine, createProgressCounters, formatCommandWithArgs, formatMessage, recordPluginResult, resetProgressCounters } from './utils.ts'
 
 /**
- * TTY logger with beautiful UI and progress indicators for local development.
+ * TTY logger for local development, with spinners and progress bars.
  */
 export const clackLogger = defineLogger({
   name: 'clack',
@@ -379,7 +379,7 @@ Run \`npm install -g @kubb/cli\` to update`,
         active.taskLog.success(getMessage(`${styleText('dim', commandWithArgs)} completed in ${duration}`))
       } else {
         // The hook's output already reached the taskLog live via `kubb:hook:line`, so `showLog`
-        // replays it here; `kubb:hook:end` carries no captured output on the streaming path.
+        // replays it here. `kubb:hook:end` carries no captured output on the streaming path.
         const reason = error?.message ? ` (${error.message})` : ''
         active.taskLog.error(getMessage(`${styleText('dim', commandWithArgs)} failed${reason}`), { showLog: true })
       }

--- a/packages/cli/src/loggers/plainLogger.ts
+++ b/packages/cli/src/loggers/plainLogger.ts
@@ -5,7 +5,7 @@ import { defineLogger } from './defineLogger.ts'
 import { createHookTimer, formatCommandWithArgs, formatMessage } from './utils.ts'
 
 /**
- * Plain console adapter for non-TTY environments with simple `console.log` output.
+ * Plain console adapter for non-TTY environments, built on `console.log`.
  */
 export const plainLogger = defineLogger({
   name: 'plain',

--- a/packages/cli/src/loggers/utils.ts
+++ b/packages/cli/src/loggers/utils.ts
@@ -156,7 +156,9 @@ export function createHookTimer(): HookTimer {
 
 /**
  * Join a command and its optional args into a single display string.
- * e.g. ("prettier", ["--write", "."]) → "prettier --write ."
+ *
+ * @example
+ * `formatCommandWithArgs('prettier', ['--write', '.']) → 'prettier --write .'`
  */
 export function formatCommandWithArgs(command: string, args?: ReadonlyArray<string>): string {
   return args?.length ? `${command} ${args.join(' ')}` : command
@@ -190,7 +192,7 @@ export function installReporter(context: LoggerContext, reporter: Reporter, ctx:
 
 /**
  * Installs the live logger (the TUI view) and the given reporters (the output). The reporters are
- * already selected by the caller (the CLI maps `--reporter` to names via `selectReporters`); this
+ * already selected by the caller (the CLI maps `--reporter` to names via `selectReporters`). This
  * only wires them. Loggers receive hook subprocess output through `kubb:hook:line` and the
  * `stdout`/`stderr` on `kubb:hook:end`, so nothing is returned here.
  *

--- a/packages/cli/src/runners/generate/run.ts
+++ b/packages/cli/src/runners/generate/run.ts
@@ -50,7 +50,7 @@ type RunToolPassOptions = {
 
 /**
  * Registers a one-shot `kubb:hook:end` listener for `hookId` BEFORE the caller emits `kubb:hook:start`,
- * avoiding the race where a synchronous emitter fires end before the listener is attached.
+ * so a synchronous emitter can't fire end before the listener is attached.
  */
 function waitForHookEnd(
   hooks: AsyncEventEmitter<KubbHooks>,

--- a/packages/cli/src/runners/generate/utils.ts
+++ b/packages/cli/src/runners/generate/utils.ts
@@ -118,8 +118,10 @@ type ExecuteHooksOptions = {
  * Tokenizes a shell command string, respecting single and double quotes.
  *
  * @example
+ * ```ts
  * tokenize('git commit -m "initial commit"')
  * // → ['git', 'commit', '-m', 'initial commit']
+ * ```
  */
 function tokenize(command: string): Array<string> {
   return (command.match(/[^\s"']+|"([^"]*)"|'([^']*)'/g) ?? []).map((token) => token.replace(/^["']|["']$/g, ''))

--- a/packages/core/src/KubbDriver.ts
+++ b/packages/core/src/KubbDriver.ts
@@ -54,7 +54,8 @@ export class KubbDriver {
   readonly options: Options
 
   /**
-   * The streaming `InputNode<true>` produced by the adapter.   * Always set after adapter setup, parse-only adapters are wrapped automatically.
+   * The streaming `InputNode<true>` produced by the adapter. Set after adapter setup.
+   * Parse-only adapters are wrapped automatically.
    */
   inputNode: InputNode<true> | null = null
   adapter: Adapter | null = null
@@ -472,7 +473,7 @@ export class KubbDriver {
    *
    * Plugins run sequentially so `kubb:plugin:end` fires as each plugin completes, instead
    * of all at once after every plugin has marched through the parallel batches together.
-   * That ordering is what drives the CLI's `Plugins N/M` counter; without it the bar would
+   * That ordering is what drives the CLI's `Plugins N/M` counter. Without it the bar would
    * sit at the initial value until the very end of the run.
    *
    * When `entries` is empty or `this.inputNode` is `null`, every entry still gets a

--- a/packages/core/src/createAdapter.ts
+++ b/packages/core/src/createAdapter.ts
@@ -35,8 +35,8 @@ export type AdapterFactoryOptions<
  * Converts input files or inline data into Kubb's universal AST `InputNode`.
  *
  * Adapters live between the spec format and the plugins. The built-in
- * `@kubb/adapter-oas` handles OpenAPI 2.0, 3.0, and 3.1; custom adapters can
- * support GraphQL, gRPC, AsyncAPI, or any domain-specific schema language.
+ * `@kubb/adapter-oas` handles OpenAPI 2.0, 3.0, and 3.1. A custom adapter can
+ * support GraphQL, gRPC, or another schema language.
  *
  * @example
  * ```ts
@@ -95,9 +95,8 @@ type AdapterBuilder<T extends AdapterFactoryOptions> = (options: T['options']) =
 
 /**
  * Defines a custom adapter that translates a spec format into Kubb's universal
- * AST. Use this when you need to consume GraphQL, gRPC, AsyncAPI, or another
- * domain-specific schema. Built-in adapters: `@kubb/adapter-oas` for
- * OpenAPI/Swagger documents.
+ * AST, for example GraphQL, gRPC, or AsyncAPI. The built-in `@kubb/adapter-oas`
+ * handles OpenAPI/Swagger documents.
  *
  * Adapters must return an `InputNode` from `parse`. That node is what every
  * plugin in the build consumes.

--- a/packages/core/src/createRenderer.ts
+++ b/packages/core/src/createRenderer.ts
@@ -43,10 +43,9 @@ export type RendererFactory<TElement = unknown> = () => Renderer<TElement>
  * (JSX, a template string, a tree of any shape) into `FileNode`s that get
  * written to disk.
  *
- * Use this to support output formats beyond JSX, for instance, a Handlebars
- * renderer, a string-template renderer, or a renderer that writes binary
- * files. Plugins and generators pick the renderer to use via the `renderer`
- * field on `defineGenerator`.
+ * A renderer can target output formats beyond JSX, for instance a Handlebars
+ * renderer or one that writes binary files. Plugins and generators pick the
+ * renderer to use via the `renderer` field on `defineGenerator`.
  *
  * @example A minimal renderer that wraps a custom runtime
  * ```ts

--- a/packages/core/src/createReporter.ts
+++ b/packages/core/src/createReporter.ts
@@ -57,7 +57,7 @@ export type ReporterContext = {
 
 /**
  * Host-facing reporter, as installed onto a run. Unlike a Logger (the live TUI view), a reporter
- * never sees the event emitter. `report` runs once per config; `drain`, when present, runs once
+ * never sees the event emitter. `report` runs once per config. `drain`, when present, runs once
  * after the last config.
  */
 export type Reporter = {

--- a/packages/core/src/createStorage.ts
+++ b/packages/core/src/createStorage.ts
@@ -1,7 +1,7 @@
 /**
  * Backend that persists generated files. Kubb ships with `fsStorage` (writes
  * to disk) and `memoryStorage` (keeps everything in RAM). Implement this
- * interface to write to S3, a database, or any other target.
+ * interface to write somewhere else, such as S3 or a database.
  */
 export type Storage = {
   /**
@@ -42,9 +42,9 @@ export type Storage = {
 
 /**
  * Defines a custom storage backend. The builder receives user options and
- * returns a `Storage` implementation. Kubb ships with filesystem and
- * in-memory storages, reach for this when you need to write generated files
- * elsewhere (cloud storage, a database, a remote API).
+ * returns a `Storage` implementation. Kubb ships with filesystem and in-memory
+ * storages. A custom backend writes generated files elsewhere, such as cloud
+ * storage or a database.
  *
  * @example In-memory storage (the built-in implementation)
  * ```ts

--- a/packages/core/src/defineGenerator.ts
+++ b/packages/core/src/defineGenerator.ts
@@ -117,8 +117,8 @@ export type GeneratorContext<TOptions extends PluginFactoryOptions = PluginFacto
  * Declares a named generator unit that walks the AST and emits files.
  *
  * Each method (`schema`, `operation`, `operations`) is called for the matching node type.
- * Each method returns `TElement | Array<FileNode> | undefined | null`. JSX-based generators require a `renderer` factory.
- * Return `Array<FileNode>` directly or call `ctx.upsertFile()` manually and return `undefined` or `null` to bypass rendering.
+ * JSX-based generators require a `renderer` factory. Return `Array<FileNode>` directly, or call
+ * `ctx.upsertFile()` manually and return `null` to bypass rendering.
  *
  * @note Generators are consumed by plugins and registered via `ctx.addGenerator()` in `kubb:plugin:setup`.
  *

--- a/packages/core/src/definePlugin.ts
+++ b/packages/core/src/definePlugin.ts
@@ -6,9 +6,9 @@ import { Diagnostics } from './diagnostics.ts'
 import type { Config, KubbHooks } from './types.ts'
 
 /**
- * Safely extracts a type from a registry, returning `{}` if the key doesn't exist.
- * Enables optional interface augmentation for `Kubb.ConfigOptionsRegistry` and `Kubb.PluginOptionsRegistry`
- * without requiring changes to core.
+ * Reads a type from a registry, falling back to `{}` when the key is absent. Lets
+ * `Kubb.ConfigOptionsRegistry` and `Kubb.PluginOptionsRegistry` be augmented without
+ * touching core.
  *
  * @internal
  */
@@ -92,7 +92,7 @@ export type Group = {
  *   files into per-group subdirectories.
  *
  * Intersect into a plugin's `Options` type instead of declaring `output` and
- * `group` directly — `mode` lives inside `output` while `group` is its sibling.
+ * `group` directly, since `mode` lives inside `output` while `group` is its sibling.
  * The generic keeps a plugin's extended `Output` shape intact.
  *
  * @example
@@ -201,9 +201,8 @@ type ByContentType = {
 }
 
 /**
- * Filter that skips matching operations or schemas during generation. Use it
- * to drop deprecated endpoints, internal-only schemas, or anything you do
- * not want code generated for.
+ * Filter that skips matching operations or schemas during generation, for example
+ * deprecated endpoints or internal-only schemas.
  *
  * @example
  * ```ts
@@ -283,8 +282,8 @@ export type PluginFactoryOptions<
 }
 
 /**
- * Context for hook-style plugin `kubb:plugin:setup` handler.
- * Provides methods to register generators, configure resolvers, transformers, and renderers.
+ * Context passed to a plugin's `kubb:plugin:setup` handler, where it registers generators and
+ * sets its resolver, transformer, and options.
  */
 export type KubbPluginSetupContext<TFactory extends PluginFactoryOptions = PluginFactoryOptions> = {
   /**
@@ -325,11 +324,8 @@ export type KubbPluginSetupContext<TFactory extends PluginFactoryOptions = Plugi
 }
 
 /**
- * A plugin object produced by `definePlugin`.
- * Instead of flat lifecycle methods, it groups all handlers under a `hooks:` property
- * (matching Astro's integration naming convention).
- *
- * @template TFactory - The plugin's `PluginFactoryOptions` type.
+ * A plugin object produced by `definePlugin`. Its lifecycle handlers live under a single
+ * `hooks` property rather than flat methods.
  */
 export type Plugin<TFactory extends PluginFactoryOptions = PluginFactoryOptions> = {
   /**
@@ -367,8 +363,8 @@ export type Plugin<TFactory extends PluginFactoryOptions = PluginFactoryOptions>
 }
 
 /**
- * Normalized plugin after setup, with runtime fields populated.
- * For internal use only, plugins use the public `Plugin` type externally.
+ * Normalized plugin after setup, with runtime fields populated. Internal only. Plugins use the
+ * public `Plugin` type.
  *
  * @internal
  */
@@ -409,8 +405,7 @@ export type KubbPluginEndContext = {
 
 /**
  * Wraps a plugin factory and returns a function that accepts user options and
- * yields a fully typed `Plugin`. Lifecycle handlers go inside a single
- * `hooks` object (inspired by Astro integrations).
+ * yields a typed `Plugin`. Lifecycle handlers go inside a single `hooks` object.
  *
  * Pass a `PluginFactoryOptions` type parameter to get a typed `ctx` inside
  * `kubb:plugin:setup`. Plugin names should follow the `plugin-<feature>`

--- a/packages/core/src/defineResolver.ts
+++ b/packages/core/src/defineResolver.ts
@@ -377,8 +377,8 @@ function defaultResolveOptions<TOptions>(node: Node, { options, exclude = [], in
 /**
  * Default path resolver used by `defineResolver`.
  *
- * - `mode: 'file'` — resolves directly to `output.path` (the full file path, extension included).
- * - `mode: 'directory'` (default) — resolves to `output.path/{baseName}`, or into a
+ * - `mode: 'file'` resolves directly to `output.path` (the full file path, extension included).
+ * - `mode: 'directory'` (default) resolves to `output.path/{baseName}`, or into a
  *   subdirectory when `group` and a `tag`/`path` value are provided.
  *
  * A custom `group.name` function overrides the default subdirectory naming.
@@ -662,8 +662,8 @@ export function defaultResolveFooter(meta: InputMeta | undefined, { output, file
  * - `resolveFile` builds the full `FileNode`.
  * - `resolveBanner` and `resolveFooter` produce the top and bottom of file text.
  *
- * Methods in the returned object can call sibling resolver methods via `this`,
- * which keeps custom rules small (`this.default(name, 'type')` to delegate).
+ * Methods in the returned object can call sibling resolver methods via `this`.
+ * A custom rule can delegate to a default, for example `this.default(name, 'type')`.
  *
  * @example Basic resolver with naming helpers
  * ```ts

--- a/packages/core/src/diagnostics.ts
+++ b/packages/core/src/diagnostics.ts
@@ -7,7 +7,7 @@ import { type DiagnosticCode, diagnosticCode } from './constants.ts'
 import type { KubbHooks } from './types.ts'
 
 /**
- * Docs major, derived from the package version so the link tracks the published major.
+ * Docs major version, derived from the package version so the link tracks the published major.
  */
 const docsMajor = version.split('.')[0] ?? '5'
 
@@ -19,9 +19,8 @@ export type DiagnosticSeverity = 'error' | 'warning' | 'info'
 
 /**
  * A human-readable explanation of a diagnostic code: a short title, what triggers it, and how
- * to resolve it. This is the single source of truth the kubb.dev `/diagnostics/<slug>` pages
- * mirror, so every code stays documented in one place. Typed as a total record over
- * {@link DiagnosticCode}, so adding a code without documenting it fails the build.
+ * to resolve it. This is the source of truth the kubb.dev `/diagnostics/<slug>` pages mirror, so
+ * every code stays documented in one place. Adding a code without documenting it fails the build.
  */
 export type DiagnosticDoc = {
   /**
@@ -83,9 +82,7 @@ export type ProblemCode = Exclude<DiagnosticCode, typeof diagnosticCode.performa
 
 /**
  * A build problem collected during a run, gathered into the result instead of
- * aborting on the first failure. It carries a stable {@link ProblemCode}, a
- * `severity`, a `message`, and optionally a `location` into the source document,
- * a `help`, the `plugin` that produced it, and the `cause` it wraps.
+ * aborting on the first failure.
  */
 export type ProblemDiagnostic = {
   /**
@@ -114,9 +111,9 @@ export type ProblemDiagnostic = {
 }
 
 /**
- * A per-plugin performance record, built with {@link Diagnostics.performance}. It carries the
- * `plugin` and its elapsed `duration`, and the `performance` kind keeps it out of the problem
- * list. It feeds the per-plugin timing bars, and reporters sum these into the run total.
+ * A per-plugin performance record, built with {@link Diagnostics.performance}. The `performance`
+ * kind keeps it out of the problem list. It feeds the per-plugin timing bars, and reporters sum
+ * these into the run total.
  */
 export type PerformanceDiagnostic = {
   kind: 'performance'
@@ -135,7 +132,7 @@ export type PerformanceDiagnostic = {
 
 /**
  * A notice that a newer Kubb version is available on npm, built with {@link Diagnostics.update}.
- * It carries the running and latest versions and renders like any info diagnostic.
+ * It renders like any info diagnostic.
  */
 export type UpdateDiagnostic = {
   kind: 'update'

--- a/packages/core/src/mocks.ts
+++ b/packages/core/src/mocks.ts
@@ -11,7 +11,6 @@ import { memoryStorage } from './storages/memoryStorage.ts'
 import type { Adapter, AdapterFactoryOptions, Config, Generator, GeneratorContext, NormalizedPlugin, PluginFactoryOptions, RendererFactory } from './types.ts'
 
 /**
-
  * Creates a minimal `PluginDriver` mock for unit tests.
  */
 export function createMockedPluginDriver(options: { name?: string; plugin?: NormalizedPlugin; config?: Config } = {}): KubbDriver {

--- a/packages/core/src/reporters/cliReporter.ts
+++ b/packages/core/src/reporters/cliReporter.ts
@@ -73,7 +73,7 @@ function renderSummary(lines: ReadonlyArray<string>, { title, status }: { title:
 
 /**
  * The default `cli` reporter. Renders the {@link Report} for each config as it finishes, independent
- * of the live logger view. Suppressed at `silent`; the `verbose` level adds the per-plugin timings.
+ * of the live logger view. Suppressed at `silent`. The `verbose` level adds the per-plugin timings.
  */
 export const cliReporter = createReporter({
   name: 'cli',

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -10,9 +10,9 @@ import type { KubbPluginEndContext, KubbPluginSetupContext, KubbPluginStartConte
 import type { KubbDriver } from './KubbDriver.ts'
 
 /**
- * Safely extracts a type from a registry, returning `{}` if the key doesn't exist.
- * Enables optional interface augmentation for `Kubb.ConfigOptionsRegistry` and `Kubb.PluginOptionsRegistry`
- * without requiring changes to core.
+ * Extracts a type from a registry, falling back to `{}` when the key doesn't exist.
+ * Lets plugins augment `Kubb.ConfigOptionsRegistry` and `Kubb.PluginOptionsRegistry`
+ * without changing core.
  *
  * @internal
  */
@@ -137,7 +137,6 @@ export type Config<TInput = Input> = {
      * Remove every file in the output directory before the build, so stale output isn't mixed
      * with new files. Leave `false` to preserve manual edits in the output directory.
      *
-     * @default false
      * @example
      * ```ts
      * clean: true  // wipes ./src/gen/* before generating
@@ -148,7 +147,6 @@ export type Config<TInput = Input> = {
      * Format the generated files after generation. `'auto'` runs the first formatter it finds
      * (oxfmt, biome, or prettier), a named tool forces that one, and `false` skips formatting.
      *
-     * @default false
      * @example
      * ```ts
      * format: 'auto'        // auto-detect prettier, biome, or oxfmt
@@ -161,7 +159,6 @@ export type Config<TInput = Input> = {
      * Lint the generated files after generation. `'auto'` runs the first linter it finds
      * (oxlint, biome, or eslint), a named tool forces that one, and `false` skips linting.
      *
-     * @default false
      * @example
      * ```ts
      * lint: 'auto'      // auto-detect oxlint, biome, or eslint
@@ -199,7 +196,6 @@ export type Config<TInput = Input> = {
      * Overwrite existing files when `true`, skip files that already exist when `false`. Individual
      * plugins can override it. Keep `false` to avoid clobbering local edits in the output folder.
      *
-     * @default false
      * @example
      * ```ts
      * override: true   // regenerate everything, even existing files
@@ -245,10 +241,9 @@ export type Config<TInput = Input> = {
    */
   plugins: Array<Plugin>
   /**
-   * Lifecycle hooks that execute during or after the build process.
+   * Lifecycle hooks that run external tools (prettier, eslint, a custom script) on build events.
    *
-   * Hooks allow you to run external tools (prettier, eslint, custom scripts) based on build events.
-   * Currently supports the `done` hook which fires after all plugins complete.
+   * Currently supports the `done` hook, which fires after all plugins complete.
    *
    * @example
    * ```ts
@@ -261,11 +256,10 @@ export type Config<TInput = Input> = {
    */
   hooks?: {
     /**
-     * Command(s) to run after all plugins complete generation.
+     * Command(s) to run after all plugins finish generating, for post-processing the output.
      *
-     * Useful for post-processing: formatting, linting, copying files, or custom validation.
-     * Pass a single command string or array of command strings to run sequentially.
-     * Commands are executed relative to the `root` directory.
+     * Pass a single command string, or an array to run them in sequence.
+     * Commands run relative to the `root` directory.
      *
      * @example
      * ```ts
@@ -762,7 +756,7 @@ export type CLIOptions = {
 
 /**
  * All accepted forms of a Kubb configuration.
- * Accepts `Config`/`Config[]`/promise or a factory (optionally receiving `TCliOptions`.
+ * Accepts `Config`/`Config[]`/promise or a factory (optionally receiving `TCliOptions`).
  */
 export type PossibleConfig<TCliOptions = undefined> =
   | PossiblePromise<Config | Array<Config>>

--- a/packages/kubb/src/defineConfig.ts
+++ b/packages/kubb/src/defineConfig.ts
@@ -23,7 +23,7 @@ type DefinedConfig<TConfig extends ConfigInput> = TConfig extends (cli: CLIOptio
  * - `parsers` defaults to `[parserTs, parserTsx, parserMd]`
  * - `reporters` defaults to `[cliReporter, jsonReporter, fileReporter]`
  * - `plugins` gets `pluginBarrel()` appended when none is already present
- * - `output.barrel` defaults to `{ type: 'named' }` **only when `pluginBarrel` is part of `plugins`**.
+ * - `output.barrel` defaults to `{ type: 'named' }` only when `pluginBarrel` is part of `plugins`.
  *   When the user provides a plugins list without `pluginBarrel`, `barrel` is left untouched.
  * - `output.format` defaults to `false`
  * - `output.lint` defaults to `false`
@@ -64,8 +64,8 @@ function normalizeConfig<TInput>(config: UserConfig<TInput> | Array<UserConfig<T
 }
 
 /**
- * Defines a Kubb build configuration and applies sensible defaults so the
- * minimal config stays small.
+ * Defines a Kubb build configuration and fills in defaults so a minimal config
+ * stays small.
  *
  * Defaults applied when omitted:
  * - `adapter` → `adapterOas()` (OpenAPI 2.0/3.0/3.1).

--- a/packages/parser-md/src/utils.ts
+++ b/packages/parser-md/src/utils.ts
@@ -25,7 +25,7 @@ function printFrontmatter(data: Record<string, unknown> | null | undefined): str
 
 /**
  * Joins a list of markdown fragments with blank lines. Plain objects are
- * rendered as YAML frontmatter via {@link printFrontmatter}; strings pass
+ * rendered as YAML frontmatter via {@link printFrontmatter}, and strings pass
  * through unchanged.
  *
  * @example

--- a/packages/parser-ts/src/utils.ts
+++ b/packages/parser-ts/src/utils.ts
@@ -49,7 +49,7 @@ export function resolveOutputPath(path: string, options: { extname?: string } | 
 
 /**
  * Serializes a `nodes` array into source text. Each entry is rendered via {@link printCodeNode}
- * and joined with a single newline; a `Break` node (`<br/>`) inserts one blank line between
+ * and joined with a single newline. A `Break` node (`<br/>`) inserts one blank line between
  * statements. Consecutive breaks, and breaks at the very start or end, are folded into the
  * separator, so a double `<br/>` never emits more than one blank line.
  */
@@ -93,9 +93,9 @@ export function indentLines(text: string, indent: number | string = INDENT): str
 
 /**
  * Removes the common leading whitespace shared by every non-blank line and trims
- * surrounding blank lines, normalizing multi-line content authored inside an
- * indented template literal back to a column-zero baseline. Leading whitespace is
- * counted by character, so N tabs and N spaces are treated as the same depth.
+ * surrounding blank lines, so multi-line content authored inside an indented template
+ * literal lines up at a column-zero baseline. Leading whitespace is counted by
+ * character, so N tabs and N spaces are treated as the same depth.
  *
  * @example
  * ```ts

--- a/packages/plugin-barrel/src/types.ts
+++ b/packages/plugin-barrel/src/types.ts
@@ -47,8 +47,6 @@ export type PluginBarrelConfig = {
   /**
    * Generate an `index.ts` in every sub-directory, each re-exporting only what's directly inside it.
    * Creates a hierarchical barrel structure instead of flat exports from the root.
-   *
-   * @default false
    */
   nested?: boolean
 }

--- a/packages/plugin-barrel/src/utils.ts
+++ b/packages/plugin-barrel/src/utils.ts
@@ -192,15 +192,11 @@ type GetBarrelFilesParams = {
   /**
    * Generate an `index.ts` in every sub-directory, each re-exporting only what's directly inside it (hierarchical).
    * When false, uses flat generation strategy with optional recursive subdirectory barrels.
-   *
-   * @default false
    */
   nested?: boolean
   /**
    * Also generate a barrel for each sub-directory when nested is false.
    * No effect when nested is true (always generates hierarchical structure).
-   *
-   * @default false
    */
   recursive?: boolean
 }

--- a/packages/renderer-jsx/src/jsx-namespace.d.ts
+++ b/packages/renderer-jsx/src/jsx-namespace.d.ts
@@ -17,7 +17,7 @@ import type {
 /**
  * JSX contract for `@kubb/renderer-jsx`, resolved through `jsxImportSource`.
  *
- * It is self-contained and does not extend `React.JSX`: the renderer only emits
+ * It is self-contained and does not extend `React.JSX`. The renderer only emits
  * the custom `kubb-*` hosts plus `br`, `indent`, and `dedent`, and supports
  * pure function components, so the HTML element and class-component machinery
  * from `@types/react` is not needed.

--- a/packages/renderer-jsx/src/jsx-runtime.ts
+++ b/packages/renderer-jsx/src/jsx-runtime.ts
@@ -10,9 +10,9 @@ export const Fragment = Symbol.for('kubb.fragment')
 
 /**
  * Create a Kubb JSX element. The automatic JSX runtime calls this for every tag,
- * so the renderer never depends on React at runtime. The element carries a
- * `$$typeof` marker, its `type` (a host string, a function component, or
- * `Fragment`), and its `props`, with children included.
+ * so the renderer never depends on React at runtime. The `type` is a host
+ * string, a function component, or `Fragment`, and children are folded into
+ * `props`.
  */
 function createElement(type: unknown, props: Record<string, unknown> | null, key?: Key | null): KubbReactElement {
   return { $$typeof: KUBB_ELEMENT, type, key: key ?? null, props: props ?? {} } as unknown as KubbReactElement

--- a/packages/renderer-jsx/src/types.ts
+++ b/packages/renderer-jsx/src/types.ts
@@ -6,9 +6,8 @@ import type { ArrowFunctionNode, ConstNode, ExportNode, FileNode, FunctionNode, 
 export type Key = string | number | bigint
 
 /**
- * Element produced by a Kubb JSX component. It carries the host or component
- * `type`, its `props`, and an optional list `key`. The renderer walks these at
- * runtime, so the fields stay opaque to type-checking.
+ * Element produced by a Kubb JSX component. The renderer walks these at runtime,
+ * so the fields stay opaque to type-checking.
  */
 export type KubbReactElement = {
   type: unknown


### PR DESCRIPTION
Applies the same jsdoc + humanizer pass from #3591 (which covered `@kubb/ast`) to the rest of the kubb packages.

## Scope

Comment-only cleanup across 32 files in 8 packages:

| Package | Files touched |
| --- | --- |
| @kubb/core | 12 |
| @kubb/cli | 7 |
| @kubb/adapter-oas | 5 |
| @kubb/renderer-jsx | 3 |
| @kubb/plugin-barrel | 2 |
| @kubb/parser-ts | 1 |
| @kubb/parser-md | 1 |
| kubb | 1 |

`@kubb/mcp` and `unplugin-kubb` were reviewed and already read clean.

## What changed

Cuts the tells the humanizer skill flags: rule-of-three "use this to X, Y, or Z" lists, `-ing`-participle fake-depth clauses, clause-joining semicolons, a couple of em dashes used as punctuation, mid-sentence bold, marketing words, and sentences that only restate the TypeScript type. Also dropped a few `@default false` tags and fixed an unbalanced-parenthesis typo in a doc.

## Safety

Every changed line is a comment. Verified by diffing with zero context and confirming no non-comment line changed (+126/-130, all inside JSDoc or `//` comments). No `@ts-*`, `/// <reference>`, or lint-disable directives were touched, so compilation and tests are unaffected.

- oxfmt `--check`: clean
- oxlint: clean (exit 0)
- A `patch` changeset covers the eight touched published packages, matching the `sync-docs-with-code-defaults` precedent.

https://claude.ai/code/session_01CFh2gpjvENtE1F8f2RhW7X

---
_Generated by [Claude Code](https://claude.ai/code/session_01CFh2gpjvENtE1F8f2RhW7X)_