### PR TITLE
refactor(core): narrow addGenerator to a variadic generator list

### DIFF
--- a/.changeset/add-generator-array-to-add-generator.md
+++ b/.changeset/add-generator-array-to-add-generator.md
@@ -2,4 +2,4 @@
 '@kubb/core': minor
 ---
 
-Let `ctx.addGenerator` register several generators in one call. Pass them as separate arguments (`ctx.addGenerator(schemaGenerator, operationGenerator)`) or hand it an existing list (`ctx.addGenerator(selectedGenerators)`), and the arrays are flattened for you. A single generator still works as before, so there is no need to loop over each one.
+Let `ctx.addGenerator` register several generators in one call. Pass them as separate arguments (`ctx.addGenerator(schemaGenerator, operationGenerator)`) or spread an existing list (`ctx.addGenerator(...selectedGenerators)`). A single generator still works as before, so there is no need to loop over each one.

--- a/packages/core/src/definePlugin.test.ts
+++ b/packages/core/src/definePlugin.test.ts
@@ -198,7 +198,7 @@ describe('PluginDriver — hook-style plugin registration', () => {
     expect(hooks.listenerCount('kubb:generate:operations')).toBe(1)
   })
 
-  it('addGenerator() flattens arrays so an existing list can be passed directly', async () => {
+  it('addGenerator() registers a spread list so an existing array can be passed in one call', async () => {
     const generators = [
       { name: 'gen-schema', schema: vi.fn() },
       { name: 'gen-operation', operation: vi.fn() },
@@ -207,7 +207,7 @@ describe('PluginDriver — hook-style plugin registration', () => {
       name: 'hook-plugin',
       hooks: {
         'kubb:plugin:setup'(ctx) {
-          ctx.addGenerator(generators)
+          ctx.addGenerator(...generators)
         },
       },
     }))()

--- a/packages/core/src/definePlugin.ts
+++ b/packages/core/src/definePlugin.ts
@@ -284,17 +284,16 @@ export type KubbPluginSetupContext<TFactory extends PluginFactoryOptions = Plugi
    * Register one or more generators dynamically. Generators fire during the AST walk
    * (schema/operation/operations) just like generators declared statically on `createPlugin`.
    *
-   * Pass generators as separate arguments or as arrays. Arrays are flattened, so spreading an
-   * existing list is optional.
+   * Pass generators as separate arguments. Spread an existing list to register it in one call.
    *
    * @example
    * ```ts
    * ctx.addGenerator(myGenerator)
    * ctx.addGenerator(schemaGenerator, operationGenerator)
-   * ctx.addGenerator(selectedGenerators)
+   * ctx.addGenerator(...selectedGenerators)
    * ```
    */
-  addGenerator<TElement = unknown>(...generators: Array<Generator<TFactory, TElement> | Array<Generator<TFactory, TElement>>>): void
+  addGenerator<TElement = unknown>(...generators: Array<Generator<TFactory, TElement>>): void
   /**
    * Set or override the resolver for this plugin.
    * The resolver controls file naming and path resolution.


### PR DESCRIPTION
## What

Narrow the `addGenerator` signature on `KubbPluginSetupContext` so it only accepts a variadic list of generators:

```ts
// before
addGenerator<TElement = unknown>(...generators: Array<Generator<TFactory, TElement> | Array<Generator<TFactory, TElement>>>): void

// after
addGenerator<TElement = unknown>(...generators: Array<Generator<TFactory, TElement>>): void
```

The bare-array argument form is dropped from the type. Pass generators as separate arguments, or spread an existing list:

```ts
ctx.addGenerator(myGenerator)
ctx.addGenerator(schemaGenerator, operationGenerator)
ctx.addGenerator(...selectedGenerators)
```

## Notes

- The runtime in `KubbDriver` still calls `.flat()`, so passing a list keeps working at runtime. This keeps the migration smooth for plugins that still pass a bare array until they switch to spread.
- Updated the `addGenerator` JSDoc, the pending changeset, and the test that previously passed a bare array (now spreads).
- `pnpm typecheck` and the `definePlugin` test suite pass.

## Follow-up

Five plugins in `kubb-labs/plugins` (`plugin-react-query`, `plugin-fetch`, `plugin-axios`, `plugin-swr`, `plugin-vue-query`) still call `ctx.addGenerator(selectedGenerators)`. They keep working at runtime, but should switch to `ctx.addGenerator(...selectedGenerators)` when they bump `@kubb/core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WB9DA2f2gjmpe6TY3qszqC

---
_Generated by [Claude Code](https://claude.ai/code/session_01WB9DA2f2gjmpe6TY3qszqC)_