### PR TITLE
fix(plugin-oas): close tuples when prefixItems has items: false

### DIFF
--- a/.changeset/fix-tuple-items-false-closed.md
+++ b/.changeset/fix-tuple-items-false-closed.md
@@ -1,0 +1,7 @@
+---
+'@kubb/plugin-oas': patch
+---
+
+Close tuples when `prefixItems` is paired with `items: false`.
+
+A `prefixItems` schema with `items: false` is the canonical closed-tuple pattern in JSON Schema 2020-12 / OpenAPI 3.1: the prefix defines the positions and `items: false` forbids any extra elements. The boolean was being parsed as a rest schema, so the tuple gained a stray `...any[]` tail (`[number, number, ...any[]]`) that both allowed extra elements and widened them to `any`. The rest element is now omitted, producing a closed `[number, number]`.

--- a/packages/plugin-oas/src/SchemaGenerator.test.ts
+++ b/packages/plugin-oas/src/SchemaGenerator.test.ts
@@ -452,4 +452,45 @@ describe('SchemaGenerator core', async () => {
     // The items should resolve to an inline object schema
     expect(tree).toMatchSnapshot()
   })
+
+  test('prefixItems with items: false produces a closed tuple without a rest element', async () => {
+    const oas = await parse(path.resolve(__dirname, '../mocks/petStore.yaml'))
+
+    const closedTuple = {
+      type: 'array',
+      prefixItems: [{ type: 'number' }, { type: 'number' }],
+      items: false,
+    } as unknown as SchemaObject
+
+    const options: GetSchemaGeneratorOptions<SchemaGenerator> = {
+      emptySchemaType: 'unknown',
+      dateType: 'date',
+      transformers: {},
+      unknownType: 'unknown',
+    }
+    const plugin = { options } as Plugin<any>
+
+    const generator = new SchemaGenerator(options, {
+      fabric,
+      oas,
+      include: undefined,
+      pluginManager: mockedPluginManager,
+      plugin,
+      contentType: undefined,
+      override: undefined,
+      mode: 'split',
+    })
+
+    const tree = generator.parse({
+      schema: closedTuple,
+      name: 'Coords',
+      parentName: null,
+    })
+
+    const tuple = tree.find((item) => item.keyword === schemaKeywords.tuple) as Extract<(typeof tree)[number], { keyword: typeof schemaKeywords.tuple }>
+
+    expect(tuple).toBeDefined()
+    expect(tuple.args.items).toHaveLength(2)
+    expect(tuple.args.rest).toBeUndefined()
+  })
 })

--- a/packages/plugin-oas/src/SchemaGenerator.ts
+++ b/packages/plugin-oas/src/SchemaGenerator.ts
@@ -1090,6 +1090,17 @@ export class SchemaGenerator<
       const min = schemaObject.minimum ?? schemaObject.minLength ?? schemaObject.minItems ?? undefined
       const max = schemaObject.maximum ?? schemaObject.maxLength ?? schemaObject.maxItems ?? undefined
 
+      // `items: false` closes the tuple — JSON Schema forbids extra elements, so emit no rest.
+      const isClosedTuple = 'items' in schemaObject && (schemaObject.items as unknown) === false
+      const rest = isClosedTuple
+        ? undefined
+        : this.parse({
+            schema: items,
+            name,
+            parentName,
+            rootName,
+          })[0]
+
       return [
         {
           keyword: schemaKeywords.tuple,
@@ -1101,12 +1112,7 @@ export class SchemaGenerator<
                 return this.parse({ schema: item, name, parentName, rootName })[0]
               })
               .filter((x): x is Schema => Boolean(x)),
-            rest: this.parse({
-              schema: items,
-              name,
-              parentName,
-              rootName,
-            })[0],
+            rest,
           },
         },
         ...baseItems.filter((item) => item.keyword !== schemaKeywords.min && item.keyword !== schemaKeywords.max),


### PR DESCRIPTION
## Summary

Fixes #3649 for the v4 line.

A `prefixItems` schema paired with `items: false` is the canonical **closed-tuple** pattern in JSON Schema 2020-12 / OpenAPI 3.1 — the prefix defines the positions and `items: false` forbids any extra elements. The `prefixItems` branch in `packages/plugin-oas/src/SchemaGenerator.ts` parsed `items` straight into the tuple's `rest`, so the boolean `false` produced a stray `...any[]` tail:

```ts
// before
export type Coords = [number, number, ...any[]]
// after
export type Coords = [number, number]
```

That tail was wrong twice over: it allowed extra elements `items: false` forbids, and it widened them to `any`.

## Changes

- `SchemaGenerator.ts`: when `items === false`, emit `rest: undefined` so no rest element is generated. An absent `items` keeps its current behavior; a homogeneous `items` schema still maps to the rest.
- Added a `SchemaGenerator` test asserting the tuple has two items and no rest for `items: false`.

The `plugin-ts` tuple renderer already omits the rest element when `args.rest` is undefined, so no renderer change is needed.

This is the v4 counterpart to #3651 (which targets `main` / `@kubb/adapter-oas`).

## Test plan

- [x] `pnpm --filter @kubb/plugin-oas test SchemaGenerator` — 15 passed
- [x] `pnpm --filter @kubb/plugin-oas typecheck` — clean
- [x] `pnpm --filter @kubb/plugin-oas lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8aa7MFjUHiC18SJHSLj53)_