### PR TITLE
fix(plugin-zod): wrap nullable allOf members instead of intersecting them

### DIFF
--- a/.changeset/fix-zod-nullable-allof.md
+++ b/.changeset/fix-zod-nullable-allof.md
@@ -1,0 +1,7 @@
+---
+'@kubb/plugin-zod': patch
+---
+
+Fix invalid Zod output when a nullable schema sits inside an `allOf`.
+
+A nullable member of an `allOf` was treated as an intersection member, so its `nullable` keyword leaked into the `.and()` chain and produced invalid syntax like `z.lazy(() => nullableStringSchema).and(.nullable())`. Modifier keywords (`nullable`, `nullish`, `optional`, `default`, `describe`) are now lifted out of the intersection and wrap the whole schema instead, emitting `z.lazy(() => nullableStringSchema).nullable()`.

--- a/packages/plugin-zod/mocks/nullableAllOf.yaml
+++ b/packages/plugin-zod/mocks/nullableAllOf.yaml
@@ -1,0 +1,33 @@
+openapi: 3.0.3
+info:
+  title: Minimal API
+  version: 1.0.0
+paths:
+  /health:
+    get:
+      operationId: getHealth
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/NullableString'
+components:
+  schemas:
+    NullableString:
+      type: string
+      nullable: true
+    NullableAllOf:
+      allOf:
+        - $ref: '#/components/schemas/NullableString'
+    NullableAllOfMulti:
+      allOf:
+        - $ref: '#/components/schemas/Base'
+        - $ref: '#/components/schemas/NullableString'
+    Base:
+      type: object
+      properties:
+        id:
+          type: string

--- a/packages/plugin-zod/src/generators/nullableAllOf.test.tsx
+++ b/packages/plugin-zod/src/generators/nullableAllOf.test.tsx
@@ -1,0 +1,94 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { Config, Plugin } from '@kubb/core'
+import type { SchemaObject } from '@kubb/oas'
+import { parse } from '@kubb/oas'
+import { buildSchema, SchemaGenerator } from '@kubb/plugin-oas'
+import { getSchemas } from '@kubb/plugin-oas/utils'
+import { createReactFabric } from '@kubb/react-fabric'
+import { describe, expect, test } from 'vitest'
+import { createMockedPluginManager } from '#mocks'
+import type { PluginZod } from '../types.ts'
+import { zodGenerator } from './zodGenerator.tsx'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+async function generate(name: string, mini: boolean): Promise<string> {
+  const fabric = createReactFabric()
+  const oas = await parse(path.resolve(__dirname, '../../mocks/nullableAllOf.yaml'))
+
+  const options: PluginZod['resolvedOptions'] = {
+    dateType: 'date',
+    transformers: {},
+    inferred: false,
+    typed: false,
+    unknownType: 'any',
+    integerType: 'number',
+    mapper: {},
+    importPath: mini ? 'zod/mini' : 'zod',
+    coercion: false,
+    operations: false,
+    override: [],
+    output: { path: '.' },
+    group: undefined,
+    wrapOutput: undefined,
+    version: '3',
+    guidType: 'uuid',
+    emptySchemaType: 'unknown',
+    mini,
+  }
+  const plugin = { options } as Plugin<PluginZod>
+  const generator = new SchemaGenerator(options, {
+    fabric,
+    oas,
+    pluginManager: createMockedPluginManager(name),
+    plugin,
+    contentType: 'application/json',
+    include: undefined,
+    override: undefined,
+    mode: 'split',
+    output: './gen',
+  })
+
+  const { schemas } = getSchemas({ oas })
+  const schema = schemas[name] as SchemaObject
+  const tree = generator.parse({ schema, name, parentName: null })
+
+  await buildSchema(
+    { name, tree, value: schema },
+    {
+      config: { root: '.', output: { path: 'test' } } as Config,
+      fabric,
+      generator,
+      Component: zodGenerator.Schema,
+      plugin,
+    },
+  )
+
+  return fabric.files.flatMap((file) => file.sources?.map((source) => source.value) ?? []).join('\n')
+}
+
+// https://github.com/kubb-labs/kubb/issues/3661
+describe('nullable allOf (issue #3661)', () => {
+  test('a single nullable allOf member wraps the schema in .nullable()', async () => {
+    const output = await generate('NullableAllOf', false)
+
+    expect(output).not.toContain('.and(.nullable())')
+    expect(output).toContain('z.lazy(() => nullableString).nullable()')
+  })
+
+  test('a nullable member of a multi-member allOf wraps the whole intersection', async () => {
+    const output = await generate('NullableAllOfMulti', false)
+
+    expect(output).not.toContain('.and(.nullable())')
+    expect(output).toContain('z.lazy(() => base).and(z.lazy(() => nullableString)).nullable()')
+  })
+
+  test('mini mode wraps the schema with z.nullable()', async () => {
+    const output = await generate('NullableAllOf', true)
+
+    expect(output).not.toContain('.and(.nullable())')
+    expect(output).toContain('z.nullable(z.lazy(() => nullableString))')
+  })
+})

--- a/packages/plugin-zod/src/parser.ts
+++ b/packages/plugin-zod/src/parser.ts
@@ -555,9 +555,7 @@ export const parse = createParser<string, ParserOptions>({
       const members = sorted.filter((item) => !isModifier(item))
       const modifiers = sorted.filter(isModifier)
 
-      const items = members
-        .map((it: Schema, _index, siblings) => this.parse({ schema, parent: current, name, current: it, siblings }, options))
-        .filter(Boolean)
+      const items = members.map((it: Schema, _index, siblings) => this.parse({ schema, parent: current, name, current: it, siblings }, options)).filter(Boolean)
 
       const base = `${items.slice(0, 1)}${zodKeywordMapper.and(items.slice(1), options.mini)}`
 

--- a/packages/plugin-zod/src/parser.ts
+++ b/packages/plugin-zod/src/parser.ts
@@ -542,14 +542,35 @@ export const parse = createParser<string, ParserOptions>({
     and(tree, options) {
       const { current, schema, name } = tree
 
-      const items = sort(current.args)
-        .filter((schema: Schema) => {
-          return ![schemaKeywords.optional, schemaKeywords.describe].includes(schema.keyword as typeof schemaKeywords.describe)
-        })
+      // Modifier keywords (nullable, optional, default, ...) are not intersection members. When a
+      // single nullable allOf member is merged into the `and`, its `nullable` keyword ends up as a
+      // sibling here; treating it as a member produced invalid output like `.and(.nullable())`.
+      // Keep the real members for the `.and()` chain and wrap the result with the modifiers instead.
+      const isModifier = (item: Schema) =>
+        [schemaKeywords.optional, schemaKeywords.nullable, schemaKeywords.nullish, schemaKeywords.default, schemaKeywords.describe].some((keyword) =>
+          isKeyword(item, keyword),
+        )
+
+      const sorted = sort(current.args)
+      const members = sorted.filter((item) => !isModifier(item))
+      const modifiers = sorted.filter(isModifier)
+
+      const items = members
         .map((it: Schema, _index, siblings) => this.parse({ schema, parent: current, name, current: it, siblings }, options))
         .filter(Boolean)
 
-      return `${items.slice(0, 1)}${zodKeywordMapper.and(items.slice(1), options.mini)}`
+      const base = `${items.slice(0, 1)}${zodKeywordMapper.and(items.slice(1), options.mini)}`
+
+      if (options.mini) {
+        return wrapWithMiniModifiers(base, extractMiniModifiers(modifiers))
+      }
+
+      const suffix = modifiers
+        .map((it: Schema, _index, siblings) => this.parse({ schema, parent: current, name, current: it, siblings }, options))
+        .filter(Boolean)
+        .join('')
+
+      return `${base}${suffix}`
     },
     array(tree, options) {
       const { current, schema, name } = tree


### PR DESCRIPTION
## What

Fixes #3661 (v4).

A nullable schema inside an `allOf` produced invalid Zod output:

```ts
export const getHealth200Schema = z.lazy(() => nullableStringSchema).and(.nullable())
```

The `.and(.nullable())` is a syntax error.

## Why

When a single nullable `allOf` member is merged into the intersection, its `nullable` keyword ends up as a sibling of the real members. The `and` handler in `parser.ts` only filtered out `optional` and `describe`, so `nullable` (and `nullish`/`default`) were parsed as intersection members — producing the broken `.and(.nullable())`.

## How

Modifier keywords (`nullable`, `nullish`, `optional`, `default`, `describe`) are now separated from the intersection members. The real members build the `.and()` chain and the modifiers wrap the whole result:

```ts
// single nullable member
export const nullableAllOf = z.lazy(() => nullableString).nullable()

// multi-member allOf with a nullable member
export const nullableAllOfMulti = z.lazy(() => base).and(z.lazy(() => nullableString)).nullable()
```

Mini mode wraps the result with the functional modifiers (`z.nullable(...)`).

## Tests

- New regression test `packages/plugin-zod/src/generators/nullableAllOf.test.tsx` covering single/multi-member `allOf` and mini mode.
- Full `@kubb/plugin-zod` suite (198) and the `3.0.x` e2e suite (9) pass; no snapshot churn.

> Note: v5 (`main`) already flattens single-member `allOf` and propagates nullable in `@kubb/adapter-oas`, so it emits valid output. A regression test for v5 is added separately in `kubb-labs/plugins`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUhMV6aMGjVezMYmfzEyQs)_