### PR TITLE
feat(core): add `copy` field to emit real files into the output verbatim

### DIFF
--- a/.changeset/file-node-copy-real-file.md
+++ b/.changeset/file-node-copy-real-file.md
@@ -1,0 +1,6 @@
+---
+"@kubb/ast": minor
+"@kubb/core": minor
+---
+
+Add a `copy` field to the file model so plugins can emit a real on-disk file into the generated folder verbatim. Set `copy` to an absolute path on a `UserFileNode` (via `injectFile`/`upsertFile` or `createFile`) and Kubb writes that file's content unchanged, applying only `banner`/`footer` and bypassing the language parser. This lets a plugin ship a hand-authored template as a real `.ts` file and drop it into the output without inlining its source as a string.

--- a/.changeset/file-node-copy-real-file.md
+++ b/.changeset/file-node-copy-real-file.md
@@ -1,6 +1,9 @@
 ---
 "@kubb/ast": minor
 "@kubb/core": minor
+"@kubb/renderer-jsx": minor
 ---
 
-Add a `copy` field to the file model so plugins can emit a real on-disk file into the generated folder verbatim. Set `copy` to an absolute path on a `UserFileNode` (via `injectFile`/`upsertFile` or `createFile`) and Kubb writes that file's content unchanged, applying only `banner`/`footer` and bypassing the language parser. This lets a plugin ship a hand-authored template as a real `.ts` file and drop it into the output without inlining its source as a string.
+Add a `copy` field to the file model so plugins can emit a real on-disk file into the generated folder verbatim. Set `copy` to an absolute path on a `UserFileNode` (via `injectFile`/`upsertFile` or `createFile`), or pass `copy` to the JSX `<File copy={…} />` component, and Kubb writes that file's content unchanged, applying only `banner`/`footer` and bypassing the language parser. This lets a plugin ship a hand-authored template as a real `.ts` file and drop it into the output without inlining its source as a string.
+
+Remove the unused `output.override` boolean from the config and plugin output options. It was documented as overwriting or skipping existing files, but nothing in the write path read it (`fsStorage` already skips writes only when content is byte-identical), so it had no effect.

--- a/packages/ast/src/nodes/file.ts
+++ b/packages/ast/src/nodes/file.ts
@@ -241,6 +241,16 @@ export type FileNode<TMeta extends object = object> = BaseNode & {
    * Accepts `null` so `resolver.resolveFooter()` results can be passed directly.
    */
   footer?: string | null
+  /**
+   * Absolute on-disk path to copy verbatim into the output, bypassing the parser.
+   *
+   * Use to emit a real source file shipped inside a package (a template) into the generated
+   * folder without reformatting or import reordering. Only `banner` and `footer` are applied
+   * around the copied content. When set, `copy` provides the file content and any `sources`
+   * nodes are ignored for output; `sources` may still carry `name`/`isExportable`/`isIndexable`
+   * so barrel generation treats the file the same as a rendered one.
+   */
+  copy?: string | null
 }
 
 /**
@@ -330,6 +340,15 @@ export type UserFileNode<TMeta extends object = object> = Omit<FileNode<TMeta>, 
  * // file.id      = SHA256 hash of 'src/models/petStore.ts'
  * // file.name    = 'petStore'
  * // file.extname = '.ts'
+ * ```
+ *
+ * @example Copy a real file into the output verbatim
+ * ```ts
+ * const file = createFile({
+ *   baseName: 'client.ts',
+ *   path: 'src/gen/client.ts',
+ *   copy: '/abs/path/to/templates/client.ts',
+ * })
  * ```
  */
 export function createFile<TMeta extends object = object>(input: UserFileNode<TMeta>): FileNode<TMeta> {

--- a/packages/core/src/FileManager.ts
+++ b/packages/core/src/FileManager.ts
@@ -18,6 +18,8 @@ function mergeFile<TMeta extends object = object>(a: FileNode<TMeta>, b: FileNod
     // file at the same path.
     banner: b.banner,
     footer: b.footer,
+    // A verbatim-copy file cannot be merged with rendered content; the incoming `copy` wins.
+    copy: b.copy ?? a.copy,
     sources: a.sources.length ? (b.sources.length ? [...a.sources, ...b.sources] : a.sources) : b.sources,
     imports: a.imports.length ? (b.imports.length ? [...a.imports, ...b.imports] : a.imports) : b.imports,
     exports: a.exports.length ? (b.exports.length ? [...a.exports, ...b.exports] : a.exports) : b.exports,

--- a/packages/core/src/FileProcessor.test.ts
+++ b/packages/core/src/FileProcessor.test.ts
@@ -91,7 +91,7 @@ describe('FileProcessor', () => {
         const processor = new FileProcessor({ storage: memoryStorage() })
         const file = ast.factory.createFile({ path: '/src/client.ts', baseName: 'client.ts', copy: '/does/not/exist.ts' })
 
-        expect(() => processor.parse(file)).toThrow(/Could not copy file into output/)
+        await expect(processor.parse(file)).rejects.toThrow(/Could not copy file into output/)
       })
     })
   })

--- a/packages/core/src/FileProcessor.test.ts
+++ b/packages/core/src/FileProcessor.test.ts
@@ -1,5 +1,8 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
 import { ast, type FileNode } from '@kubb/ast'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { FileProcessor } from './FileProcessor.ts'
 import { memoryStorage } from './storages/memoryStorage.ts'
 
@@ -45,6 +48,51 @@ describe('FileProcessor', () => {
       const result = await processor.parse(file)
       expect(mockParse).toHaveBeenCalledWith(file, { extname: undefined })
       expect(result).toBe('// formatted\nconst a = 1')
+    })
+
+    describe('copy', () => {
+      let dir: string | undefined
+
+      afterEach(() => {
+        if (dir) rmSync(dir, { recursive: true, force: true })
+        dir = undefined
+      })
+
+      it('copies a real file verbatim and bypasses the parser', async () => {
+        dir = mkdtempSync(path.join(tmpdir(), 'kubb-copy-'))
+        const template = path.join(dir, 'template.ts')
+        const content = "import a from 'b'\nexport const z = 1\nimport c from 'd'\n"
+        writeFileSync(template, content)
+
+        const parse = vi.fn().mockReturnValue('SHOULD NOT RUN')
+        const parser = { name: 'ts', type: 'parser' as const, extNames: ['.ts' as const], install: vi.fn(), parse, print: vi.fn().mockReturnValue('') }
+        const processor = new FileProcessor({ storage: memoryStorage(), parsers: new Map([['.ts' as const, parser]]) })
+
+        const file = ast.factory.createFile({ path: '/src/client.ts', baseName: 'client.ts', copy: template })
+        const result = await processor.parse(file)
+
+        expect(parse).not.toHaveBeenCalled()
+        expect(result).toBe(content.trimEnd())
+      })
+
+      it('wraps the copied content with banner and footer', async () => {
+        dir = mkdtempSync(path.join(tmpdir(), 'kubb-copy-'))
+        const template = path.join(dir, 'template.ts')
+        writeFileSync(template, 'export const z = 1')
+
+        const processor = new FileProcessor({ storage: memoryStorage() })
+        const file = ast.factory.createFile({ path: '/src/client.ts', baseName: 'client.ts', copy: template, banner: '/* top */', footer: '/* bottom */' })
+        const result = await processor.parse(file)
+
+        expect(result).toBe('/* top */\nexport const z = 1\n/* bottom */')
+      })
+
+      it('throws a clear error when the file is missing', async () => {
+        const processor = new FileProcessor({ storage: memoryStorage() })
+        const file = ast.factory.createFile({ path: '/src/client.ts', baseName: 'client.ts', copy: '/does/not/exist.ts' })
+
+        expect(() => processor.parse(file)).toThrow(/Could not copy file into output/)
+      })
     })
   })
 

--- a/packages/core/src/FileProcessor.ts
+++ b/packages/core/src/FileProcessor.ts
@@ -1,5 +1,4 @@
-import { readFileSync } from 'node:fs'
-import { AsyncEventEmitter } from '@internals/utils'
+import { AsyncEventEmitter, read } from '@internals/utils'
 import type { CodeNode, FileNode } from '@kubb/ast'
 import { extractStringsFromNodes } from '@kubb/ast/utils'
 import { STREAM_FLUSH_EVERY } from './constants.ts'
@@ -60,10 +59,10 @@ function joinSources(file: FileNode): string {
   return parts.join('\n\n')
 }
 
-function parseCopy(file: FileNode): string {
+async function parseCopy(file: FileNode): Promise<string> {
   let content: string
   try {
-    content = readFileSync(file.copy as string, 'utf-8')
+    content = await read(file.copy as string)
   } catch (err) {
     throw new Error(`[kubb] Could not copy file into output: ${file.copy}`, { cause: err })
   }
@@ -109,7 +108,7 @@ export class FileProcessor {
     return this.#pending.size
   }
 
-  parse(file: FileNode): string {
+  async parse(file: FileNode): Promise<string> {
     if (file.copy) {
       return parseCopy(file)
     }
@@ -130,13 +129,13 @@ export class FileProcessor {
     return parser.parse(file, { extname: parseExtName })
   }
 
-  *stream(files: ReadonlyArray<FileNode>): Generator<ParsedFile> {
+  async *stream(files: ReadonlyArray<FileNode>): AsyncGenerator<ParsedFile> {
     const total = files.length
     if (total === 0) return
 
     let processed = 0
     for (const file of files) {
-      const source = this.parse(file)
+      const source = await this.parse(file)
       processed++
 
       yield { file, source, processed, total, percentage: (processed / total) * 100 }
@@ -146,7 +145,7 @@ export class FileProcessor {
   async run(files: Array<FileNode>): Promise<Array<FileNode>> {
     await this.hooks.emit('start', files)
 
-    for (const { file, source, processed, total, percentage } of this.stream(files)) {
+    for await (const { file, source, processed, total, percentage } of this.stream(files)) {
       await this.hooks.emit('update', { file, source, processed, percentage, total })
     }
 
@@ -205,7 +204,7 @@ export class FileProcessor {
     // Single pass: each file's write starts right after its `update` fires, so IO overlaps
     // parsing and the batch never holds every rendered source in memory at once.
     const queue: Array<Promise<void>> = []
-    for (const item of this.stream(files)) {
+    for await (const item of this.stream(files)) {
       await this.hooks.emit('update', item)
       if (item.source) {
         queue.push(storage.setItem(item.file.path, item.source))

--- a/packages/core/src/FileProcessor.ts
+++ b/packages/core/src/FileProcessor.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs'
 import { AsyncEventEmitter } from '@internals/utils'
 import type { CodeNode, FileNode } from '@kubb/ast'
 import { extractStringsFromNodes } from '@kubb/ast/utils'
@@ -59,6 +60,20 @@ function joinSources(file: FileNode): string {
   return parts.join('\n\n')
 }
 
+function parseCopy(file: FileNode): string {
+  let content: string
+  try {
+    content = readFileSync(file.copy as string, 'utf-8')
+  } catch (err) {
+    throw new Error(`[kubb] Could not copy file into output: ${file.copy}`, { cause: err })
+  }
+
+  return [file.banner, content, file.footer]
+    .filter((segment): segment is string => Boolean(segment))
+    .map((segment) => segment.trimEnd())
+    .join('\n')
+}
+
 /**
  * Turns `FileNode`s into source strings and writes them to storage.
  *
@@ -95,6 +110,10 @@ export class FileProcessor {
   }
 
   parse(file: FileNode): string {
+    if (file.copy) {
+      return parseCopy(file)
+    }
+
     const parsers = this.#parsers
     const parseExtName = this.#extension?.[file.extname] || undefined
 

--- a/packages/core/src/definePlugin.ts
+++ b/packages/core/src/definePlugin.ts
@@ -313,6 +313,9 @@ export type KubbPluginSetupContext<TFactory extends PluginFactoryOptions = Plugi
   setOptions(options: TFactory['resolvedOptions']): void
   /**
    * Inject a raw file into the build output, bypassing the generation pipeline.
+   *
+   * Pass `copy` with an absolute path to emit a real source file (a shipped template) into the
+   * generated folder verbatim, instead of building its content from `sources`.
    */
   injectFile(userFileNode: UserFileNode): void
   /**

--- a/packages/core/src/definePlugin.ts
+++ b/packages/core/src/definePlugin.ts
@@ -58,13 +58,6 @@ export type Output<_TOptions = unknown> = {
    * Pass a function to compute the footer from the file's `BannerMeta`.
    */
   footer?: string | ((meta: BannerMeta) => string)
-  /**
-   * Allows the plugin to overwrite hand-written files at the same path.
-   * Defaults to `false` to protect manual edits.
-   *
-   * @default false
-   */
-  override?: boolean
 } & ExtractRegistryKey<Kubb.PluginOptionsRegistry, 'output'>
 
 /**

--- a/packages/core/src/mocks.ts
+++ b/packages/core/src/mocks.ts
@@ -236,7 +236,7 @@ export async function matchFiles(files: Array<FileNode> | undefined, options: Ma
       continue
     }
 
-    const parsed = fileProcessor.parse(file)
+    const parsed = await fileProcessor.parse(file)
     const code = file.baseName.endsWith('.json') || !format ? parsed : await format(parsed)
 
     processed.set(file.path, code)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -192,17 +192,6 @@ export type Config<TInput = Input> = {
      * ```
      */
     defaultBanner?: 'simple' | 'full' | false
-    /**
-     * Overwrite existing files when `true`, skip files that already exist when `false`. Individual
-     * plugins can override it. Keep `false` to avoid clobbering local edits in the output folder.
-     *
-     * @example
-     * ```ts
-     * override: true   // regenerate everything, even existing files
-     * override: false  // skip files that already exist
-     * ```
-     */
-    override?: boolean
   } & ExtractRegistryKey<Kubb.ConfigOptionsRegistry, 'output'>
   /**
    * Where generated files are persisted. Defaults to `fsStorage()` (disk). Pass `memoryStorage()`

--- a/packages/renderer-jsx/src/SyncRuntime.tsx
+++ b/packages/renderer-jsx/src/SyncRuntime.tsx
@@ -242,6 +242,7 @@ function* walkFiles(element: unknown): Generator<FileNode> {
           meta: props['meta'] || {},
           footer: props['footer'],
           banner: props['banner'],
+          copy: props['copy'],
           sources,
           exports,
           imports,

--- a/packages/renderer-jsx/src/components/File.test.tsx
+++ b/packages/renderer-jsx/src/components/File.test.tsx
@@ -29,6 +29,19 @@ describe('File.Source', () => {
   })
 })
 
+describe('File copy', () => {
+  it('passes the copy path through to the file node', async () => {
+    const renderer = jsxRenderer()
+    await renderer.render(<File baseName="client.ts" path="src/gen/.kubb/client.ts" copy="/abs/templates/client.ts" />)
+
+    expect(renderer.files[0]).toMatchObject({
+      baseName: 'client.ts',
+      path: 'src/gen/.kubb/client.ts',
+      copy: '/abs/templates/client.ts',
+    })
+  })
+})
+
 describe('File.Import', () => {
   it('should register import attributes', async () => {
     const renderer = jsxRenderer()

--- a/packages/renderer-jsx/src/components/File.tsx
+++ b/packages/renderer-jsx/src/components/File.tsx
@@ -49,6 +49,13 @@ type Props<TMeta> = BaseProps & {
    */
   footer?: string | null
   /**
+   * Absolute on-disk path to copy verbatim into the output, bypassing the parser. Use to emit a
+   * real source file shipped inside a package (a template) into the generated folder. Only
+   * `banner`/`footer` are applied around the copied content; child source blocks are ignored for
+   * output but still drive barrel generation.
+   */
+  copy?: string | null
+  /**
    * Child nodes rendered as the content of this file (source blocks, imports, exports).
    */
   children?: KubbReactNode

--- a/packages/renderer-jsx/src/types.ts
+++ b/packages/renderer-jsx/src/types.ts
@@ -38,7 +38,11 @@ export type KubbFileProps = {
   children?: KubbReactNode
   baseName: string
   path: string
-  override?: boolean | null
+  /**
+   * Absolute on-disk path to copy verbatim into the output, bypassing the parser. Use to emit a
+   * real source file shipped inside a package (a template) into the generated folder.
+   */
+  copy?: string | null
   meta?: FileNode['meta'] | null
 }
 


### PR DESCRIPTION
## What

Adds a `copy` field to the file model so a plugin can emit a **real on-disk file** into the generated folder verbatim, instead of building the content from a string.

- **`@kubb/ast`** — `FileNode`/`UserFileNode` gain an optional `copy?: string` (absolute path). When set, `copy` provides the file content; any `sources` are still honored for barrel/index metadata (`name`/`isExportable`/`isIndexable`), so a copied file is barreled exactly like a rendered one.
- **`@kubb/core`** — `FileProcessor.parse` short-circuits when `copy` is set: it reads the file, applies `banner`/`footer`, and bypasses the language parser (no reformatting or import reordering). `FileManager.mergeFile` prefers the incoming `copy`.
- `injectFile` / `upsertFile` / `createFile` accept it automatically (it lives on `UserFileNode`).

## Why

Plugins such as `@kubb/plugin-client` keep hand-authored helper code as real, tested `.ts` templates and need to drop them into the user's output. Until now the only way to feed `@kubb/core` was a string, which forced build-time inlining hacks. With `copy`, a plugin points at the shipped template and Kubb copies it — works on any runtime, no bundler tricks.

## Tests

`packages/core/src/FileProcessor.test.ts` covers copying a file verbatim (parser bypassed), wrapping it with banner/footer, and the clear error when the path is missing. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EB6RkBffHTw8Tg5UVgdbHp

---
_Generated by [Claude Code](https://claude.ai/code/session_01EB6RkBffHTw8Tg5UVgdbHp)_