### PR TITLE
fix(ast): keep re-export-only utils in the CJS build

### DIFF
--- a/.changeset/ast-cjs-sideeffects-utils.md
+++ b/.changeset/ast-cjs-sideeffects-utils.md
@@ -1,0 +1,7 @@
+---
+'@kubb/ast': patch
+---
+
+Fix the CJS build dropping re-export-only `@kubb/ast/utils` helpers.
+
+With `"sideEffects": false`, rolldown tree-shook the modules that the `utils` subpath only re-exports (`schemaGraph`, `operationParams`, `codegen`, `strings`, and friends) out of the multi-entry CJS bundle, while still emitting their export getters. Requiring `@kubb/ast/utils` from a CommonJS context then threw `findCircularSchemas is not defined` (and the same for `createOperationParams`, `containsCircularRef`, `caseParams`, `buildJSDoc`, and the rest). The ESM build was unaffected, so this only surfaced for CJS consumers such as a `kubb.config.cjs`. Dropping the `sideEffects` declaration keeps those modules in the CJS output.

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -23,7 +23,6 @@
     "!/**/__snapshots__/**"
   ],
   "type": "module",
-  "sideEffects": false,
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Problem

Requiring `@kubb/ast/utils` from a CommonJS context throws at runtime:

```
ReferenceError: findCircularSchemas is not defined
```

…and the same for `createOperationParams`, `containsCircularRef`, `caseParams`, `buildJSDoc`, `collectUsedSchemaNames`, and the rest of the helpers that the `utils` subpath only re-exports.

This surfaced in [kubb-labs/plugins#413](https://github.com/kubb-labs/plugins/pull/413): the faker example uses a `kubb.config.cjs`, so `@kubb/adapter-oas` loads as CommonJS and calls `findCircularSchemas` imported from `@kubb/ast/utils` — which blew up the "Update generated examples" CI job. Every other example uses an ESM config and was unaffected.

## Root cause

`@kubb/ast` builds four entries (`index`, `factory`, `types`, `utils`) in one multi-entry bundle. The modules that `utils/index.ts` only **re-exports** (`schemaGraph`, `operationParams`, `codegen`, `strings`, `extractStringsFromNodes`, `transformers`) are shared with the `index`/`factory` entries.

With `"sideEffects": false`, rolldown treats those modules as pure and, in the **CJS** multi-entry pass, tree-shakes their definitions out entirely while still emitting the export getters — so the getters reference free variables that don't exist (`return findCircularSchemas` where `findCircularSchemas` was dropped). The ESM pass wires the shared chunk correctly, which is why only CommonJS consumers hit it.

This started when `createOperationParams` moved into `@kubb/ast/utils` (the `utils` barrel grew to share modules with the other entries).

## Fix

Drop the `"sideEffects": false` declaration on `@kubb/ast` so rolldown keeps those modules in the CJS output. One line, original `tsdown.config.ts` untouched.

## Verification

- `require('@kubb/ast/utils')` (via the package `require` exports condition → `dist/utils.cjs`) now resolves `findCircularSchemas`, `createOperationParams`, `containsCircularRef`, `caseParams`, `buildJSDoc`, … as functions; `findCircularSchemas([])` returns `[]`.
- ESM `@kubb/ast/utils` still resolves all 26 exports.
- `@kubb/ast`: 14 test files / 351 tests pass, `typecheck` passes.

## Release coordination

Needs to publish as the next beta. Once released, kubb-labs/plugins#413 should bump its catalog from `5.0.0-beta.59` to that version (beta.59's CJS build is the broken one).

https://claude.ai/code/session_01JcGgmSkvxZq7VfMGEKwnZq

---
_Generated by [Claude Code](https://claude.ai/code/session_01JcGgmSkvxZq7VfMGEKwnZq)_