### PR TITLE
feat(core): registry-backed imports (resolveFromExports)

### DIFF
--- a/.changeset/registry-backed-imports.md
+++ b/.changeset/registry-backed-imports.md
@@ -1,0 +1,10 @@
+---
+'@kubb/ast': minor
+'@kubb/core': minor
+---
+
+Add registry-backed imports so a generator can import a symbol without knowing which file defines it.
+
+An `ImportNode` can set `resolveFromExports: true` (with no `path`). During a build, `@kubb/core` collects every file's exported names into an export registry and, at the drain barrier (after all files exist), rewrites those imports to point at the file that defines each name, grouped per file and deduped. New `@kubb/ast/utils` helpers — `buildExportRegistry`, `hasDeferredImports`, and `resolveDeferredImports` — implement the resolution.
+
+This lets consumer plugins reference a type that may live in a different file (for example a component type inlined by `@kubb/plugin-ts`) without each plugin re-deriving the source file. Files with deferred imports are held back from the streaming writer until the registry is complete, so output stays correct regardless of plugin order; unresolved names are dropped.

--- a/packages/ast/src/nodes/file.ts
+++ b/packages/ast/src/nodes/file.ts
@@ -57,6 +57,14 @@ export type ImportNode = BaseNode & {
    */
   path: string
   /**
+   * Resolve {@link path} from the build's export registry instead of providing it up front.
+   * When `true`, the import's `name`(s) are matched against the names every generated file exports,
+   * and the import is rewritten to point at the file that defines each name (grouped per file).
+   * Lets a generator reference a symbol owned by another plugin without knowing which file it lands
+   * in. Unresolved names are dropped. `path` is ignored while this is set.
+   */
+  resolveFromExports?: boolean | null
+  /**
    * Add a type-only import prefix.
    * - `true` generates `import type { Type } from './path'`
    * - `false` generates `import { Type } from './path'`

--- a/packages/ast/src/utils/exportRegistry.test.ts
+++ b/packages/ast/src/utils/exportRegistry.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import { createText } from '../nodes/code.ts'
+import { createFile, createImport, createSource } from '../nodes/file.ts'
+import { buildExportRegistry, hasDeferredImports, resolveDeferredImports } from './exportRegistry.ts'
+
+function modelFile(name: string, path: string) {
+  return createFile({
+    baseName: `${name}.ts`,
+    path,
+    sources: [createSource({ name, isExportable: true, nodes: [createText(`export type ${name} = { id: number }`)] })],
+  })
+}
+
+describe('buildExportRegistry', () => {
+  it('maps exportable source names to their defining file path', () => {
+    const registry = buildExportRegistry([modelFile('Pet', 'src/models/Pet.ts'), modelFile('Order', 'src/models/Order.ts')])
+
+    expect(registry.get('Pet')).toBe('src/models/Pet.ts')
+    expect(registry.get('Order')).toBe('src/models/Order.ts')
+  })
+
+  it('ignores non-exportable sources', () => {
+    const file = createFile({
+      baseName: 'internal.ts',
+      path: 'src/internal.ts',
+      sources: [createSource({ name: 'Helper', isExportable: false, nodes: [createText('const Helper = 1')] })],
+    })
+
+    expect(buildExportRegistry([file]).has('Helper')).toBe(false)
+  })
+
+  it('keeps the first file that exports a name when duplicates exist', () => {
+    const registry = buildExportRegistry([modelFile('Pet', 'src/models/Pet.ts'), modelFile('Pet', 'src/other/Pet.ts')])
+
+    expect(registry.get('Pet')).toBe('src/models/Pet.ts')
+  })
+})
+
+describe('hasDeferredImports', () => {
+  it('is true only when an import is marked resolveFromExports', () => {
+    const deferred = createFile({
+      baseName: 'useAddPet.ts',
+      path: 'src/hooks/useAddPet.ts',
+      imports: [createImport({ name: ['Pet'], path: '', resolveFromExports: true })],
+    })
+    const plain = createFile({
+      baseName: 'plain.ts',
+      path: 'src/plain.ts',
+      imports: [createImport({ name: ['z'], path: 'zod' })],
+      sources: [createSource({ name: 'x', nodes: [createText('const x = z')] })],
+    })
+
+    expect(hasDeferredImports(deferred)).toBe(true)
+    expect(hasDeferredImports(plain)).toBe(false)
+  })
+})
+
+describe('resolveDeferredImports', () => {
+  const registry = buildExportRegistry([modelFile('Pet', 'src/models/Pet.ts'), modelFile('Error', 'src/models/Error.ts')])
+
+  it('rewrites a deferred import to the files that define each name, grouped per file', () => {
+    const consumer = createFile({
+      baseName: 'useAddPet.ts',
+      path: 'src/hooks/useAddPet.ts',
+      imports: [createImport({ name: ['Pet', 'Error'], path: '', resolveFromExports: true, isTypeOnly: true })],
+      sources: [createSource({ name: 'useAddPet', nodes: [createText('export function useAddPet(): Pet | Error { return {} as Pet }')] })],
+    })
+
+    const resolved = resolveDeferredImports(consumer, registry)
+
+    expect(hasDeferredImports(resolved)).toBe(false)
+    const byPath = Object.fromEntries(resolved.imports.map((imp) => [imp.path, imp]))
+    expect(byPath['src/models/Pet.ts']?.name).toStrictEqual(['Pet'])
+    expect(byPath['src/models/Error.ts']?.name).toStrictEqual(['Error'])
+    expect(resolved.imports.every((imp) => imp.isTypeOnly)).toBe(true)
+  })
+
+  it('drops names that are not in the registry', () => {
+    const consumer = createFile({
+      baseName: 'useGhost.ts',
+      path: 'src/hooks/useGhost.ts',
+      imports: [createImport({ name: ['Ghost'], path: '', resolveFromExports: true })],
+      sources: [createSource({ name: 'useGhost', nodes: [createText('export const useGhost = (): Ghost => ({}) as Ghost')] })],
+    })
+
+    expect(resolveDeferredImports(consumer, registry).imports).toHaveLength(0)
+  })
+
+  it('keeps non-deferred imports untouched', () => {
+    const consumer = createFile({
+      baseName: 'useAddPet.ts',
+      path: 'src/hooks/useAddPet.ts',
+      imports: [createImport({ name: ['useMutation'], path: '@tanstack/react-query' }), createImport({ name: ['Pet'], path: '', resolveFromExports: true, isTypeOnly: true })],
+      sources: [createSource({ name: 'useAddPet', nodes: [createText('export const useAddPet = () => useMutation<Pet>()')] })],
+    })
+
+    const resolved = resolveDeferredImports(consumer, registry)
+    const paths = resolved.imports.map((imp) => imp.path)
+
+    expect(paths).toContain('@tanstack/react-query')
+    expect(paths).toContain('src/models/Pet.ts')
+  })
+
+  it('returns the file unchanged when there are no deferred imports', () => {
+    const file = createFile({
+      baseName: 'plain.ts',
+      path: 'src/plain.ts',
+      imports: [createImport({ name: ['z'], path: 'zod' })],
+      sources: [createSource({ name: 'x', nodes: [createText('const x = z')] })],
+    })
+
+    expect(resolveDeferredImports(file, registry)).toBe(file)
+  })
+})

--- a/packages/ast/src/utils/exportRegistry.test.ts
+++ b/packages/ast/src/utils/exportRegistry.test.ts
@@ -90,7 +90,10 @@ describe('resolveDeferredImports', () => {
     const consumer = createFile({
       baseName: 'useAddPet.ts',
       path: 'src/hooks/useAddPet.ts',
-      imports: [createImport({ name: ['useMutation'], path: '@tanstack/react-query' }), createImport({ name: ['Pet'], path: '', resolveFromExports: true, isTypeOnly: true })],
+      imports: [
+        createImport({ name: ['useMutation'], path: '@tanstack/react-query' }),
+        createImport({ name: ['Pet'], path: '', resolveFromExports: true, isTypeOnly: true }),
+      ],
       sources: [createSource({ name: 'useAddPet', nodes: [createText('export const useAddPet = () => useMutation<Pet>()')] })],
     })
 

--- a/packages/ast/src/utils/exportRegistry.ts
+++ b/packages/ast/src/utils/exportRegistry.ts
@@ -1,0 +1,75 @@
+import { createFile } from '../nodes/file.ts'
+import type { FileNode, ImportNode } from '../nodes/file.ts'
+
+/**
+ * Maps every exported symbol name to the path of the file that defines it. Built once from the
+ * full set of generated files and used to resolve {@link ImportNode.resolveFromExports} imports.
+ */
+export type ExportRegistry = Map<string, string>
+
+type ImportItem = string | { propertyName: string; name?: string }
+
+function importItemName(item: ImportItem): string {
+  return typeof item === 'string' ? item : (item.name ?? item.propertyName)
+}
+
+/**
+ * Builds a registry of `exported name → defining file path` from every file's exportable sources.
+ * Re-exports (barrel files) are ignored so imports resolve to where a symbol is defined, not to a
+ * barrel. The first file to export a name wins, so later duplicates do not clobber it.
+ */
+export function buildExportRegistry(files: ReadonlyArray<FileNode>): ExportRegistry {
+  const registry: ExportRegistry = new Map()
+  for (const file of files) {
+    for (const source of file.sources) {
+      if (source.isExportable && source.name && !registry.has(source.name)) {
+        registry.set(source.name, file.path)
+      }
+    }
+  }
+  return registry
+}
+
+/**
+ * Whether a file has at least one import whose path must be resolved from the export registry.
+ */
+export function hasDeferredImports(file: FileNode): boolean {
+  return file.imports.some((imp) => imp.resolveFromExports)
+}
+
+/**
+ * Rewrites a file's {@link ImportNode.resolveFromExports} imports to concrete imports pointing at
+ * the files that define each name (grouped per file), then re-normalizes via `createFile` so the
+ * result is merged, deduped, and stripped of self-imports. Names missing from the registry are
+ * dropped. Returns the file unchanged when it has no deferred imports.
+ */
+export function resolveDeferredImports(file: FileNode, registry: ExportRegistry): FileNode {
+  if (!hasDeferredImports(file)) {
+    return file
+  }
+
+  const imports: Array<ImportNode> = []
+  for (const imp of file.imports) {
+    if (!imp.resolveFromExports) {
+      imports.push(imp)
+      continue
+    }
+
+    const { resolveFromExports: _resolveFromExports, ...rest } = imp
+    const root = rest.root ?? file.path
+    const names = Array.isArray(imp.name) ? imp.name : [imp.name]
+    const byPath = new Map<string, Array<ImportItem>>()
+    for (const item of names) {
+      const targetPath = registry.get(importItemName(item))
+      if (!targetPath) continue
+      const grouped = byPath.get(targetPath) ?? []
+      grouped.push(item)
+      byPath.set(targetPath, grouped)
+    }
+    for (const [targetPath, grouped] of byPath) {
+      imports.push({ ...rest, name: grouped, path: targetPath, root })
+    }
+  }
+
+  return createFile({ ...file, imports })
+}

--- a/packages/ast/src/utils/index.ts
+++ b/packages/ast/src/utils/index.ts
@@ -1,5 +1,6 @@
 export { isValidVarName } from '@internals/utils'
 export { buildJSDoc, buildList, buildObject, objectKey } from './codegen.ts'
+export { buildExportRegistry, hasDeferredImports, resolveDeferredImports, type ExportRegistry } from './exportRegistry.ts'
 export { extractStringsFromNodes } from './extractStringsFromNodes.ts'
 export { childName, enumPropName, extractRefName, isStringType, syncSchemaRef } from './refs.ts'
 export { mergeAdjacentObjectsLazy } from './schemaMerge.ts'

--- a/packages/core/src/KubbDriver.ts
+++ b/packages/core/src/KubbDriver.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path'
 import { arrayToAsyncIterable, type AsyncEventEmitter, getElapsedMs, isPromise, memoize, Url } from '@internals/utils'
-import { collectUsedSchemaNames } from '@kubb/ast/utils'
+import { buildExportRegistry, collectUsedSchemaNames, hasDeferredImports, resolveDeferredImports } from '@kubb/ast/utils'
 import { ast, type Enforce, type FileNode, type InputMeta, type InputNode, type OperationNode, type SchemaNode } from '@kubb/ast'
 import { GENERATE_FLUSH_EVERY, OPERATION_FILTER_TYPES } from './constants.ts'
 import { type Diagnostic, Diagnostics, type ProblemDiagnostic } from './diagnostics.ts'
@@ -355,9 +355,24 @@ export class KubbDriver {
       await hooks.emit('kubb:files:processing:end', { files })
     })
     const onFileUpsert = (file: FileNode): void => {
+      // Files whose imports must be resolved from the export registry are held back: the registry
+      // is only complete once every file exists, so they are resolved and enqueued at the drain
+      // barrier below. Everything else streams to the processor as usual.
+      if (hasDeferredImports(file)) return
       processor.enqueue(file)
     }
     this.fileManager.hooks.on('upsert', onFileUpsert)
+
+    // Resolves every held deferred-import file against the now-complete export registry and queues
+    // the rewritten versions for writing. Run right before draining so all defining files exist.
+    const enqueueDeferredImports = (): void => {
+      const filesWithDeferred = this.fileManager.files.filter(hasDeferredImports)
+      if (filesWithDeferred.length === 0) return
+      const registry = buildExportRegistry(this.fileManager.files)
+      for (const file of filesWithDeferred) {
+        processor.enqueue(resolveDeferredImports(file, registry))
+      }
+    }
 
     // Make `diagnostics` the active sink so deep code (adapter parse, lazily consumed
     // streams, generators) can report into this run via `Diagnostics.report`.
@@ -417,6 +432,8 @@ export class KubbDriver {
           // When there are no entries it returns early. When `inputNode` is missing it still
           // closes out each entry's `kubb:plugin:end` directly.
           diagnostics.push(...(await this.#runGenerators(generatorPlugins, () => processor.flush())))
+          // Resolve registry-backed imports now that every generated file exists, then write.
+          enqueueDeferredImports()
           // Wait for the last in-flight batch and write anything still pending.
           await processor.drain()
 


### PR DESCRIPTION
Foundation for letting a generator import a symbol **without knowing which file defines it** — the generic mechanism behind the per-operation type inlining in kubb-labs/plugins#507.

## Motivation

When `@kubb/plugin-ts` inlines a single-`$ref` operation type (e.g. `AddPetStatus200` → `Pet`), the base type moves to its own model file. Today every consumer plugin (react-query, vue-query, swr, cypress, msw, faker) independently re-derives "which file does this type live in" to build its imports. This pushes that resolution into core so a generator can just say "import `Pet`, wherever it's defined."

## What this adds

- **`ImportNode.resolveFromExports`** (`@kubb/ast`): mark an import whose `path` is resolved from the build's export registry instead of being provided up front.
- **`@kubb/ast/utils` helpers**: `buildExportRegistry(files)` (name → defining file path, from exportable sources), `hasDeferredImports(file)`, and `resolveDeferredImports(file, registry)` (rewrites deferred imports to concrete per-file imports, then re-normalizes via `createFile` so they're merged/deduped and self-imports dropped; unresolved names are dropped).
- **`@kubb/core` wiring**: files with deferred imports are held back from the streaming writer in `onFileUpsert`; at the drain barrier (after every file exists) they're resolved against the complete registry and enqueued.

## Why it's streaming-safe

`FileManager` already holds every file's AST for the whole build, so the export map is fully available — streaming only avoids holding all *rendered source* at once. Only the (minority) files with deferred imports wait for the drain barrier; everything else still streams. Holding to the barrier also makes resolution correct regardless of plugin order.

## Tests

- 8 new unit tests for `buildExportRegistry` / `hasDeferredImports` / `resolveDeferredImports` (grouping per file, dropping unresolved names, preserving non-deferred imports, first-export-wins).
- Full `@kubb/ast` + `@kubb/core` suites green (500 tests); typecheck + lint clean.

## Note on validation / rollout

The resolution logic is unit-tested here. End-to-end validation against the plugins needs a canary release of `@kubb/core`/`@kubb/ast` (the plugins repo consumes the published versions), after which the consumer plugins in #507 can drop their manual per-name file resolution in favor of `resolveFromExports`. #507 remains the shipping solution until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TPdqWWtWKwQnA7Vry9NDbG)_