### PR TITLE
fix(adapter-oas): keep binary request body schema for application/octet-stream

### DIFF
--- a/.changeset/adapter-oas-octet-stream-request-body.md
+++ b/.changeset/adapter-oas-octet-stream-request-body.md
@@ -1,0 +1,7 @@
+---
+'@kubb/adapter-oas': patch
+---
+
+Keep generating a request body schema for `application/octet-stream` bodies.
+
+The 3.0 -> 3.1 upgrade drops the schema from an `application/octet-stream` request body, leaving an empty media type object. `getRequestSchema` now recognizes a binary media type and synthesizes the `{ type: 'string', contentMediaType: 'application/octet-stream' }` schema, so operations like `uploadFile` still emit a binary request body type (for example the Zod `uploadFileDataSchema`).

--- a/packages/adapter-oas/src/mime.ts
+++ b/packages/adapter-oas/src/mime.ts
@@ -19,11 +19,3 @@ const jsonMimeFragments = ['application/json', 'application/x-json', 'text/json'
 export function isJsonMimeType(mimeType: string): boolean {
   return jsonMimeFragments.some((fragment) => mimeType.includes(fragment))
 }
-
-/**
- * Returns `true` when a media type denotes a raw binary body. OAS 3.1 (and the 3.0 -> 3.1 upgrade)
- * represents an `application/octet-stream` body as an empty media type object, dropping the schema.
- */
-export function isBinaryMimeType(mimeType: string): boolean {
-  return mimeType === 'application/octet-stream'
-}

--- a/packages/adapter-oas/src/mime.ts
+++ b/packages/adapter-oas/src/mime.ts
@@ -21,16 +21,8 @@ export function isJsonMimeType(mimeType: string): boolean {
 }
 
 /**
- * Returns `true` when a media type denotes a raw binary body.
- *
- * OAS 3.1 (and the 3.0 -> 3.1 upgrade) represents an `application/octet-stream` body as an empty
- * media type object, dropping the schema. Generators use this to recognize the body is still binary.
- *
- * @example
- * ```ts
- * isBinaryMimeType('application/octet-stream') // true
- * isBinaryMimeType('application/json')         // false
- * ```
+ * Returns `true` when a media type denotes a raw binary body. OAS 3.1 (and the 3.0 -> 3.1 upgrade)
+ * represents an `application/octet-stream` body as an empty media type object, dropping the schema.
  */
 export function isBinaryMimeType(mimeType: string): boolean {
   return mimeType === 'application/octet-stream'

--- a/packages/adapter-oas/src/mime.ts
+++ b/packages/adapter-oas/src/mime.ts
@@ -19,3 +19,19 @@ const jsonMimeFragments = ['application/json', 'application/x-json', 'text/json'
 export function isJsonMimeType(mimeType: string): boolean {
   return jsonMimeFragments.some((fragment) => mimeType.includes(fragment))
 }
+
+/**
+ * Returns `true` when a media type denotes a raw binary body.
+ *
+ * OAS 3.1 (and the 3.0 -> 3.1 upgrade) represents an `application/octet-stream` body as an empty
+ * media type object, dropping the schema. Generators use this to recognize the body is still binary.
+ *
+ * @example
+ * ```ts
+ * isBinaryMimeType('application/octet-stream') // true
+ * isBinaryMimeType('application/json')         // false
+ * ```
+ */
+export function isBinaryMimeType(mimeType: string): boolean {
+  return mimeType === 'application/octet-stream'
+}

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -442,6 +442,35 @@ describe('buildAst', () => {
       expect(upload?.requestBody?.content?.[0]?.contentType).toBe('multipart/form-data')
     })
 
+    it('keeps a binary requestBody for an application/octet-stream body upgraded to 3.1', async () => {
+      const oas = await parseDocument({
+        openapi: '3.0.3',
+        info: { title: 'Test', version: '1.0.0' },
+        paths: {
+          '/pet/{petId}/uploadImage': {
+            post: {
+              operationId: 'uploadFile',
+              requestBody: {
+                required: true,
+                content: {
+                  'application/octet-stream': {
+                    schema: { type: 'string', format: 'binary' },
+                  },
+                },
+              },
+              responses: { '200': { description: 'successful operation' } },
+            },
+          },
+        },
+      })
+      const root = parseOas(oas).root
+      const uploadFile = root.operations.find((op) => op.operationId === 'uploadFile')
+
+      expect(uploadFile?.requestBody?.content).toHaveLength(1)
+      expect(uploadFile?.requestBody?.content?.[0]?.contentType).toBe('application/octet-stream')
+      expect(uploadFile?.requestBody?.content?.[0]?.schema?.type).toBe('blob')
+    })
+
     it('populates response.content with a single entry when the response has one content type', async () => {
       const oas = await buildMinimalOas()
       const root = parseOas(oas).root

--- a/packages/adapter-oas/src/resolvers.ts
+++ b/packages/adapter-oas/src/resolvers.ts
@@ -3,7 +3,7 @@ import { Diagnostics } from '@kubb/core'
 import type { ast } from '@kubb/core'
 import { formatMap, SCHEMA_REF_PREFIX, specialCasedFormats, structuralKeys } from './constants.ts'
 import { isReference } from './guards.ts'
-import { isJsonMimeType } from './mime.ts'
+import { isBinaryMimeType, isJsonMimeType } from './mime.ts'
 import { getRequestContent, getResponseByStatusCode } from './operation.ts'
 import { dereferenceWithRef, resolveRef } from './refs.ts'
 import type { ContentType, Document, MediaTypeObject, Operation, ParameterObject, ResponseObject, SchemaObject, ServerObject } from './types.ts'
@@ -209,7 +209,15 @@ export function getRequestSchema(document: Document, operation: Operation, optio
     return null
   }
 
+  const mediaType = Array.isArray(requestBody) ? requestBody[0] : options.contentType
   const schema = Array.isArray(requestBody) ? requestBody[1].schema : requestBody.schema
+
+  // OAS 3.1 (and the 3.0 -> 3.1 upgrade) drops the schema for an `application/octet-stream` body,
+  // leaving an empty media type object. Synthesize the binary schema so generators still emit a
+  // request body type for the operation.
+  if (mediaType && isBinaryMimeType(mediaType) && (!schema || Object.keys(schema).length === 0)) {
+    return { type: 'string', contentMediaType: 'application/octet-stream' }
+  }
 
   if (!schema) {
     return null

--- a/packages/adapter-oas/src/resolvers.ts
+++ b/packages/adapter-oas/src/resolvers.ts
@@ -3,7 +3,7 @@ import { Diagnostics } from '@kubb/core'
 import type { ast } from '@kubb/core'
 import { formatMap, SCHEMA_REF_PREFIX, specialCasedFormats, structuralKeys } from './constants.ts'
 import { isReference } from './guards.ts'
-import { isBinaryMimeType, isJsonMimeType } from './mime.ts'
+import { isJsonMimeType } from './mime.ts'
 import { getRequestContent, getResponseByStatusCode } from './operation.ts'
 import { dereferenceWithRef, resolveRef } from './refs.ts'
 import type { ContentType, Document, MediaTypeObject, Operation, ParameterObject, ResponseObject, SchemaObject, ServerObject } from './types.ts'
@@ -215,7 +215,7 @@ export function getRequestSchema(document: Document, operation: Operation, optio
   // OAS 3.1 (and the 3.0 -> 3.1 upgrade) drops the schema for an `application/octet-stream` body,
   // leaving an empty media type object. Synthesize the binary schema so generators still emit a
   // request body type for the operation.
-  if (mediaType && isBinaryMimeType(mediaType) && (!schema || Object.keys(schema).length === 0)) {
+  if (mediaType === 'application/octet-stream' && (!schema || Object.keys(schema).length === 0)) {
     return { type: 'string', contentMediaType: 'application/octet-stream' }
   }
 


### PR DESCRIPTION
## Problem

After moving to OpenAPI 3.1 by default (#3619), `application/octet-stream` request bodies stopped generating a request body schema. For example, the Zod plugin no longer emitted `uploadFileDataSchema` for the petstore `uploadFile` operation.

### Root cause

`parseDocument` now upgrades every document to 3.1 via `@scalar/openapi-upgrader`. For binary `application/octet-stream` bodies the upgrader replaces the whole media type object with `{}`, dropping the schema entirely:

```yaml
# input (3.0)
requestBody:
  content:
    application/octet-stream:
      schema: { type: string, format: binary }

# after upgrade (3.1)
requestBody:
  content:
    application/octet-stream: {}
```

`getRequestSchema` then sees no schema and returns `null`, so `parseOperation` skips the content entry and no request body type is generated.

## Fix

`getRequestSchema` now recognizes a binary media type and, when the schema is empty or missing, synthesizes the canonical 3.1 binary schema `{ type: 'string', contentMediaType: 'application/octet-stream' }`. The existing `blob` rule (via `dialect.schema.isBinary`) picks it up, so the operation emits a binary request body type again.

- Added `isBinaryMimeType` helper in `mime.ts`.
- Updated `getRequestSchema` in `resolvers.ts`.
- Added an end-to-end parser test that upgrades a 3.0 `octet-stream` body and asserts the request body content resolves to a `blob` schema.

## Testing

- `pnpm vitest run` in `@kubb/adapter-oas` — 495 passed
- `pnpm typecheck` and `oxlint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6NM1MEW73L7jEhhZkT6Ma

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6NM1MEW73L7jEhhZkT6Ma)_