### PR TITLE
test(unplugin-kubb): cover rolldown subpackage and nuxt plugin registration

### DIFF
--- a/internals/shared/src/loader.ts
+++ b/internals/shared/src/loader.ts
@@ -37,7 +37,7 @@ export type ModuleLoader = {
  * ```
  */
 export function createModuleLoader(): ModuleLoader {
-  const jiti= createJiti(import.meta.url, JITI_OPTIONS)
+  const jiti = createJiti(import.meta.url, JITI_OPTIONS)
 
   return {
     load<T>(filePath: string, options?: LoadModuleOptions) {

--- a/packages/unplugin-kubb/src/unpluginFactory.test.ts
+++ b/packages/unplugin-kubb/src/unpluginFactory.test.ts
@@ -1,12 +1,21 @@
 import path from 'node:path'
+import * as kit from '@nuxt/kit'
 import { createMockedAdapter } from '@kubb/core/mocks'
 import { ast, definePlugin, type Storage, type UserConfig } from '@kubb/core'
 import { describe, expect, test, vi } from 'vitest'
 import type { UnpluginBuildContext } from 'unplugin'
 import nuxtModule from './nuxt.ts'
+import rolldown from './rolldown.ts'
 import { unpluginFactory } from './unpluginFactory.ts'
 import vite from './vite.ts'
 import webpack from './webpack.ts'
+
+// @nuxt/kit re-exports addVitePlugin and addWebpackPlugin as non-configurable ESM
+// bindings, so they cannot be spied per test. Mock just those two and keep the rest real.
+vi.mock('@nuxt/kit', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@nuxt/kit')>()
+  return { ...actual, addVitePlugin: vi.fn(), addWebpackPlugin: vi.fn() }
+})
 
 type KubbUnpluginOptions = ReturnType<typeof unpluginFactory>
 
@@ -67,9 +76,10 @@ function createMemoryStorage() {
 }
 
 describe('unpluginFactory', () => {
-  test('creates vite and webpack subpackage plugins', () => {
+  test('creates vite, webpack, and rolldown subpackage plugins', () => {
     expect(vite({ config: { output: { path: './gen' } } })).toMatchObject({ name: 'unplugin-kubb' })
     expect(webpack({ config: { output: { path: './gen' } } })).toBeDefined()
+    expect(rolldown({ config: { output: { path: './gen' } } })).toMatchObject({ name: 'unplugin-kubb' })
   })
 
   test('creates a nuxt module that registers vite and webpack integrations', async () => {
@@ -77,6 +87,25 @@ describe('unpluginFactory', () => {
       name: 'nuxt-unplugin-kubb',
       configKey: 'unpluginKubb',
     })
+
+    const addVite = vi.mocked(kit.addVitePlugin)
+    const addWebpack = vi.mocked(kit.addWebpackPlugin)
+    addVite.mockClear()
+    addWebpack.mockClear()
+
+    const fakeNuxt = {
+      options: { _modules: [], build: { transpile: [] }, modules: [] },
+      hook: vi.fn(),
+      callHook: vi.fn(),
+      hooks: { hook: vi.fn(), callHook: vi.fn() },
+    }
+    await (nuxtModule as unknown as (options: unknown, nuxt: unknown) => Promise<void>)({ config: { output: { path: './gen' } } }, fakeNuxt)
+
+    expect(addVite).toHaveBeenCalledTimes(1)
+    expect(addWebpack).toHaveBeenCalledTimes(1)
+
+    const registerVitePlugin = addVite.mock.calls.at(0)?.at(0) as () => { name: string }
+    expect(registerVitePlugin()).toMatchObject({ name: 'unplugin-kubb' })
   })
 
   test('uses the same generation defaults as defineConfig', async () => {


### PR DESCRIPTION
## What

Validated that `unplugin-kubb` works across Vite, Webpack, Rolldown, and Nuxt, and added the test coverage that was missing for two of those paths.

The factory (`unpluginFactory`) is shared by every bundler wrapper, so its generation logic was already exercised. The gaps were the **rolldown** entry point and whether the **nuxt** module actually registers working integrations (the old test only checked its meta).

## Validation performed

Drove each real bundler against a Kubb config that injects a known file and confirmed it lands on disk:

| Bundler  | Result |
| -------- | ------ |
| Vite     | generates files during `build` |
| Rollup   | generates files |
| Rolldown | generates files (hooks fire on `generate`/`write`) |
| Webpack  | generates files |
| esbuild  | generates files |
| Nuxt     | registers a working vite plugin and webpack plugin |

## Changes

Test-only. No runtime or published-output change (tests are excluded from the package `files`), so no changeset.

- Assert the `rolldown` subpackage builds a plugin, alongside the existing vite/webpack check
- Drive the nuxt module's `setup` and assert it calls `addVitePlugin` and `addWebpackPlugin`, and that the registered vite factory returns a real `unplugin-kubb` plugin

## Note

Under Vite the plugin applies only during `build` (`apply: 'build'`, as documented in the factory JSDoc). That also means it runs on `nuxt build` but not `nuxt dev`. This is the intended design, called out here for visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VMngmUutKZ9Prguf9mj86V)_