### PR TITLE
feat(core): let addGenerator register multiple generators in one call

### DIFF
--- a/.changeset/add-generator-array-to-add-generator.md
+++ b/.changeset/add-generator-array-to-add-generator.md
@@ -1,0 +1,5 @@
+---
+'@kubb/core': minor
+---
+
+Let `ctx.addGenerator` register several generators in one call. Pass them as separate arguments (`ctx.addGenerator(schemaGenerator, operationGenerator)`) or hand it an existing list (`ctx.addGenerator(selectedGenerators)`), and the arrays are flattened for you. A single generator still works as before, so there is no need to loop over each one.

--- a/internals/shared/src/loader.ts
+++ b/internals/shared/src/loader.ts
@@ -37,7 +37,7 @@ export type ModuleLoader = {
  * ```
  */
 export function createModuleLoader(): ModuleLoader {
-  const jiti= createJiti(import.meta.url, JITI_OPTIONS)
+  const jiti = createJiti(import.meta.url, JITI_OPTIONS)
 
   return {
     load<T>(filePath: string, options?: LoadModuleOptions) {

--- a/packages/core/src/KubbDriver.ts
+++ b/packages/core/src/KubbDriver.ts
@@ -213,8 +213,10 @@ export class KubbDriver {
         const pluginCtx: KubbPluginSetupContext = {
           ...globalCtx,
           options: plugin.options ?? {},
-          addGenerator: (gen) => {
-            this.registerGenerator(plugin.name, gen)
+          addGenerator: (...generators) => {
+            for (const generator of generators.flat()) {
+              this.registerGenerator(plugin.name, generator)
+            }
           },
           setResolver: (resolver) => {
             this.setPluginResolver(plugin.name, resolver)

--- a/packages/core/src/definePlugin.test.ts
+++ b/packages/core/src/definePlugin.test.ts
@@ -171,6 +171,58 @@ describe('PluginDriver — hook-style plugin registration', () => {
     expect(driver.plugins.get('hook-plugin')?.generators ?? []).toHaveLength(0)
   })
 
+  it('addGenerator() registers every generator passed as separate arguments', async () => {
+    const hookPlugin = definePlugin(() => ({
+      name: 'hook-plugin',
+      hooks: {
+        'kubb:plugin:setup'(ctx) {
+          ctx.addGenerator(
+            { name: 'gen-schema', schema: vi.fn() },
+            { name: 'gen-operation', operation: vi.fn() },
+            { name: 'gen-operations', operations: vi.fn() },
+          )
+        },
+      },
+    }))()
+
+    const hooks = new AsyncEventEmitter<KubbHooks>()
+    const driver = new KubbDriver(makeConfig([hookPlugin]), { hooks })
+    await driver.setup()
+
+    await driver.emitSetupHooks()
+
+    expect(driver.hasEventGenerators('hook-plugin')).toBe(true)
+    // Each generator wires up the listener for the hook it implements.
+    expect(hooks.listenerCount('kubb:generate:schema')).toBe(1)
+    expect(hooks.listenerCount('kubb:generate:operation')).toBe(1)
+    expect(hooks.listenerCount('kubb:generate:operations')).toBe(1)
+  })
+
+  it('addGenerator() flattens arrays so an existing list can be passed directly', async () => {
+    const generators = [
+      { name: 'gen-schema', schema: vi.fn() },
+      { name: 'gen-operation', operation: vi.fn() },
+    ]
+    const hookPlugin = definePlugin(() => ({
+      name: 'hook-plugin',
+      hooks: {
+        'kubb:plugin:setup'(ctx) {
+          ctx.addGenerator(generators)
+        },
+      },
+    }))()
+
+    const hooks = new AsyncEventEmitter<KubbHooks>()
+    const driver = new KubbDriver(makeConfig([hookPlugin]), { hooks })
+    await driver.setup()
+
+    await driver.emitSetupHooks()
+
+    expect(driver.hasEventGenerators('hook-plugin')).toBe(true)
+    expect(hooks.listenerCount('kubb:generate:schema')).toBe(1)
+    expect(hooks.listenerCount('kubb:generate:operation')).toBe(1)
+  })
+
   it('options passed to definePlugin are forwarded via ctx.options', async () => {
     const capturedOptions: Array<unknown> = []
     const hookPlugin = definePlugin<TestPluginOptions>((options) => ({

--- a/packages/core/src/definePlugin.ts
+++ b/packages/core/src/definePlugin.ts
@@ -281,10 +281,20 @@ export type PluginFactoryOptions<
  */
 export type KubbPluginSetupContext<TFactory extends PluginFactoryOptions = PluginFactoryOptions> = {
   /**
-   * Register a generator dynamically. Generators fire during the AST walk (schema/operation/operations)
-   * just like generators declared statically on `createPlugin`.
+   * Register one or more generators dynamically. Generators fire during the AST walk
+   * (schema/operation/operations) just like generators declared statically on `createPlugin`.
+   *
+   * Pass generators as separate arguments or as arrays. Arrays are flattened, so spreading an
+   * existing list is optional.
+   *
+   * @example
+   * ```ts
+   * ctx.addGenerator(myGenerator)
+   * ctx.addGenerator(schemaGenerator, operationGenerator)
+   * ctx.addGenerator(selectedGenerators)
+   * ```
    */
-  addGenerator<TElement = unknown>(generator: Generator<TFactory, TElement>): void
+  addGenerator<TElement = unknown>(...generators: Array<Generator<TFactory, TElement> | Array<Generator<TFactory, TElement>>>): void
   /**
    * Set or override the resolver for this plugin.
    * The resolver controls file naming and path resolution.


### PR DESCRIPTION
## Summary

`ctx.addGenerator` (the `kubb:plugin:setup` context method) now registers more than one generator per call, so a plugin no longer needs to loop:

```ts
// Before
for (const gen of selectedGenerators) {
  ctx.addGenerator(gen)
}

// After — any of these work
ctx.addGenerator(schemaGenerator, operationGenerator)
ctx.addGenerator(selectedGenerators)
ctx.addGenerator(...selectedGenerators)
```

The method takes rest parameters where each argument is a generator or an array of generators, and the arrays are flattened before registration. A single-generator call (`ctx.addGenerator(gen)`) keeps working exactly as before, so this is backward compatible.

## Changes

- `KubbPluginSetupContext.addGenerator` signature updated to `(...generators: Array<Generator | Array<Generator>>) => void` with updated JSDoc and examples.
- `KubbDriver` flattens the arguments and registers each generator.
- Added tests covering the separate-arguments path and the array-flattening path.
- Added a `minor` changeset for `@kubb/core`.

Docs for the new signature are in a companion PR on `kubb-labs/docs`.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (215 passing in `@kubb/core`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oJGyEx9pkcd8guDidb473

---
_Generated by [Claude Code](https://claude.ai/code/session_018oJGyEx9pkcd8guDidb473)_