### PR TITLE
test(adapter-oas): cover readOnly/writeOnly keysToOmit by direction

### DIFF
--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -547,6 +547,105 @@ describe('buildAst', () => {
       expect(ok?.content).toHaveLength(1)
       expect(ok?.content?.[0]?.contentType).toBe('application/xml')
     })
+
+    describe('keysToOmit by direction (readOnly / writeOnly)', () => {
+      async function parseUserOperation() {
+        const oas = await parseDocument({
+          openapi: '3.0.3',
+          info: { title: 'Test', version: '1.0.0' },
+          paths: {
+            '/users': {
+              post: {
+                operationId: 'createUser',
+                requestBody: {
+                  required: true,
+                  content: {
+                    'application/json': {
+                      schema: {
+                        type: 'object',
+                        properties: {
+                          id: { type: 'string', readOnly: true },
+                          name: { type: 'string' },
+                          password: { type: 'string', writeOnly: true },
+                        },
+                      },
+                    },
+                  },
+                },
+                responses: {
+                  '200': {
+                    description: 'The created user',
+                    content: {
+                      'application/json': {
+                        schema: {
+                          type: 'object',
+                          properties: {
+                            id: { type: 'string', readOnly: true },
+                            name: { type: 'string' },
+                            password: { type: 'string', writeOnly: true },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        })
+        return parseOas(oas).root.operations.find((op) => op.operationId === 'createUser')
+      }
+
+      it('marks readOnly request-body keys to omit so they never reach the request type', async () => {
+        const createUser = await parseUserOperation()
+
+        expect(createUser?.requestBody?.content?.[0]?.keysToOmit).toStrictEqual(['id'])
+      })
+
+      it('marks writeOnly response keys to omit so a password never leaks into the response type', async () => {
+        const createUser = await parseUserOperation()
+        const ok = createUser?.responses.find((r) => r.statusCode === '200')
+
+        expect(ok?.content?.[0]?.keysToOmit).toStrictEqual(['password'])
+      })
+
+      it('leaves keysToOmit null when a body has no readOnly or writeOnly properties', async () => {
+        const oas = await parseDocument({
+          openapi: '3.0.3',
+          info: { title: 'Test', version: '1.0.0' },
+          paths: {
+            '/pets': {
+              post: {
+                operationId: 'createPet',
+                requestBody: {
+                  required: true,
+                  content: {
+                    'application/json': {
+                      schema: { type: 'object', properties: { name: { type: 'string' } } },
+                    },
+                  },
+                },
+                responses: {
+                  '200': {
+                    description: 'OK',
+                    content: {
+                      'application/json': {
+                        schema: { type: 'object', properties: { name: { type: 'string' } } },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        })
+        const createPet = parseOas(oas).root.operations.find((op) => op.operationId === 'createPet')
+        const ok = createPet?.responses.find((r) => r.statusCode === '200')
+
+        expect(createPet?.requestBody?.content?.[0]?.keysToOmit).toBeNull()
+        expect(ok?.content?.[0]?.keysToOmit).toBeNull()
+      })
+    })
   })
 })
 


### PR DESCRIPTION
## Summary

`parseOperation` in `@kubb/adapter-oas` already fills `content.keysToOmit` with `readOnly` keys for the request body and `writeOnly` keys for responses (`collectPropertyKeysByFlag`). This is the core of plugin-ts's request/response direction filtering, but the operation-level wiring was untested.

## Changes

Adds a `keysToOmit by direction (readOnly / writeOnly)` block to `parser.test.ts`:

- a `readOnly` request-body key is marked for omission (`['id']`)
- a `writeOnly` response key is marked for omission (`['password']`), so a password never reaches the response type
- `keysToOmit` stays `null` when a body has neither flag

Tests only, no runtime change.

## Test plan

- `pnpm --filter @kubb/adapter-oas test` — 347 passed (3 new)
- typecheck and lint clean

Companion PRs: plugin-ts regression test in `kubb-labs/plugins` and a docs section in `kubb-labs/docs`, same branch name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GNi9XwzoTm48KbCpaaHUhm)_