### PR TITLE
refactor: replace plugin-client references with plugin-axios and plugin-fetch

### DIFF
--- a/.changeset/banner-per-file-context.md
+++ b/.changeset/banner-per-file-context.md
@@ -7,7 +7,7 @@ Give `output.banner`/`output.footer` per-file context so a directive like `'use 
 A `banner`/`footer` function now receives a `BannerMeta`, the document `InputMeta` extended with the file it is rendered into: `filePath`, `baseName`, `isBarrel` (an `index.ts` barrel), and `isAggregation` (a group `[dir]/[dir].ts` file). Existing `(meta) => ...` functions keep working since `BannerMeta` extends `InputMeta`.
 
 ```ts
-pluginClient({
+pluginAxios({
   output: {
     banner: (meta) => (meta.isBarrel || meta.isAggregation ? '' : "'use server'"),
   },

--- a/.changeset/init-axios-fetch-plugins.md
+++ b/.changeset/init-axios-fetch-plugins.md
@@ -1,0 +1,5 @@
+---
+'@kubb/cli': patch
+---
+
+`kubb init` now scaffolds and lists `@kubb/plugin-axios` and `@kubb/plugin-fetch` instead of the removed `@kubb/plugin-client`.

--- a/codecov.yml
+++ b/codecov.yml
@@ -49,10 +49,6 @@ component_management:
       name: '@kubb/mcp'
       paths:
         - packages/mcp/**
-    - component_id: plugin-client
-      name: '@kubb/plugin-client'
-      paths:
-        - packages/plugin-client/**
     - component_id:  plugin-cypress
       name: '@kubb/plugin-cypress'
       paths:

--- a/internals/shared/src/constants.ts
+++ b/internals/shared/src/constants.ts
@@ -18,10 +18,17 @@ export const availablePlugins: Array<PluginOption> = [
     category: 'types',
   },
   {
-    value: 'plugin-client',
-    label: 'Client (Fetch/Axios)',
-    packageName: '@kubb/plugin-client',
-    importName: 'pluginClient',
+    value: 'plugin-axios',
+    label: 'Axios Client',
+    packageName: '@kubb/plugin-axios',
+    importName: 'pluginAxios',
+    category: 'client',
+  },
+  {
+    value: 'plugin-fetch',
+    label: 'Fetch Client',
+    packageName: '@kubb/plugin-fetch',
+    importName: 'pluginFetch',
     category: 'client',
   },
   {

--- a/packages/ast/src/utils/fileMerge.test.ts
+++ b/packages/ast/src/utils/fileMerge.test.ts
@@ -296,8 +296,8 @@ describe('combineImports', () => {
   })
 
   it('keeps a default import when a used named import from the same path is retained', () => {
-    const client = createImport({ name: 'client', path: '@kubb/plugin-client/clients/axios' })
-    const types = createImport({ name: ['Client', 'RequestConfig'], path: '@kubb/plugin-client/clients/axios', isTypeOnly: true })
+    const client = createImport({ name: 'client', path: '@kubb/plugin-axios/clients/axios' })
+    const types = createImport({ name: ['Client', 'RequestConfig'], path: '@kubb/plugin-axios/clients/axios', isTypeOnly: true })
     // The merged grouped source omits the function body, so `client` is absent — but `Client` is referenced.
     const result = combineImports([client, types], [], 'Partial<RequestConfig> & { client?: Client }')
 
@@ -306,8 +306,8 @@ describe('combineImports', () => {
   })
 
   it('still drops a default import when no named import from the same path is used', () => {
-    const client = createImport({ name: 'client', path: '@kubb/plugin-client/clients/axios' })
-    const types = createImport({ name: ['Client'], path: '@kubb/plugin-client/clients/axios', isTypeOnly: true })
+    const client = createImport({ name: 'client', path: '@kubb/plugin-axios/clients/axios' })
+    const types = createImport({ name: ['Client'], path: '@kubb/plugin-axios/clients/axios', isTypeOnly: true })
     const result = combineImports([client, types], [], 'const x = 1')
 
     expect(result).toHaveLength(0)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -62,7 +62,7 @@ npx kubb init
 | `--output <path>`  | `-o`  | string  | `./src/gen`      | Output directory for generated files       |
 | `--plugins <list>` |       | string  |                  | Comma-separated list of plugins to install |
 
-Available plugin values for `--plugins`: `plugin-ts`, `plugin-client`, `plugin-react-query`, `plugin-vue-query`, `plugin-zod`, `plugin-faker`, `plugin-msw`, `plugin-cypress`, `plugin-mcp`, `plugin-redoc`.
+Available plugin values for `--plugins`: `plugin-ts`, `plugin-axios`, `plugin-fetch`, `plugin-react-query`, `plugin-vue-query`, `plugin-zod`, `plugin-faker`, `plugin-msw`, `plugin-cypress`, `plugin-mcp`, `plugin-redoc`.
 
 #### Examples
 
@@ -77,7 +77,7 @@ npx kubb init --yes
 npx kubb init --input ./openapi.yaml --output ./src/gen --plugins plugin-ts,plugin-zod
 
 # Select specific plugins only
-npx kubb init --plugins plugin-ts,plugin-client,plugin-react-query
+npx kubb init --plugins plugin-ts,plugin-axios,plugin-react-query
 ```
 
 The wizard will:

--- a/packages/cli/src/Telemetry.test.ts
+++ b/packages/cli/src/Telemetry.test.ts
@@ -58,7 +58,7 @@ describe('Telemetry.build', () => {
     const hrStart = process.hrtime()
     const plugins: Array<TelemetryPlugin> = [
       { name: 'plugin-ts', options: { output: { path: 'types' } } },
-      { name: 'plugin-client', options: { output: { path: 'clients' } } },
+      { name: 'plugin-axios', options: { output: { path: 'clients' } } },
     ]
     const event = Telemetry.build({
       command: 'generate',

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -9,7 +9,7 @@ export const command = defineCommand({
     'kubb init',
     'kubb init --yes',
     'kubb init --input ./openapi.yaml --output ./src/gen --plugins plugin-ts,plugin-zod',
-    'kubb init --plugins plugin-ts,plugin-client,plugin-react-query',
+    'kubb init --plugins plugin-ts,plugin-axios,plugin-react-query',
   ],
   options: {
     yes: {
@@ -33,7 +33,7 @@ export const command = defineCommand({
     plugins: {
       type: 'string',
       description:
-        'Comma-separated list of plugins to use (plugin-ts, plugin-client, plugin-react-query, plugin-vue-query, plugin-zod, plugin-faker, plugin-msw, plugin-cypress, plugin-mcp, plugin-redoc)',
+        'Comma-separated list of plugins to use (plugin-ts, plugin-axios, plugin-fetch, plugin-react-query, plugin-vue-query, plugin-zod, plugin-faker, plugin-msw, plugin-cypress, plugin-mcp, plugin-redoc)',
       hint: 'plugin-ts,plugin-zod,...',
     },
   },

--- a/packages/core/src/FileManager.test.ts
+++ b/packages/core/src/FileManager.test.ts
@@ -36,7 +36,7 @@ describe('FileManager', () => {
 
     it('keeps a default client import when grouped sources omit its body usage', () => {
       const manager = new FileManager()
-      const clientPath = '@kubb/plugin-client/clients/axios'
+      const clientPath = '@kubb/plugin-axios/clients/axios'
       // Source references the type imports (Client/RequestConfig) but not the lowercase `client`
       // binding — mirroring grouped output where the function body that uses `client` is omitted.
       const make = (op: string) =>

--- a/packages/core/src/definePlugin.test.ts
+++ b/packages/core/src/definePlugin.test.ts
@@ -548,7 +548,7 @@ describe('normalizeOutput', () => {
   })
 
   it('passes through directory mode when a group is configured', () => {
-    const result = normalizeOutput({ output: { path: 'clients', mode: 'directory' }, group: { type: 'tag' }, pluginName: 'plugin-client' })
+    const result = normalizeOutput({ output: { path: 'clients', mode: 'directory' }, group: { type: 'tag' }, pluginName: 'plugin-axios' })
 
     expect(result).toStrictEqual({ path: 'clients', mode: 'directory' })
   })

--- a/packages/kubb/README.md
+++ b/packages/kubb/README.md
@@ -57,7 +57,7 @@ See the [documentation](https://kubb.dev) for detailed usage and advanced featur
 
 - Generate from a schema: Kubb produces TypeScript types, type-safe API clients, [TanStack Query](https://github.com/TanStack/query) hooks for React and Vue, [SWR](https://github.com/vercel/swr) hooks, [Zod](https://github.com/colinhacks/zod) validators, [Faker](https://github.com/faker-js/faker) mocks, and [MSW](https://github.com/mswjs/msw) handlers.
 - Plug in input formats through adapters like [`@kubb/adapter-oas`](https://npmx.dev/package/@kubb/adapter-oas), with TypeScript-first output that runs on Node.js and Bun.
-- Pick what you generate from the [plugin ecosystem](https://github.com/kubb-labs/plugins): `plugin-ts`, `plugin-client`, `plugin-react-query`, `plugin-vue-query`, `plugin-swr`, `plugin-zod`, `plugin-faker`, `plugin-msw`, `plugin-cypress`, `plugin-redoc`, and `plugin-mcp`. Enable only the ones a project needs.
+- Pick what you generate from the [plugin ecosystem](https://github.com/kubb-labs/plugins): `plugin-ts`, `plugin-axios`, `plugin-fetch`, `plugin-react-query`, `plugin-vue-query`, `plugin-swr`, `plugin-zod`, `plugin-faker`, `plugin-msw`, `plugin-cypress`, `plugin-redoc`, and `plugin-mcp`. Enable only the ones a project needs.
 - Choose your HTTP client: use the axios or fetch presets, or point at a custom client module so generated requests run through your own wrapper.
 - Control the generated tree: group files by tag, emit barrel exports, and include or exclude operations to keep the output focused.
 - Build your own output with custom plugins, adapters, and the JSX-based renderer (`@kubb/renderer-jsx`) for full control over what lands on disk.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -157,7 +157,7 @@ Example `kubb.config.ts`:
 import { defineConfig } from 'kubb'
 import { pluginOas } from '@kubb/plugin-oas'
 import { pluginTs } from '@kubb/plugin-ts'
-import { pluginClient } from '@kubb/plugin-client'
+import { pluginAxios } from '@kubb/plugin-axios'
 
 export default defineConfig({
   input: {
@@ -166,7 +166,7 @@ export default defineConfig({
   output: {
     path: './src/generated',
   },
-  plugins: [pluginOas(), pluginTs(), pluginClient()],
+  plugins: [pluginOas(), pluginTs(), pluginAxios()],
 })
 ```
 

--- a/packages/parser-ts/src/utils.test.ts
+++ b/packages/parser-ts/src/utils.test.ts
@@ -635,8 +635,8 @@ describe('printImport', () => {
   })
 
   it('renders a default import', () => {
-    expect(printImport({ name: 'client', path: '@kubb/plugin-client/clients/axios' })).toMatchInlineSnapshot(
-      `"import client from '@kubb/plugin-client/clients/axios'"`,
+    expect(printImport({ name: 'client', path: '@kubb/plugin-axios/clients/axios' })).toMatchInlineSnapshot(
+      `"import client from '@kubb/plugin-axios/clients/axios'"`,
     )
   })
 

--- a/tools/claude/agents/kubb-expert.md
+++ b/tools/claude/agents/kubb-expert.md
@@ -18,7 +18,7 @@ Approach:
    `kubb validate --input <spec>` before doing anything destructive.
 2. Decide which `@kubb/plugin-*` packages match what the user wants generated. Keep `plugin-ts`
    as the base, since the client, framework and MSW plugins need it. Add a client or framework
-   plugin for data fetching (the framework plugins also pull in `plugin-client`), `plugin-zod` for
+   plugin for data fetching (the framework plugins also pull in a client plugin like `plugin-axios` or `plugin-fetch`), `plugin-zod` for
    runtime validation, and `plugin-faker` with `plugin-msw` for tests (MSW needs faker). Check the
    plugin's docs page on kubb.dev for the full dependency list. There is no `pluginOas`, since the
    OpenAPI adapter is applied automatically.

--- a/tools/claude/commands/init.md
+++ b/tools/claude/commands/init.md
@@ -10,7 +10,7 @@ comma-separated plugin list (`--plugins`). Read the `config` skill before choosi
 Parsed from **$ARGUMENTS** (ask only for what is missing):
 
 1. Choose plugins. Map the requested outputs to `@kubb/plugin-*` packages with the `config`
-   skill. Valid values: `plugin-ts`, `plugin-client`, `plugin-react-query`, `plugin-vue-query`,
+   skill. Valid values: `plugin-ts`, `plugin-axios`, `plugin-fetch`, `plugin-react-query`, `plugin-vue-query`,
    `plugin-zod`, `plugin-faker`, `plugin-msw`, `plugin-cypress`, `plugin-mcp`, `plugin-redoc`.
    Default to `plugin-ts` when the user is unsure.
 2. Run init with `--yes` and the chosen values so it never prompts:

--- a/tools/claude/skills/config/SKILL.md
+++ b/tools/claude/skills/config/SKILL.md
@@ -27,7 +27,7 @@ build powers the bundled MCP server.
 ```ts
 import { defineConfig } from 'kubb'
 import { pluginTs } from '@kubb/plugin-ts'
-import { pluginClient } from '@kubb/plugin-client'
+import { pluginAxios } from '@kubb/plugin-axios'
 
 export default defineConfig({
   root: '.',
@@ -41,7 +41,7 @@ export default defineConfig({
   },
   plugins: [
     pluginTs({ output: { path: 'models' } }),
-    pluginClient({ output: { path: 'clients' } }),
+    pluginAxios({ output: { path: 'clients' } }),
   ],
 })
 ```
@@ -51,8 +51,8 @@ Rules that matter:
 - Set adapter options only when you need them, through a top-level
   `adapter: adapterOas({ ... })` from `@kubb/adapter-oas` (for `validate`, `serverIndex`,
   `serverVariables`, `discriminator` or `contentType`).
-- `pluginTs` is the base. `pluginClient` needs it, the framework plugins (`pluginReactQuery`,
-  `pluginVueQuery`, `pluginSwr`) need `pluginTs` and `pluginClient`, and `pluginMsw` needs
+- `pluginTs` is the base. The client plugins (`pluginAxios`, `pluginFetch`) need it, the framework plugins (`pluginReactQuery`,
+  `pluginVueQuery`, `pluginSwr`) need `pluginTs` and a client plugin, and `pluginMsw` needs
   `pluginTs` and `pluginFaker`. Check the plugin's docs page on kubb.dev
   (`https://kubb.dev/plugins/plugin-<name>`) for the full dependency list.
 - Each generator plugin takes its own `output.path`, resolved relative to the top-level
@@ -71,7 +71,8 @@ Pick plugins by what the consumer needs, then install `kubb` plus each package.
 | Need | Package | Import |
 | --- | --- | --- |
 | TypeScript types (recommended base) | `@kubb/plugin-ts` | `pluginTs` |
-| Fetch/Axios client | `@kubb/plugin-client` | `pluginClient` |
+| Axios client | `@kubb/plugin-axios` | `pluginAxios` |
+| Fetch client | `@kubb/plugin-fetch` | `pluginFetch` |
 | TanStack React Query hooks | `@kubb/plugin-react-query` | `pluginReactQuery` |
 | Vue Query hooks | `@kubb/plugin-vue-query` | `pluginVueQuery` |
 | SWR hooks | `@kubb/plugin-swr` | `pluginSwr` |
@@ -91,7 +92,7 @@ truth instead of guessing an option name.
 Common combinations:
 
 - Types only: `pluginTs()`.
-- Typed data fetching: add `pluginClient()`, or a framework plugin (`pluginReactQuery`,
+- Typed data fetching: add `pluginAxios()` or `pluginFetch()`, or a framework plugin (`pluginReactQuery`,
   `pluginVueQuery` or `pluginSwr`) which pulls in client generation.
 - Runtime validation: add `pluginZod()` and point the client at it for typed, validated responses.
 - Testing and mocks: add `pluginFaker()` and `pluginMsw()`.


### PR DESCRIPTION
`@kubb/plugin-client` has been removed from the kubb ecosystem (see kubb-labs/plugins#478) in favor of the dedicated `@kubb/plugin-axios` and `@kubb/plugin-fetch` packages. This updates the references in the core/CLI repo.

## Changes
- `internals/shared/src/constants.ts`: list `plugin-axios` and `plugin-fetch` (category `client`) instead of `plugin-client`, so `kubb init --plugins` and config scaffolding offer the new packages.
- `packages/cli/src/commands/init.ts` and the CLI / kubb / mcp READMEs: use `pluginAxios` in examples and plugin lists.
- Claude tooling (`tools/claude/commands/init.md`, `agents/kubb-expert.md`, `skills/config/SKILL.md`): document the axios/fetch client plugins.
- `codecov.yml`: drop the stale `plugin-client` component (the package lives in kubb-labs/plugins).
- Unit-test fixtures (`core`, `cli`, `parser-ts`, `ast`): use `'plugin-axios'` as the example plugin name.

## Validation
- Unit tests for the touched packages pass (636 tests).
- Edited packages typecheck cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kktvb7J3bF6x7Znx8ZmsvT)_