### PR TITLE
docs: add Open Collective badge and supporting link

### DIFF
--- a/packages/kubb/README.md
+++ b/packages/kubb/README.md
@@ -183,13 +183,7 @@ See [LICENSE](./LICENSE) for details.
 
 ## Star history
 
-<a href="https://star-history.com/#kubb-labs/kubb&Date">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=kubb-labs/kubb&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=kubb-labs/kubb&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=kubb-labs/kubb&type=Date" />
-  </picture>
-</a>
+![Star history chart](https://shieldcn.dev/chart/github/stars/kubb-labs/kubb.svg?theme=orange)
 
 <!-- Badges -->
 

--- a/packages/kubb/README.md
+++ b/packages/kubb/README.md
@@ -76,7 +76,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <p align="center">
   <a href="https://github.com/sponsors/stijnvanhulle">
-    <img src="https://raw.githubusercontent.com/stijnvanhulle/sponsors/main/sponsors.svg" alt="My sponsors" />
+    <img src="https://shieldcn.dev/sponsors/stijnvanhulle.svg?titleAlign=center&mode=dark" alt="stijnvanhulle sponsors" />
   </a>
 </p>
 

--- a/packages/kubb/README.md
+++ b/packages/kubb/README.md
@@ -76,7 +76,7 @@ Kubb is an open source project, and its development is funded entirely by sponso
 
 <p align="center">
   <a href="https://github.com/sponsors/stijnvanhulle">
-    <img src="https://shieldcn.dev/sponsors/stijnvanhulle.svg?titleAlign=center&mode=dark" alt="stijnvanhulle sponsors" />
+    <img src="https://shieldcn.dev/sponsors/stijnvanhulle.svg?titleAlign=center&mode=dark" alt="stijnvanhulle sponsors" width="100%" />
   </a>
 </p>
 

--- a/packages/kubb/README.md
+++ b/packages/kubb/README.md
@@ -183,7 +183,7 @@ See [LICENSE](./LICENSE) for details.
 
 ## Star history
 
-![Star history chart](https://shieldcn.dev/chart/github/stars/kubb-labs/kubb.svg?theme=orange)
+<img alt="Star history chart" src="https://shieldcn.dev/chart/github/stars/kubb-labs/kubb.svg?theme=orange" width="100%" />
 
 <!-- Badges -->
 

--- a/packages/kubb/README.md
+++ b/packages/kubb/README.md
@@ -9,6 +9,7 @@
 [![License][license-src]][license-href]
 [![Coverage][coverage-src]][coverage-href]
 [![Node][node-src]][node-href]
+[![OC Backers][oc-backers-src]][oc-backers-href]
 
 <h4>
 <a href="https://kubb.dev" target="_blank">Documentation</a>
@@ -70,6 +71,7 @@ See the [documentation](https://kubb.dev) for detailed usage and advanced featur
 Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
 
 - [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
+- [Back Kubb on Open Collective](https://opencollective.com/kubb)
 - [See sponsorship tiers and our sponsors](https://kubb.dev/sponsors)
 
 <p align="center">
@@ -205,3 +207,5 @@ See [LICENSE](./LICENSE) for details.
 [contributors-href]: #contributors-
 [coverage-src]: https://shieldcn.dev/codecov/github/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [coverage-href]: https://app.codecov.io/gh/kubb-labs/kubb
+[oc-backers-src]: https://shieldcn.dev/opencollective/backers/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[oc-backers-href]: https://opencollective.com/kubb


### PR DESCRIPTION
Adds an Open Collective backers badge to the README and a "Back Kubb on Open Collective" link in the Supporting Kubb section, pointing at https://opencollective.com/kubb.

The badge matches the existing shieldcn.dev badge style used across the project:

```
[oc-backers-src]: https://shieldcn.dev/opencollective/backers/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
[oc-backers-href]: https://opencollective.com/kubb
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CyQKoGYxDHYX2LXoMvgJLP)_