### PR TITLE
feat(ast): accept a binding-pattern name in createFunctionParameter

### DIFF
--- a/.changeset/ast-function-parameter-binding-name.md
+++ b/.changeset/ast-function-parameter-binding-name.md
@@ -1,0 +1,7 @@
+---
+'@kubb/ast': patch
+---
+
+Let `createFunctionParameter` accept a pre-built `ObjectBindingPatternNode` as its `name`.
+
+The `name`-form input now takes `string | ObjectBindingPatternNode`, so a destructured group that is typed from a single reference (or carries no type) can go through the factory instead of a hand-built `{ kind: 'FunctionParameter' }` literal, for example `createFunctionParameter({ name: createObjectBindingPattern({ elements: [{ name: 'path' }] }), type: "Omit<Config, 'url'>", default: '{}' })`. The `FunctionParameterNode` shape is unchanged.

--- a/packages/ast/src/nodes/function.ts
+++ b/packages/ast/src/nodes/function.ts
@@ -188,7 +188,7 @@ type FunctionParameterProperty = {
 }
 
 type FunctionParameterInput =
-  | { name: string; type?: TypeExpression; optional?: boolean; default?: string; rest?: boolean }
+  | { name: string | ObjectBindingPatternNode; type?: TypeExpression; optional?: boolean; default?: string; rest?: boolean }
   | { properties: Array<FunctionParameterProperty>; optional?: boolean; default?: string }
 
 /**
@@ -265,6 +265,12 @@ export const createObjectBindingPattern = objectBindingPatternDef.create
  * ```ts
  * createFunctionParameter({ properties: [{ name: 'id', type: 'string' }, { name: 'name', type: 'string', optional: true }], default: '{}' })
  * // → { id, name }: { id: string; name?: string } = {}
+ * ```
+ *
+ * @example Destructured group typed from a single reference
+ * ```ts
+ * createFunctionParameter({ name: createObjectBindingPattern({ elements: [{ name: 'path' }] }), type: "Omit<Config, 'url'>", default: '{}' })
+ * // → { path }: Omit<Config, 'url'> = {}
  * ```
  */
 export const createFunctionParameter = functionParameterDef.create


### PR DESCRIPTION
## What this does

Widens `createFunctionParameter`'s `name`-form input from `string` to `string | ObjectBindingPatternNode`. The `FunctionParameterNode.name` field already accepts a binding pattern, and the factory's build just spreads the input, so this is a one-line type widening with no shape change.

This lets a destructured group that's typed from a single reference (or carries no type at all) go through the factory instead of a hand-built `{ kind: 'FunctionParameter' }` literal:

```ts
createFunctionParameter({
  name: createObjectBindingPattern({ elements: [{ name: 'path' }] }),
  type: "Omit<Config, 'url'>",
  default: '{}',
})
// → { path }: Omit<Config, 'url'> = {}
```

It enables a follow-up in the plugins repo to route the remaining raw `FunctionParameter` literals (the grouped client/query params, the MCP handler signature) through the factory, which the existing `{ properties }` form can't express because it requires a per-member type.

## Verification

`pnpm build`, `pnpm typecheck` (11/11), `pnpm test` (1437), `pnpm lint`, `pnpm format`. Additive and non-breaking; changeset added as a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZWQmXCtL8i8fQZMnhqS43)_