### PR TITLE
fix(plugin-ts): preserve empty string values in enum type generation [v4]

### DIFF
--- a/.changeset/empty-string-enum-typescript.md
+++ b/.changeset/empty-string-enum-typescript.md
@@ -1,0 +1,14 @@
+---
+"@kubb/plugin-ts": patch
+---
+
+Fix empty string enum values being dropped from generated TypeScript types.
+
+OpenAPI enums containing `""` (empty string) were silently omitted from the emitted
+TypeScript type in all enum modes (`asConst`, `asPascalConst`, `literal`, `inlineLiteral`,
+`enum`, `constEnum`). The Zod plugin already handled empty strings correctly, causing a
+mismatch and a broken cast (`as unknown as z.ZodType<...>`).
+
+Root cause: three truthiness guards (`if (value)` / `if (key)`) in
+`createEnumDeclaration` treated `''` as falsy. Replaced all three with explicit
+`!== null && !== undefined` checks.

--- a/packages/plugin-ts/src/__snapshots__/factory.test.ts.snap
+++ b/packages/plugin-ts/src/__snapshots__/factory.test.ts.snap
@@ -122,6 +122,21 @@ exports[`Code Generation > should create enum declaration 10`] = `
 "
 `;
 
+exports[`Code Generation > should create enum declaration 11`] = `
+"export const proxyHostALPN = {
+  '': '',
+  h3: 'h3',
+  h2: 'h2',
+} as const
+export type ProxyHostALPNKey = (typeof proxyHostALPN)[keyof typeof proxyHostALPN]
+"
+`;
+
+exports[`Code Generation > should create enum declaration 12`] = `
+"export type ProxyHostALPN = '' | 'h3' | 'h2'
+"
+`;
+
 exports[`Code Generation > should create export declaration 1`] = `
 "export * from './hello.ts'
 "

--- a/packages/plugin-ts/src/factory.test.ts
+++ b/packages/plugin-ts/src/factory.test.ts
@@ -464,7 +464,7 @@ describe('Code Generation', () => {
   })
 
   it('should quote enum keys that parse as private identifiers (#-prefixed)', async () => {
-    // A `#`-prefixed name (e.g. a hex colour like `#ccff9a`) parses as a TypeScript
+    // A `#`-prefixed name (e.g. a hex color like `#ccff9a`) parses as a TypeScript
     // private identifier, which is only valid inside a class body. As an object key it
     // must be quoted, otherwise the generated `as const` map is a syntax error (TS18016).
     const output = await formatTS(

--- a/packages/plugin-ts/src/factory.test.ts
+++ b/packages/plugin-ts/src/factory.test.ts
@@ -430,6 +430,37 @@ describe('Code Generation', () => {
         }),
       ),
     ).toMatchSnapshot()
+
+    // empty string is a valid enum value and must not be dropped
+    expect(
+      await formatTS(
+        createEnumDeclaration({
+          type: 'asConst',
+          name: 'proxyHostALPN',
+          typeName: 'ProxyHostALPNKey',
+          enums: [
+            ['', ''],
+            ['h3', 'h3'],
+            ['h2', 'h2'],
+          ],
+        }),
+      ),
+    ).toMatchSnapshot()
+
+    expect(
+      await formatTS(
+        createEnumDeclaration({
+          type: 'literal',
+          name: 'proxyHostALPN',
+          typeName: 'ProxyHostALPN',
+          enums: [
+            ['', ''],
+            ['h3', 'h3'],
+            ['h2', 'h2'],
+          ],
+        }),
+      ),
+    ).toMatchSnapshot()
   })
 
   it('should quote enum keys that parse as private identifiers (#-prefixed)', async () => {

--- a/packages/plugin-ts/src/factory.ts
+++ b/packages/plugin-ts/src/factory.ts
@@ -497,7 +497,7 @@ export function createEnumDeclaration({
               if (typeof value === 'boolean') {
                 return factory.createLiteralTypeNode(value ? factory.createTrue() : factory.createFalse())
               }
-              if (value) {
+              if (value !== null && value !== undefined) {
                 return factory.createLiteralTypeNode(factory.createStringLiteral(value.toString()))
               }
 
@@ -537,7 +537,7 @@ export function createEnumDeclaration({
               return factory.createEnumMember(propertyName(casingKey), initializer)
             }
 
-            if (key) {
+            if (key !== null && key !== undefined) {
               const casingKey = applyEnumKeyCasing(key.toString(), enumKeyCasing)
               return factory.createEnumMember(propertyName(casingKey), initializer)
             }
@@ -600,7 +600,7 @@ export function createEnumDeclaration({
                       initializer = value ? factory.createTrue() : factory.createFalse()
                     }
 
-                    if (key) {
+                    if (key !== null && key !== undefined) {
                       const casingKey = applyEnumKeyCasing(key.toString(), enumKeyCasing)
                       return factory.createPropertyAssignment(propertyName(casingKey), initializer)
                     }


### PR DESCRIPTION
## Summary

Backport of the empty string enum fix to v4.

- Fixes empty string `""` enum values being silently dropped from all TypeScript enum modes (`asConst`, `asPascalConst`, `literal`, `inlineLiteral`, `enum`, `constEnum`)
- Root cause: three truthiness guards (`if (value)` / `if (key)`) in `createEnumDeclaration` treated `''` as falsy — replaced with explicit `!== null && !== undefined` checks
- Adds test cases for `asConst` and `literal` modes with an empty string enum value

## Reproducer

```json
"ProxyHostALPN": {
  "type": "string",
  "enum": ["", "h3", "h2", "http/1.1", ...]
}
```

Before: `''` was dropped from the generated type, breaking the `as unknown as z.ZodType<ProxyHostALPN>` cast.

After (`asConst` mode):
```ts
export const proxyHostALPN = {
  '': '',
  h3: 'h3',
  ...
} as const
```

## Test plan

- [ ] New `createEnumDeclaration` snapshot tests for `asConst` and `literal` with an empty string value pass
- [ ] All existing tests continue to pass (CI green)

https://claude.ai/code/session_01UdPAqdiu1amMh1Hu25gmjW

---
_Generated by [Claude Code](https://claude.ai/code/session_01UdPAqdiu1amMh1Hu25gmjW)_