### PR TITLE
ci: make canary publish non-fatal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,7 @@ jobs:
 
       - name: Publish canary
         if: ${{ steps.changesets.outputs.published != 'true' && steps.changesets.outputs.staged != 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        continue-on-error: true
         shell: bash
         env:
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

- Adds `continue-on-error: true` to the "Publish canary" step in `.github/workflows/release.yml`

A failing canary publish (network glitch, npm rate limit, timestamp collision) previously failed the entire release job, blocking downstream jobs like `notify` and `sync-changelog-docs`. Canary is best-effort — it should never break the pipeline.

## Test plan

- [ ] Verify the release job still succeeds even if the canary step errors
- [ ] Verify downstream jobs (`notify`, `sync-changelog-docs`) still run after a canary failure

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qx2Qixw8pPF1GVi7KPxDe2)_