### PR TITLE
fix(adapter-oas): close tuples when prefixItems has items: false

### DIFF
--- a/.changeset/fix-tuple-items-false-closed.md
+++ b/.changeset/fix-tuple-items-false-closed.md
@@ -1,0 +1,7 @@
+---
+'@kubb/adapter-oas': patch
+---
+
+Close tuples when `prefixItems` is paired with `items: false`.
+
+A `prefixItems` schema with `items: false` is the canonical closed-tuple pattern in JSON Schema 2020-12 / OpenAPI 3.1: the prefix defines the positions and `items: false` forbids any extra elements. The boolean was being read as a falsy rest schema, so the tuple gained a stray `...any[]` tail (`[number, number, ...any[]]`) that both allowed extra elements and widened them to `any`. The rest element is now omitted, producing a closed `[number, number]`. An absent `items` still widens the tail to `any`, and `items: true` keeps the unconstrained rest.

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -1906,6 +1906,25 @@ describe('parseSchema prefixItems (tuple)', () => {
     expect(narrowed?.rest?.type).toBe('any')
   })
 
+  it('omits rest when items is false — closed tuple', () => {
+    const node = parseSchema(ctx, {
+      schema: { prefixItems: [{ type: 'number' }, { type: 'number' }], items: false },
+    })
+    const narrowed = ast.narrowSchema(node, 'tuple')
+
+    expect(narrowed?.items).toHaveLength(2)
+    expect(narrowed?.rest).toBeUndefined()
+  })
+
+  it('defaults rest to any when items is true', () => {
+    const node = parseSchema(ctx, {
+      schema: { prefixItems: [{ type: 'string' }], items: true },
+    })
+    const narrowed = ast.narrowSchema(node, 'tuple')
+
+    expect(narrowed?.rest?.type).toBe('any')
+  })
+
   it('converts a $ref prefixItem to a ref node', () => {
     const node = parseSchema(ctx, {
       schema: {

--- a/packages/adapter-oas/src/parser.ts
+++ b/packages/adapter-oas/src/parser.ts
@@ -666,11 +666,23 @@ export function createSchemaParser(ctx: OasParserContext, dialect: OasDialect = 
   }
 
   /**
+   * Resolves a tuple's rest-element schema from the `items` keyword that sits alongside `prefixItems`.
+   *
+   * `items: false` closes the tuple, so no rest element is emitted. An absent `items` widens the tail
+   * to `any`, and a schema object (or `items: true`) becomes the homogeneous rest type.
+   */
+  function resolveTupleRest(items: SchemaObject['items'], rawOptions: Partial<ast.ParserOptions> | undefined): ast.SchemaNode | undefined {
+    if (items === false) return undefined
+    if (!items || items === true) return ast.factory.createSchema({ type: 'any' })
+    return parseSchema({ schema: items as SchemaObject }, rawOptions)
+  }
+
+  /**
    * Converts an OAS 3.1 `prefixItems` tuple into a `TupleSchemaNode`.
    */
   function convertTuple({ schema, name, nullable, defaultValue, rawOptions }: SchemaContext): ast.SchemaNode {
     const tupleItems = (schema.prefixItems ?? []).map((item) => parseSchema({ schema: item as SchemaObject }, rawOptions))
-    const rest = schema.items ? parseSchema({ schema: schema.items as SchemaObject }, rawOptions) : ast.factory.createSchema({ type: 'any' })
+    const rest = resolveTupleRest(schema.items, rawOptions)
 
     return ast.factory.createSchema({
       type: 'tuple',

--- a/packages/adapter-oas/src/types.ts
+++ b/packages/adapter-oas/src/types.ts
@@ -64,8 +64,11 @@ export type SchemaObject = {
   patternProperties?: Record<string, SchemaObject | boolean>
   /**
    * Single-schema form of `items`. Narrowed from the base type to take precedence over the tuple overload.
+   *
+   * Alongside `prefixItems`, the JSON Schema boolean form applies: `items: false` closes the tuple
+   * (no extra elements allowed), while `items: true` is equivalent to an unconstrained rest.
    */
-  items?: SchemaObject | ReferenceObject
+  items?: SchemaObject | ReferenceObject | boolean
   /**
    * Allowed values for this schema.
    */


### PR DESCRIPTION
## Summary

Fixes #3649 for the v5 line.

A `prefixItems` schema paired with `items: false` is the canonical **closed-tuple** pattern in JSON Schema 2020-12 / OpenAPI 3.1 — the prefix defines the positions and `items: false` forbids any extra elements. `convertTuple` in `packages/adapter-oas/src/parser.ts` read `items` with a truthy check, so the boolean `false` fell through to the `{ type: 'any' }` fallback and the tuple gained a stray `...any[]` tail:

```ts
// before
export type Coords = [number, number, ...any[]]
// after
export type Coords = [number, number]
```

That tail was wrong twice over: it allowed extra elements `items: false` forbids, and it widened them to `any`.

## Changes

- `parser.ts`: extract a `resolveTupleRest` helper that distinguishes the three cases — `items: false` → no rest (closed tuple), `items` absent → `any` rest (unchanged), `items` schema (or `items: true`) → homogeneous rest.
- `types.ts`: broaden `SchemaObject['items']` to include `boolean`, reflecting the valid JSON Schema boolean form.
- Added parser tests for `items: false` (closed) and `items: true` (open `any` rest).

The renderer in `kubb-labs/plugins` (`buildTupleNode`) already omits the rest element when `node.rest` is undefined, so no plugins-repo change is needed.

A companion PR targets the `v4` branch (`@kubb/plugin-oas`).

## Test plan

- [x] `pnpm --filter @kubb/adapter-oas test parser` — 344 passed
- [x] `pnpm --filter @kubb/adapter-oas typecheck` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8aa7MFjUHiC18SJHSLj53)_