### PR TITLE
chore: bump all packages to 5.0.0-beta.75

### DIFF
--- a/packages/adapter-oas/package.json
+++ b/packages/adapter-oas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/adapter-oas",
-  "version": "5.0.0-beta.63",
+  "version": "5.0.0-beta.75",
   "description": "OpenAPI and Swagger adapter for Kubb. Parses and validates OAS 2.0/3.x specifications into a @kubb/ast RootNode for downstream code generation plugins.",
   "keywords": [
     "adapter",

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/ast",
-  "version": "5.0.0-beta.63",
+  "version": "5.0.0-beta.75",
   "description": "Spec-agnostic AST layer for Kubb. Defines the node tree, visitor pattern, factory functions, and type guards used across all code generation plugins.",
   "keywords": [
     "ast",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/cli",
-  "version": "5.0.0-beta.63",
+  "version": "5.0.0-beta.75",
   "description": "Official CLI for Kubb. Run kubb generate, kubb init, kubb validate, and kubb mcp to manage the full code generation lifecycle from OpenAPI/Swagger specs.",
   "keywords": [
     "cli",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/core",
-  "version": "5.0.0-beta.63",
+  "version": "5.0.0-beta.75",
   "description": "Core engine for Kubb's plugin-based code generation system. Provides the plugin driver, file manager, defineConfig, and build orchestration used by every Kubb plugin.",
   "keywords": [
     "code-generator",

--- a/packages/kubb/package.json
+++ b/packages/kubb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kubb",
   "version": "5.0.0-beta.75",
-  "description": "Meta-package and entry point for Kubb \u2014 a plugin-based code generation framework for OpenAPI. Includes defineConfig, all public APIs, and serves as the gateway to the entire Kubb ecosystem.",
+  "description": "Meta-package and entry point for Kubb — a plugin-based code generation framework for OpenAPI. Includes defineConfig, all public APIs, and serves as the gateway to the entire Kubb ecosystem.",
   "keywords": [
     "api-client",
     "code-generator",

--- a/packages/kubb/package.json
+++ b/packages/kubb/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kubb",
-  "version": "5.0.0-beta.63",
-  "description": "Meta-package and entry point for Kubb — a plugin-based code generation framework for OpenAPI. Includes defineConfig, all public APIs, and serves as the gateway to the entire Kubb ecosystem.",
+  "version": "5.0.0-beta.75",
+  "description": "Meta-package and entry point for Kubb \u2014 a plugin-based code generation framework for OpenAPI. Includes defineConfig, all public APIs, and serves as the gateway to the entire Kubb ecosystem.",
   "keywords": [
     "api-client",
     "code-generator",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/mcp",
-  "version": "5.0.0-beta.63",
+  "version": "5.0.0-beta.75",
   "description": "MCP server for Kubb. Exposes code generation as a tool over the Model Context Protocol so AI assistants like Claude, Cursor, and other MCP-compatible clients can generate TypeScript types, clients, and more from OpenAPI specs.",
   "keywords": [
     "ai",

--- a/packages/parser-md/package.json
+++ b/packages/parser-md/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/parser-md",
-  "version": "5.0.0-beta.63",
+  "version": "5.0.0-beta.75",
   "description": "Markdown source file parser for Kubb. Converts the universal AST to `.md` source and renders YAML frontmatter via the `print` helper.",
   "keywords": [
     "codegen",

--- a/packages/parser-ts/package.json
+++ b/packages/parser-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/parser-ts",
-  "version": "5.0.0-beta.63",
+  "version": "5.0.0-beta.75",
   "description": "TypeScript and TSX source file parser for Kubb. Converts AST nodes and raw TypeScript code into formatted source strings using the TypeScript compiler API.",
   "keywords": [
     "codegen",

--- a/packages/plugin-barrel/package.json
+++ b/packages/plugin-barrel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/plugin-barrel",
-  "version": "5.0.0-beta.63",
+  "version": "5.0.0-beta.75",
   "description": "Barrel-file plugin for Kubb. Automatically generates index.ts re-export files per plugin output directory and an optional root barrel after all plugins complete.",
   "keywords": [
     "barrel",

--- a/packages/renderer-jsx/package.json
+++ b/packages/renderer-jsx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kubb/renderer-jsx",
-  "version": "5.0.0-beta.63",
+  "version": "5.0.0-beta.75",
   "description": "Self-contained synchronous JSX renderer for Kubb. Turns JSX into FileNodes with built-in components (File, Function, Type, Const) for component-based, type-safe code generation. No React dependency.",
   "keywords": [
     "codegen",

--- a/packages/unplugin-kubb/package.json
+++ b/packages/unplugin-kubb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unplugin-kubb",
-  "version": "5.0.0-beta.63",
+  "version": "5.0.0-beta.75",
   "description": "Universal build integration for Kubb using unplugin. Plug OpenAPI code generation into Vite, Webpack, Rollup, esbuild, Rspack, Nuxt, and Astro as part of your regular build pipeline.",
   "keywords": [
     "astro",


### PR DESCRIPTION
## Summary

- Bumps all kubb packages (`@kubb/core`, `@kubb/ast`, `@kubb/cli`, `@kubb/adapter-oas`, `@kubb/mcp`, `@kubb/parser-md`, `@kubb/parser-ts`, `@kubb/plugin-barrel`, `@kubb/renderer-jsx`, `kubb`, `unplugin-kubb`) from `5.0.0-beta.63` to `5.0.0-beta.75`, aligning the source version with the latest published beta on npm.

## Test plan

- [ ] Verify package versions are `5.0.0-beta.75` in each `packages/*/package.json`
- [ ] CI passes on the branch

https://claude.ai/code/session_01KLVhCYCqtsS9RtP3bUNme9

---
_Generated by [Claude Code](https://claude.ai/code/session_01KLVhCYCqtsS9RtP3bUNme9)_