### PR TITLE
feat(adapter-oas): map x-enumDescriptions vendor extensions to enum members

### DIFF
--- a/.changeset/enum-member-descriptions.md
+++ b/.changeset/enum-member-descriptions.md
@@ -1,0 +1,8 @@
+---
+'@kubb/adapter-oas': minor
+'@kubb/ast': patch
+---
+
+Surface enum member descriptions from the `x-enumDescriptions` / `x-enum-descriptions` vendor extensions.
+
+`adapter-oas` now reads these extensions alongside the existing `x-enumNames` / `x-enum-varnames` name extensions and attaches each label to the matching `namedEnumValues` entry (new optional `description` on the AST `EnumValueNode`). A string enum that only carries `x-enum-descriptions` (no varnames) now produces `namedEnumValues` too, so the descriptions are not lost. `@kubb/plugin-ts` renders them as per-member JSDoc.

--- a/.changeset/enum-member-descriptions.md
+++ b/.changeset/enum-member-descriptions.md
@@ -3,6 +3,6 @@
 '@kubb/ast': patch
 ---
 
-Surface enum member descriptions from the `x-enumDescriptions` / `x-enum-descriptions` vendor extensions.
+Read enum member descriptions from the `x-enumDescriptions` and `x-enum-descriptions` vendor extensions.
 
-`adapter-oas` now reads these extensions alongside the existing `x-enumNames` / `x-enum-varnames` name extensions and attaches each label to the matching `namedEnumValues` entry (new optional `description` on the AST `EnumValueNode`). A string enum that only carries `x-enum-descriptions` (no varnames) now produces `namedEnumValues` too, so the descriptions are not lost. `@kubb/plugin-ts` renders them as per-member JSDoc.
+`adapter-oas` already mapped the `x-enumNames` / `x-enum-varnames` names into `namedEnumValues`. It now reads the matching description extensions too, attaching each label to its `namedEnumValues` entry through a new optional `description` on the AST `EnumValueNode`. An enum that carries only `x-enum-descriptions` (no varnames) now produces `namedEnumValues` as well, so those labels survive instead of being dropped. `@kubb/plugin-ts` renders them as per-member JSDoc.

--- a/packages/adapter-oas/src/constants.ts
+++ b/packages/adapter-oas/src/constants.ts
@@ -108,3 +108,15 @@ export const formatMap = {
  * ```
  */
 export const enumExtensionKeys = ['x-enumNames', 'x-enum-varnames'] as const
+
+/**
+ * Vendor extension keys that attach human-readable descriptions to enum values, checked in priority order.
+ *
+ * @example
+ * ```ts
+ * import { enumDescriptionKeys } from '@kubb/adapter-oas'
+ *
+ * const key = enumDescriptionKeys.find((k) => k in schema) // 'x-enumDescriptions' | 'x-enum-descriptions' | undefined
+ * ```
+ */
+export const enumDescriptionKeys = ['x-enumDescriptions', 'x-enum-descriptions'] as const

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -2385,6 +2385,51 @@ describe('parseSchema enum', () => {
     expect(values?.map((v) => v.value)).toStrictEqual(['active', 'inactive'])
   })
 
+  it('uses x-enumDescriptions as namedEnumValues descriptions', () => {
+    const node = parseSchema(ctx, {
+      schema: {
+        type: 'integer',
+        enum: [1, 2],
+        'x-enumNames': ['One', 'Two'],
+        'x-enumDescriptions': ['The first value', 'The second value'],
+      },
+    })
+    const narrowed = ast.narrowSchema(node, 'enum')
+
+    const values = narrowed?.namedEnumValues
+    expect(values?.map((v) => v.name)).toStrictEqual(['One', 'Two'])
+    expect(values?.map((v) => v.description)).toStrictEqual(['The first value', 'The second value'])
+  })
+
+  it('uses x-enum-descriptions as namedEnumValues descriptions', () => {
+    const node = parseSchema(ctx, {
+      schema: {
+        enum: ['active', 'inactive'],
+        'x-enum-varnames': ['Active', 'Inactive'],
+        'x-enum-descriptions': ['Currently active', 'No longer active'],
+      },
+    })
+    const narrowed = ast.narrowSchema(node, 'enum')
+
+    const values = narrowed?.namedEnumValues
+    expect(values?.map((v) => v.name)).toStrictEqual(['Active', 'Inactive'])
+    expect(values?.map((v) => v.description)).toStrictEqual(['Currently active', 'No longer active'])
+  })
+
+  it('produces namedEnumValues from x-enumDescriptions on a string enum without varnames', () => {
+    const node = parseSchema(ctx, {
+      schema: {
+        enum: ['active', 'inactive'],
+        'x-enum-descriptions': ['Currently active', 'No longer active'],
+      },
+    })
+    const narrowed = ast.narrowSchema(node, 'enum')
+
+    const values = narrowed?.namedEnumValues
+    expect(values?.map((v) => v.name)).toStrictEqual(['active', 'inactive'])
+    expect(values?.map((v) => v.description)).toStrictEqual(['Currently active', 'No longer active'])
+  })
+
   it('x-enumNames deduplicates names', () => {
     const node = parseSchema(ctx, {
       schema: {

--- a/packages/adapter-oas/src/parser.ts
+++ b/packages/adapter-oas/src/parser.ts
@@ -2,7 +2,7 @@ import { pascalCase } from '@internals/utils'
 import { macroDiscriminatorEnum, macroEnumName, macroSimplifyUnion } from '@kubb/ast/macros'
 import { childName, enumPropName, extractRefName, mergeAdjacentObjectsLazy } from '@kubb/ast/utils'
 import { ast } from '@kubb/core'
-import { DEFAULT_PARSER_OPTIONS, enumExtensionKeys, SCHEMA_REF_PREFIX } from './constants.ts'
+import { DEFAULT_PARSER_OPTIONS, enumDescriptionKeys, enumExtensionKeys, SCHEMA_REF_PREFIX } from './constants.ts'
 import { oasDialect, type OasDialect } from './dialect.ts'
 import { createDiscriminantNode, findDiscriminator } from './discriminator.ts'
 import { getOperationId, getOperations, getRequestContentType, getResponseByStatusCode, getResponseStatusCodes } from './operation.ts'
@@ -561,12 +561,14 @@ export function createSchemaParser(ctx: OasParserContext, dialect: OasDialect = 
     }
 
     const extensionKey = enumExtensionKeys.find((key) => key in schema)
-    if (extensionKey || enumPrimitive === 'number' || enumPrimitive === 'integer' || enumPrimitive === 'boolean') {
+    const descriptionKey = enumDescriptionKeys.find((key) => key in schema)
+    if (extensionKey || descriptionKey || enumPrimitive === 'number' || enumPrimitive === 'integer' || enumPrimitive === 'boolean') {
       const enumPrimitiveType = (enumPrimitive === 'number' || enumPrimitive === 'integer' ? 'number' : enumPrimitive === 'boolean' ? 'boolean' : 'string') as
         | 'number'
         | 'boolean'
         | 'string'
       const rawEnumNames = extensionKey ? ((schema as Record<string, unknown>)[extensionKey] as Array<string | number>) : undefined
+      const rawEnumDescriptions = descriptionKey ? ((schema as Record<string, unknown>)[descriptionKey] as Array<string>) : undefined
       const uniqueValues = [...new Set(filteredValues)]
       const seenNames = new Set<string>()
 
@@ -578,6 +580,7 @@ export function createSchemaParser(ctx: OasParserContext, dialect: OasDialect = 
             name: String(rawEnumNames?.[index] ?? value),
             value,
             primitive: enumPrimitiveType,
+            description: rawEnumDescriptions?.[index],
           }))
           .filter((entry) => {
             if (seenNames.has(entry.name)) return false

--- a/packages/ast/src/nodes/schema.ts
+++ b/packages/ast/src/nodes/schema.ts
@@ -322,6 +322,11 @@ type EnumValueNode = {
    * Primitive type of the enum value.
    */
   primitive: Extract<PrimitiveSchemaType, 'string' | 'number' | 'boolean'>
+  /**
+   * Human-readable label for the enum item, sourced from the `x-enumDescriptions`
+   * or `x-enum-descriptions` vendor extension. Surfaced as per-member JSDoc.
+   */
+  description?: string
 }
 
 /**

--- a/packages/ast/src/nodes/schema.ts
+++ b/packages/ast/src/nodes/schema.ts
@@ -323,8 +323,9 @@ type EnumValueNode = {
    */
   primitive: Extract<PrimitiveSchemaType, 'string' | 'number' | 'boolean'>
   /**
-   * Human-readable label for the enum item, sourced from the `x-enumDescriptions`
-   * or `x-enum-descriptions` vendor extension. Surfaced as per-member JSDoc.
+   * Label for the enum item, taken from the `x-enumDescriptions` or
+   * `x-enum-descriptions` vendor extension. `@kubb/plugin-ts` renders it as
+   * JSDoc on the matching enum member.
    */
   description?: string
 }


### PR DESCRIPTION
## Summary

Surfaces per-member enum documentation from the `x-enumDescriptions` / `x-enum-descriptions` vendor extensions, which were previously dropped during parsing.

`adapter-oas` already mapped the `x-enumNames` / `x-enum-varnames` *name* extensions into `namedEnumValues`. This adds the matching *description* extensions:

- New optional `description` on the AST `EnumValueNode` (`@kubb/ast`).
- `convertEnum` reads `x-enumDescriptions` (priority) and `x-enum-descriptions`, attaching each label to the matching `namedEnumValues` entry by deduped-value index, the same way names are mapped.
- A string enum that carries **only** `x-enum-descriptions` (no varnames) now produces `namedEnumValues` too, so the descriptions are not lost.

`@kubb/plugin-ts` consumes the new field and renders the descriptions as per-member JSDoc (see the companion PR in `kubb-labs/plugins`).

## Verification

- Adapter mapping of `x-enum-varnames` / `x-enumNames` into `namedEnumValues` confirmed already present (the open question from the task).
- Added parser tests for `x-enumDescriptions`, `x-enum-descriptions`, and the descriptions-without-varnames case.
- `@kubb/adapter-oas` + `@kubb/ast`: tests, typecheck, and lint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FnzP2N7CzC1rKYRgAXknAk

---
_Generated by [Claude Code](https://claude.ai/code/session_01FnzP2N7CzC1rKYRgAXknAk)_