### PR TITLE
docs(changeset): forbid @internals packages in changeset frontmatter

### DIFF
--- a/.claude/commands/changeset.md
+++ b/.claude/commands/changeset.md
@@ -12,6 +12,10 @@ Create a Changeset for the changes above.
    `minor` for backwards-compatible features, `major` for breaking changes.
 3. Add a markdown file under `.changeset/` with the correct frontmatter and a concise,
    user-facing summary of what changed and why.
+4. Never list `@internals/*` packages in the frontmatter. They are private and excluded from
+   releases by the changeset `ignore` config, so a changeset that bumps one fails
+   `changeset version`. Reference them in the summary text when relevant, but do not give them a
+   `patch`, `minor`, or `major` bump.
 
 For wording and release-note conventions, follow the `changelog` skill. For the surrounding
 PR checklist, follow the `pr` skill.


### PR DESCRIPTION
## What

Codify the rule that `@internals/*` packages must never appear in changeset frontmatter with a `patch`, `minor`, or `major` bump.

## Why

`@internals/*` packages are private and already excluded from releases via the changeset `ignore` config (`.changeset/config.json`). Listing one in a changeset makes `changeset version` fail. The `/changeset` command didn't state this, so an agent could add an internals bump by accident.

## Changes

- `.claude/commands/changeset.md`: add a step instructing to never give `@internals/*` a version bump, while still allowing them to be referenced in the summary text.

I also audited every existing changeset in the repo: none bump an `@internals/*` package, so there was nothing to remove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPM57W7aNjGvNhbQQLTKGC)_