### PR TITLE
feat(diagnostics): lead terminal diagnostics with the code

### DIFF
--- a/.changeset/diagnostics-tree-render.md
+++ b/.changeset/diagnostics-tree-render.md
@@ -4,6 +4,6 @@
 '@kubb/mcp': patch
 ---
 
-Render terminal diagnostics as a box-drawing tree instead of the oxlint glyph style.
+Lead terminal diagnostics with the code and rename the help/docs labels.
 
-A diagnostic now prints as `[CODE] plugin: message` with the code tinted by severity, followed by `├▶ at:`, `├▶ fix:`, and `╰▶ see:` rows (the last row uses `╰▶`). The `help:` and `docs:` labels are renamed to `fix:` and `see:`, matching the diagnostics docs pages. The `--reporter json` output and the `SerializedDiagnostic` fields (`help`, `docsUrl`) are unchanged.
+A diagnostic now prints as `[CODE] plugin: message` with the code tinted by severity, followed by indented `at:`, `fix:`, and `see:` rows. The `help:` and `docs:` labels are renamed to `fix:` and `see:`, matching the diagnostics docs pages, and the standalone `×`/`⚠`/`ℹ` glyph is dropped. The `--reporter json` output and the `SerializedDiagnostic` fields (`help`, `docsUrl`) are unchanged.

--- a/.changeset/diagnostics-tree-render.md
+++ b/.changeset/diagnostics-tree-render.md
@@ -1,0 +1,9 @@
+---
+'@kubb/core': patch
+'@kubb/cli': patch
+'@kubb/mcp': patch
+---
+
+Render terminal diagnostics as a box-drawing tree instead of the oxlint glyph style.
+
+A diagnostic now prints as `[CODE] plugin: message` with the code tinted by severity, followed by `├▶ at:`, `├▶ fix:`, and `╰▶ see:` rows (the last row uses `╰▶`). The `help:` and `docs:` labels are renamed to `fix:` and `see:`, matching the diagnostics docs pages. The `--reporter json` output and the `SerializedDiagnostic` fields (`help`, `docsUrl`) are unchanged.

--- a/packages/cli/src/loggers/clackLogger.ts
+++ b/packages/cli/src/loggers/clackLogger.ts
@@ -182,11 +182,10 @@ Run \`npm install -g @kubb/cli\` to update`,
         return
       }
 
-      // Hand the severity glyph to clack as the gutter `symbol`, then let it draw the
-      // bar on each detail line via the default `secondarySymbol`. The headline and
-      // details carry their own colors, so clack only owns the gutter.
-      const { symbol, headline, details } = Diagnostics.format(diagnostic)
-      clack.log.message([headline, ...details], { symbol })
+      // The diagnostic renders as its own box-drawing tree, so clear clack's gutter and
+      // bar (`symbol`/`secondarySymbol`) to keep the `├▶`/`╰▶` connectors flush.
+      const { headline, details } = Diagnostics.format(diagnostic)
+      clack.log.message([headline, ...details], { symbol: '', secondarySymbol: '' })
     })
 
     context.on('kubb:lifecycle:start', async ({ version }) => {

--- a/packages/cli/src/loggers/clackLogger.ts
+++ b/packages/cli/src/loggers/clackLogger.ts
@@ -182,8 +182,8 @@ Run \`npm install -g @kubb/cli\` to update`,
         return
       }
 
-      // The diagnostic renders as its own box-drawing tree, so clear clack's gutter and
-      // bar (`symbol`/`secondarySymbol`) to keep the `├▶`/`╰▶` connectors flush.
+      // The diagnostic carries the code and its own indented detail rows, so clear clack's
+      // gutter and bar (`symbol`/`secondarySymbol`) and let the block stand on its own.
       const { headline, details } = Diagnostics.format(diagnostic)
       clack.log.message([headline, ...details], { symbol: '', secondarySymbol: '' })
     })

--- a/packages/core/src/diagnostics.test.ts
+++ b/packages/core/src/diagnostics.test.ts
@@ -151,8 +151,8 @@ describe('Diagnostics.update', () => {
 
 // styleText respects NO_COLOR/non-TTY, so assert on the plain text the parts contain.
 describe('Diagnostics.format', () => {
-  it('splits a diagnostic into symbol, headline, and details parts', () => {
-    const { symbol, headline, details } = Diagnostics.format({
+  it('splits a diagnostic into a headline and tree details', () => {
+    const { headline, details } = Diagnostics.format({
       code: 'KUBB_REF_NOT_FOUND',
       severity: 'error',
       message: 'boom',
@@ -160,38 +160,36 @@ describe('Diagnostics.format', () => {
       location: { kind: 'schema', pointer: '#/components/schemas/Pet' },
     })
 
-    expect(symbol).toContain('×')
-    expect(headline).toContain('KUBB_REF_NOT_FOUND')
+    expect(headline).toContain('[KUBB_REF_NOT_FOUND]')
     expect(headline).toContain('boom')
-    expect(details.some((line) => line.includes('at #/components/schemas/Pet'))).toBe(true)
-    expect(details.some((line) => line.includes('help: fix the ref'))).toBe(true)
-    expect(details.some((line) => line.includes('docs: https://kubb.dev'))).toBe(true)
+    expect(details.some((line) => line.includes('at: #/components/schemas/Pet'))).toBe(true)
+    expect(details.some((line) => line.includes('fix: fix the ref'))).toBe(true)
+    expect(details.some((line) => line.includes('see: https://kubb.dev'))).toBe(true)
+    expect(details.at(-1)).toContain('╰▶')
   })
 
-  it('wraps the code in plugin(code) when a plugin is known', () => {
+  it('puts the plugin after the code in the headline', () => {
     expect(Diagnostics.format({ code: 'KUBB_REF_NOT_FOUND', severity: 'error', message: 'boom', plugin: '@kubb/plugin-zod' }).headline).toContain(
-      '@kubb/plugin-zod(',
+      '@kubb/plugin-zod:',
     )
   })
 
-  it('omits the docs line for KUBB_UNKNOWN', () => {
-    expect(Diagnostics.format({ code: 'KUBB_UNKNOWN', severity: 'error', message: 'boom' }).details.some((line) => line.includes('docs:'))).toBe(false)
+  it('omits the see line for KUBB_UNKNOWN', () => {
+    expect(Diagnostics.format({ code: 'KUBB_UNKNOWN', severity: 'error', message: 'boom' }).details.some((line) => line.includes('see:'))).toBe(false)
   })
 })
 
 describe('Diagnostics.formatLines', () => {
-  it('renders a self-contained miette-style block with the symbol on the header', () => {
+  it('renders a self-contained tree block with the code on the header', () => {
     const [header] = Diagnostics.formatLines({ code: 'KUBB_REF_NOT_FOUND', severity: 'error', message: 'Could not find Pet' })
 
-    expect(header).toContain('×')
-    expect(header).toContain('KUBB_REF_NOT_FOUND')
+    expect(header).toContain('[KUBB_REF_NOT_FOUND]')
     expect(header).toContain('Could not find Pet')
   })
 
-  it('renders an update notice as an info line with the version message', () => {
+  it('renders an update notice as a line with the version message', () => {
     const [header] = Diagnostics.formatLines(Diagnostics.update({ currentVersion: '5.0.0', latestVersion: '5.1.0' }))
 
-    expect(header).toContain('ℹ')
     expect(header).toContain('KUBB_UPDATE_AVAILABLE')
     expect(header).toContain('v5.0.0 → v5.1.0')
   })

--- a/packages/core/src/diagnostics.test.ts
+++ b/packages/core/src/diagnostics.test.ts
@@ -165,7 +165,6 @@ describe('Diagnostics.format', () => {
     expect(details.some((line) => line.includes('at: #/components/schemas/Pet'))).toBe(true)
     expect(details.some((line) => line.includes('fix: fix the ref'))).toBe(true)
     expect(details.some((line) => line.includes('see: https://kubb.dev'))).toBe(true)
-    expect(details.at(-1)).toContain('╰▶')
   })
 
   it('puts the plugin after the code in the headline', () => {

--- a/packages/core/src/diagnostics.ts
+++ b/packages/core/src/diagnostics.ts
@@ -223,13 +223,13 @@ const isPerformance = isKind<PerformanceDiagnostic>('performance')
 const isUpdate = isKind<UpdateDiagnostic>('update')
 
 /**
- * Glyph and accent color per severity, matching the miette/oxlint convention
- * (`×` error, `⚠` warning, `ℹ` advice).
+ * Accent color per severity. The color tints the `[CODE]` tag and the tree connectors
+ * (red error, yellow warning, blue info).
  */
-const severityStyle: Record<DiagnosticSeverity, { glyph: string; color: 'red' | 'yellow' | 'blue' }> = {
-  error: { glyph: '×', color: 'red' },
-  warning: { glyph: '⚠', color: 'yellow' },
-  info: { glyph: 'ℹ', color: 'blue' },
+const severityStyle: Record<DiagnosticSeverity, { color: 'red' | 'yellow' | 'blue' }> = {
+  error: { color: 'red' },
+  warning: { color: 'yellow' },
+  info: { color: 'blue' },
 }
 
 /**
@@ -623,40 +623,44 @@ export class Diagnostics {
   }
 
   /**
-   * Renders a {@link Diagnostic} for terminal output as its parts: the colored severity `symbol`
-   * (the gutter glyph), the `plugin(CODE): message` `headline`, and the `details` lines (optional
-   * `at <pointer>`, `help:`, and `docs:`).
+   * Renders a {@link Diagnostic} for terminal output as a box-drawing tree: the `headline`
+   * (`[CODE] plugin: message`, with the code in the severity color) and the `details` rows
+   * (`at:` pointer, `fix:` help, `see:` docs link), each prefixed with a `├▶` connector and the
+   * last with `╰▶`.
    *
-   * Hosts compose these to fit their gutter: a clack logger passes `symbol` as its own gutter and
-   * `[headline, ...details]` as the message, while plain text outputs use {@link Diagnostics.formatLines}.
+   * Hosts compose these to fit their gutter: a clack logger passes `[headline, ...details]` as the
+   * message with no gutter symbol, while plain text outputs use {@link Diagnostics.formatLines}.
    */
-  static format(diagnostic: Diagnostic): { symbol: string; headline: string; details: Array<string> } {
+  static format(diagnostic: Diagnostic): { headline: string; details: Array<string> } {
     const { code, severity, message } = diagnostic
-    const { glyph, color } = severityStyle[severity]
+    const { color } = severityStyle[severity]
     const problem = isProblem(diagnostic) ? diagnostic : undefined
 
-    const rule = styleText(color, styleText('bold', problem?.plugin ? `${problem.plugin}(${code})` : code))
-    const details: Array<string> = []
+    const tag = styleText(color, styleText('bold', `[${code}]`))
+    const headline = problem?.plugin ? `${tag} ${problem.plugin}: ${message}` : `${tag}: ${message}`
 
+    const rows: Array<string> = []
     if (problem?.location && 'pointer' in problem.location) {
-      details.push(`  ${styleText('dim', 'at')} ${styleText('cyan', problem.location.pointer)}`)
+      rows.push(`${styleText('dim', 'at:')} ${styleText('cyan', problem.location.pointer)}`)
     }
     if (problem?.help) {
-      details.push(`  ${styleText('cyan', 'help:')} ${problem.help}`)
+      rows.push(`${styleText('cyan', 'fix:')} ${problem.help}`)
     }
     if (code !== diagnosticCode.unknown) {
-      details.push(`  ${styleText('dim', 'docs:')} ${styleText('cyan', Diagnostics.docsUrl(code))}`)
+      rows.push(`${styleText('dim', 'see:')} ${styleText('cyan', Diagnostics.docsUrl(code))}`)
     }
 
-    return { symbol: styleText(color, styleText('bold', glyph)), headline: `${rule}: ${message}`, details }
+    const details = rows.map((row, index) => `${styleText(color, index === rows.length - 1 ? '╰▶' : '├▶')} ${row}`)
+
+    return { headline, details }
   }
 
   /**
-   * The self-contained block form of {@link Diagnostics.format}: `${symbol} ${headline}` followed by
-   * the detail lines. Used where there is no gutter to own the symbol (plain and file output).
+   * The self-contained block form of {@link Diagnostics.format}: the `headline` followed by the
+   * connector rows. Used where there is no gutter (plain and file output).
    */
   static formatLines(diagnostic: Diagnostic): Array<string> {
-    const { symbol, headline, details } = Diagnostics.format(diagnostic)
-    return [`${symbol} ${headline}`, ...details]
+    const { headline, details } = Diagnostics.format(diagnostic)
+    return [headline, ...details]
   }
 }

--- a/packages/core/src/diagnostics.ts
+++ b/packages/core/src/diagnostics.ts
@@ -223,8 +223,8 @@ const isPerformance = isKind<PerformanceDiagnostic>('performance')
 const isUpdate = isKind<UpdateDiagnostic>('update')
 
 /**
- * Accent color per severity. The color tints the `[CODE]` tag and the tree connectors
- * (red error, yellow warning, blue info).
+ * Accent color per severity. The color tints the `[CODE]` tag (red error, yellow warning,
+ * blue info).
  */
 const severityStyle: Record<DiagnosticSeverity, { color: 'red' | 'yellow' | 'blue' }> = {
   error: { color: 'red' },
@@ -623,10 +623,9 @@ export class Diagnostics {
   }
 
   /**
-   * Renders a {@link Diagnostic} for terminal output as a box-drawing tree: the `headline`
-   * (`[CODE] plugin: message`, with the code in the severity color) and the `details` rows
-   * (`at:` pointer, `fix:` help, `see:` docs link), each prefixed with a `├▶` connector and the
-   * last with `╰▶`.
+   * Renders a {@link Diagnostic} for terminal output as its parts: the `headline`
+   * (`[CODE] plugin: message`, with the code in the severity color) and the indented `details`
+   * rows (`at:` pointer, `fix:` help, `see:` docs link).
    *
    * Hosts compose these to fit their gutter: a clack logger passes `[headline, ...details]` as the
    * message with no gutter symbol, while plain text outputs use {@link Diagnostics.formatLines}.
@@ -639,25 +638,23 @@ export class Diagnostics {
     const tag = styleText(color, styleText('bold', `[${code}]`))
     const headline = problem?.plugin ? `${tag} ${problem.plugin}: ${message}` : `${tag}: ${message}`
 
-    const rows: Array<string> = []
+    const details: Array<string> = []
     if (problem?.location && 'pointer' in problem.location) {
-      rows.push(`${styleText('dim', 'at:')} ${styleText('cyan', problem.location.pointer)}`)
+      details.push(`  ${styleText('dim', 'at:')} ${styleText('cyan', problem.location.pointer)}`)
     }
     if (problem?.help) {
-      rows.push(`${styleText('cyan', 'fix:')} ${problem.help}`)
+      details.push(`  ${styleText('cyan', 'fix:')} ${problem.help}`)
     }
     if (code !== diagnosticCode.unknown) {
-      rows.push(`${styleText('dim', 'see:')} ${styleText('cyan', Diagnostics.docsUrl(code))}`)
+      details.push(`  ${styleText('dim', 'see:')} ${styleText('cyan', Diagnostics.docsUrl(code))}`)
     }
-
-    const details = rows.map((row, index) => `${styleText(color, index === rows.length - 1 ? '╰▶' : '├▶')} ${row}`)
 
     return { headline, details }
   }
 
   /**
    * The self-contained block form of {@link Diagnostics.format}: the `headline` followed by the
-   * connector rows. Used where there is no gutter (plain and file output).
+   * indented detail rows. Used where there is no gutter (plain and file output).
    */
   static formatLines(diagnostic: Diagnostic): Array<string> {
     const { headline, details } = Diagnostics.format(diagnostic)

--- a/packages/core/src/reporters/fileReporter.test.ts
+++ b/packages/core/src/reporters/fileReporter.test.ts
@@ -42,8 +42,8 @@ describe('fileReporter', () => {
     expect(written).toContain('Plugins   2 passed (2)')
     expect(written).toContain('Files     1 generated')
     expect(written).toContain('## Problems')
-    expect(written).toContain('KUBB_DEPRECATED: This schema is marked as deprecated.')
-    expect(written).toContain('at #/components/schemas/Tag')
+    expect(written).toContain('[KUBB_DEPRECATED]: This schema is marked as deprecated.')
+    expect(written).toContain('at: #/components/schemas/Tag')
     expect(written).toContain('## Timings')
     // Slowest first.
     expect(written.indexOf('plugin-ts')).toBeLessThan(written.indexOf('plugin-redoc'))

--- a/packages/mcp/src/utils.test.ts
+++ b/packages/mcp/src/utils.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { formatDiagnostics } from './utils.ts'
 
 describe('formatDiagnostics', () => {
-  it('renders code, pointer, fix, and see as a tree for an agent without ANSI styling', () => {
+  it('renders code, pointer, fix, and see for an agent without ANSI styling', () => {
     const diagnostic: SerializedDiagnostic = {
       code: 'KUBB_REF_NOT_FOUND',
       severity: 'error',
@@ -19,9 +19,9 @@ describe('formatDiagnostics', () => {
     expect(output).toBe(
       [
         '[KUBB_REF_NOT_FOUND] @kubb/adapter-oas: missing Pet',
-        '├▶ at: #/components/schemas/Pet',
-        '├▶ fix: add it',
-        '╰▶ see: https://kubb.dev/docs/5.x/reference/diagnostics/kubb-ref-not-found',
+        '  at: #/components/schemas/Pet',
+        '  fix: add it',
+        '  see: https://kubb.dev/docs/5.x/reference/diagnostics/kubb-ref-not-found',
       ].join('\n'),
     )
   })

--- a/packages/mcp/src/utils.test.ts
+++ b/packages/mcp/src/utils.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest'
 import { formatDiagnostics } from './utils.ts'
 
 describe('formatDiagnostics', () => {
-  it('renders code, pointer, help, and docs for an agent without ANSI styling', () => {
+  it('renders code, pointer, fix, and see as a tree for an agent without ANSI styling', () => {
     const diagnostic: SerializedDiagnostic = {
       code: 'KUBB_REF_NOT_FOUND',
       severity: 'error',
@@ -18,15 +18,15 @@ describe('formatDiagnostics', () => {
 
     expect(output).toBe(
       [
-        'error @kubb/adapter-oas(KUBB_REF_NOT_FOUND): missing Pet',
-        '  at #/components/schemas/Pet',
-        '  help: add it',
-        '  docs: https://kubb.dev/docs/5.x/reference/diagnostics/kubb-ref-not-found',
+        '[KUBB_REF_NOT_FOUND] @kubb/adapter-oas: missing Pet',
+        '├▶ at: #/components/schemas/Pet',
+        '├▶ fix: add it',
+        '╰▶ see: https://kubb.dev/docs/5.x/reference/diagnostics/kubb-ref-not-found',
       ].join('\n'),
     )
   })
 
   it('drops absent fields and uses the bare code when no plugin is set', () => {
-    expect(formatDiagnostics([{ code: 'KUBB_UNKNOWN', severity: 'error', message: 'boom' }])).toBe('error KUBB_UNKNOWN: boom')
+    expect(formatDiagnostics([{ code: 'KUBB_UNKNOWN', severity: 'error', message: 'boom' }])).toBe('[KUBB_UNKNOWN]: boom')
   })
 })

--- a/packages/mcp/src/utils.ts
+++ b/packages/mcp/src/utils.ts
@@ -16,21 +16,22 @@ export function formatDiagnostics(diagnostics: ReadonlyArray<SerializedDiagnosti
 }
 
 function formatDiagnostic(diagnostic: SerializedDiagnostic): string {
-  const { code, severity, message, location, help, plugin, docsUrl } = diagnostic
-  const rule = plugin ? `${plugin}(${code})` : code
-  const lines = [`${severity} ${rule}: ${message}`]
+  const { code, message, location, help, plugin, docsUrl } = diagnostic
+  const headline = plugin ? `[${code}] ${plugin}: ${message}` : `[${code}]: ${message}`
 
+  const rows: Array<string> = []
   if (location && 'pointer' in location) {
-    lines.push(`  at ${location.pointer}`)
+    rows.push(`at: ${location.pointer}`)
   }
   if (help) {
-    lines.push(`  help: ${help}`)
+    rows.push(`fix: ${help}`)
   }
   if (docsUrl) {
-    lines.push(`  docs: ${docsUrl}`)
+    rows.push(`see: ${docsUrl}`)
   }
 
-  return lines.join('\n')
+  const details = rows.map((row, index) => `${index === rows.length - 1 ? '╰▶' : '├▶'} ${row}`)
+  return [headline, ...details].join('\n')
 }
 
 type NotifyFunction = (type: string, message: string, data?: Record<string, unknown>) => Promise<void>

--- a/packages/mcp/src/utils.ts
+++ b/packages/mcp/src/utils.ts
@@ -17,21 +17,19 @@ export function formatDiagnostics(diagnostics: ReadonlyArray<SerializedDiagnosti
 
 function formatDiagnostic(diagnostic: SerializedDiagnostic): string {
   const { code, message, location, help, plugin, docsUrl } = diagnostic
-  const headline = plugin ? `[${code}] ${plugin}: ${message}` : `[${code}]: ${message}`
+  const lines = [plugin ? `[${code}] ${plugin}: ${message}` : `[${code}]: ${message}`]
 
-  const rows: Array<string> = []
   if (location && 'pointer' in location) {
-    rows.push(`at: ${location.pointer}`)
+    lines.push(`  at: ${location.pointer}`)
   }
   if (help) {
-    rows.push(`fix: ${help}`)
+    lines.push(`  fix: ${help}`)
   }
   if (docsUrl) {
-    rows.push(`see: ${docsUrl}`)
+    lines.push(`  see: ${docsUrl}`)
   }
 
-  const details = rows.map((row, index) => `${index === rows.length - 1 ? '╰▶' : '├▶'} ${row}`)
-  return [headline, ...details].join('\n')
+  return lines.join('\n')
 }
 
 type NotifyFunction = (type: string, message: string, data?: Record<string, unknown>) => Promise<void>


### PR DESCRIPTION
## Summary

Reworks how Kubb prints diagnostics in the terminal, keeping the existing descriptive `KUBB_` codes. A diagnostic now leads with the code and lists its details on indented lines below:

```txt
[KUBB_REF_NOT_FOUND] @kubb/plugin-zod: Could not find a definition for #/components/schemas/Pet.
  at: #/components/schemas/Pet
  fix: Add the schema under components.schemas, or fix the $ref.
  see: https://kubb.dev/docs/5.x/reference/diagnostics/kubb-ref-not-found
```

- The code leads the headline as `[CODE]`, tinted by severity (red error, yellow warning, blue info), replacing the standalone `×`/`⚠`/`ℹ` glyph.
- Detail labels renamed: `help:` → `fix:`, `docs:` → `see:`, `at` → `at:`.
- `KUBB_UNKNOWN` still drops the `see:` line; a pluginless diagnostic reads `[CODE]: message`.

## Scope

- `@kubb/core`: rewrite `Diagnostics.format` / `Diagnostics.formatLines` (the `symbol`/glyph is dropped; severity now lives in the colored `[CODE]`).
- `@kubb/cli`: the clack logger clears its gutter and bar; the plain and file outputs pick up the new block automatically.
- `@kubb/mcp`: the agent-facing `formatDiagnostic` text mirrors the same shape (no color).

The machine-readable output is unchanged: `--reporter json` and the `SerializedDiagnostic` fields (`help`, `docsUrl`, …) keep their shape, so CI consumers are unaffected.

## Tests

Updated `diagnostics.test.ts`, `mcp/utils.test.ts`, and `fileReporter.test.ts`. `pnpm test`, `pnpm typecheck`, and `pnpm lint` pass across `@kubb/core`, `@kubb/cli`, and `@kubb/mcp`.

The matching docs pages under `kubb-labs/docs` (`docs/5.x/reference/diagnostics/`) are updated in a companion PR.

https://claude.ai/code/session_01CiXaK22m25anCtj6acSeax