### PR TITLE
fix(adapter-oas): treat OpenAPI 3.1 const as a literal, not a named enum

### DIFF
--- a/.changeset/openapi-const-literal.md
+++ b/.changeset/openapi-const-literal.md
@@ -1,0 +1,7 @@
+---
+'@kubb/adapter-oas': patch
+---
+
+Stop registering an OpenAPI 3.1 `const` schema as a named enum.
+
+A `const` is parsed into a single-value enum node, which `@kubb/plugin-ts` now renders as a literal type rather than a named enum. The pre-scan no longer adds single-value enums to `enumNames`, and `enums: 'root'` no longer promotes them to top-level enum types, so references to a const resolve to its plain name and stay inline literals.

--- a/.changeset/openapi-const-literal.md
+++ b/.changeset/openapi-const-literal.md
@@ -2,6 +2,6 @@
 '@kubb/adapter-oas': patch
 ---
 
-Stop registering an OpenAPI 3.1 `const` schema as a named enum.
+Stop treating an OpenAPI 3.1 `const` as a named enum.
 
-A `const` is parsed into a single-value enum node, which `@kubb/plugin-ts` now renders as a literal type rather than a named enum. The pre-scan no longer adds single-value enums to `enumNames`, and `enums: 'root'` no longer promotes them to top-level enum types, so references to a const resolve to its plain name and stay inline literals.
+A `const` is parsed into a single-value enum. The pre-scan no longer records these in `enumNames`, and `enums: 'root'` no longer lifts them to top-level enums, so a reference to a `const` resolves to its plain name and `@kubb/plugin-ts` can render it as an inline literal.

--- a/packages/adapter-oas/src/promoteEnums.test.ts
+++ b/packages/adapter-oas/src/promoteEnums.test.ts
@@ -35,6 +35,12 @@ describe('collectInlineEnums', () => {
 
     expect(collectInlineEnums([pet, order], new Set(['Pet', 'Order'])).size).toBe(1)
   })
+
+  it('skips a single-value enum (OAS 3.1 const) so it stays an inline literal', () => {
+    const pet = objectWith('Pet', 'plan', stringEnum(['pro'], 'PetPlanEnum'))
+
+    expect(collectInlineEnums([pet], new Set(['Pet'])).size).toBe(0)
+  })
 })
 
 describe('refPromotedEnums', () => {

--- a/packages/adapter-oas/src/promoteEnums.ts
+++ b/packages/adapter-oas/src/promoteEnums.ts
@@ -13,6 +13,9 @@ export function collectInlineEnums(roots: ReadonlyArray<ast.Node>, topLevelNames
     const isSchemaRoot = root.kind === 'Schema'
     for (const node of ast.collect<ast.SchemaNode>(root, { schema: (schemaNode) => schemaNode })) {
       if (node.type !== 'enum' || !node.name) continue
+      // A single-value enum is an OAS 3.1 `const`: it stays an inline literal, so it is never lifted
+      // to a named top-level enum.
+      if ((node.namedEnumValues ?? node.enumValues ?? []).length === 1) continue
       // Skip a top-level enum component (it is already its own type) and any enum whose name a
       // component already owns.
       if (isSchemaRoot && node === root) continue

--- a/packages/adapter-oas/src/stream.test.ts
+++ b/packages/adapter-oas/src/stream.test.ts
@@ -111,6 +111,21 @@ describe('preScan', () => {
     expect(enumNames).toStrictEqual(['Status'])
   })
 
+  it('excludes single-value enums (OAS 3.1 const) from enum names', () => {
+    const document: Document = { openapi: '3.1.0', info: { title: 'Test API', version: '1.0.0' }, paths: {} }
+    const { parseSchema } = createSchemaParser({ document })
+    const constSchemas: Record<string, SchemaObject> = { Status: statusSchema, Plan: { const: 'pro' } }
+
+    const { enumNames } = preScan({
+      schemas: constSchemas,
+      parseSchema,
+      parserOptions,
+      discriminator: 'preserve',
+    })
+
+    expect(enumNames).toStrictEqual(['Status'])
+  })
+
   it('builds refAliasMap for pure $ref alias schemas only', () => {
     const { refAliasMap } = preScan({
       schemas,

--- a/packages/adapter-oas/src/stream.ts
+++ b/packages/adapter-oas/src/stream.ts
@@ -89,7 +89,11 @@ export function preScan({
     if (node.type === 'ref' && node.name && node.name !== name) {
       refAliasMap.set(name, node)
     }
-    if (ast.narrowSchema(node, ast.schemaTypes.enum) && node.name) {
+    const enumNode = ast.narrowSchema(node, ast.schemaTypes.enum)
+    // A single-value enum is an OAS 3.1 `const`: it renders as a literal type, not a named enum, so
+    // it must not be registered as an enum name (which would suffix references to it).
+    const isConstEnum = (enumNode?.namedEnumValues ?? enumNode?.enumValues ?? []).length === 1
+    if (enumNode && node.name && !isConstEnum) {
       enumNames.push(node.name)
     }
     if (discriminator === 'propagate' && (schema.oneOf ?? schema.anyOf) && schema.discriminator?.propertyName) {


### PR DESCRIPTION
## What

A `const` schema is parsed into a single-value enum node, which `@kubb/plugin-ts` now renders as a literal type rather than a named enum. This adjusts the pre-scan so a const is no longer treated as a named enum.

## How

- **`stream.ts`** — `preScan` no longer adds single-value enums to `enumNames`. `enumNames` drives ref-suffixing in plugins, so registering a const there would suffix references to it (`StatusKey`) while the plugin now exports the plain literal (`Status`), producing a broken import.
- **`promoteEnums.ts`** — `collectInlineEnums` (`enums: 'root'`) no longer promotes single-value enums to top-level enum types, so a const stays an inline literal.

Both key off "exactly one value", matching the `isConstEnum` predicate in `@kubb/plugin-ts`.

## Tests

- `preScan` excludes a single-value `const` from `enumNames` while keeping a multi-value enum.
- `collectInlineEnums` skips a single-value enum so it stays inline.
- Full `@kubb/adapter-oas` suite green (486 tests).

## Companion change

Pairs with kubb-labs/plugins#528 (`@kubb/plugin-ts`), which emits the literal type for a `const`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Su3LWXUwQKgEUdsfRXxWB

---
_Generated by [Claude Code](https://claude.ai/code/session_012Su3LWXUwQKgEUdsfRXxWB)_