### PR TITLE
feat(ast,adapter-oas): capture parameter style and explode, keep ast spec-neutral

### DIFF
--- a/.changeset/parameter-style-explode.md
+++ b/.changeset/parameter-style-explode.md
@@ -1,0 +1,8 @@
+---
+'@kubb/ast': minor
+'@kubb/adapter-oas': minor
+---
+
+Capture the OpenAPI parameter `style` and `explode` on the AST.
+
+`ParameterNode` gains optional `style` (`'matrix' | 'label' | 'form' | 'simple' | 'spaceDelimited' | 'pipeDelimited' | 'deepObject'`) and `explode` fields, and the OpenAPI adapter now reads them from each parameter object. Both stay `undefined` when the spec omits them, so consumers keep applying the per-location default. This lets client generators emit per-parameter serialization metadata for full `label` / `matrix` path-parameter support.

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -274,6 +274,44 @@ describe('buildAst', () => {
       expect((petId?.schema as { name?: string }).name).toBe('PetId')
     })
 
+    it('captures the parameter style and explode metadata', async () => {
+      const oas = await parseDocument({
+        openapi: '3.0.3',
+        info: { title: 'Test', version: '1.0.0' },
+        paths: {
+          '/pets/{ids}': {
+            get: {
+              operationId: 'listPetsByIds',
+              parameters: [
+                { name: 'ids', in: 'path', required: true, style: 'matrix', explode: true, schema: { type: 'array', items: { type: 'integer' } } },
+                { name: 'tags', in: 'query', style: 'spaceDelimited', explode: false, schema: { type: 'array', items: { type: 'string' } } },
+              ],
+              responses: { '200': { description: 'OK' } },
+            },
+          },
+        },
+      })
+      const root = parseOas(oas).root
+      const op = root.operations.find((o) => o.operationId === 'listPetsByIds')
+      const ids = op?.parameters.find((p) => p.name === 'ids')
+      const tags = op?.parameters.find((p) => p.name === 'tags')
+
+      expect(ids?.style).toBe('matrix')
+      expect(ids?.explode).toBe(true)
+      expect(tags?.style).toBe('spaceDelimited')
+      expect(tags?.explode).toBe(false)
+    })
+
+    it('leaves style and explode undefined when the spec omits them', async () => {
+      const oas = await buildMinimalOas()
+      const root = parseOas(oas).root
+      const getPet = root.operations.find((op) => op.operationId === 'getPetById')
+      const petId = getPet?.parameters.find((p) => p.name === 'petId')
+
+      expect(petId?.style).toBeUndefined()
+      expect(petId?.explode).toBeUndefined()
+    })
+
     it('converts requestBody', async () => {
       const oas = await buildMinimalOas()
       const root = parseOas(oas).root

--- a/packages/adapter-oas/src/parser.ts
+++ b/packages/adapter-oas/src/parser.ts
@@ -904,6 +904,9 @@ export function createSchemaParser(ctx: OasParserContext, dialect: OasDialect = 
       ? parseSchema({ schema: param['schema'] as SchemaObject, name: schemaName }, options)
       : ast.factory.createSchema({ type: options.unknownType })
 
+    const style = param['style'] as ast.ParameterStyle | undefined
+    const explode = param['explode'] as boolean | undefined
+
     return ast.factory.createParameter({
       name: paramName,
       in: param['in'] as ast.ParameterLocation,
@@ -912,6 +915,8 @@ export function createSchemaParser(ctx: OasParserContext, dialect: OasDialect = 
         description: (param['description'] as string | undefined) ?? schema.description,
       },
       required,
+      ...(style !== undefined ? { style } : {}),
+      ...(explode !== undefined ? { explode } : {}),
     })
   }
 

--- a/packages/ast/src/defineDialect.ts
+++ b/packages/ast/src/defineDialect.ts
@@ -1,7 +1,7 @@
 /**
  * The spec-specific questions a schema parser answers while turning a source document into Kubb
- * AST nodes. The rest of the pipeline is generic JSON Schema, so this is the one seam where
- * OpenAPI, AsyncAPI, and plain JSON Schema differ.
+ * AST nodes. The rest of the pipeline is generic, so this is the one seam where source formats
+ * differ.
  */
 export type SchemaDialect<TSchema = unknown, TRef = TSchema, TDiscriminated = TSchema, TDocument = unknown> = {
   /**

--- a/packages/ast/src/infer.ts
+++ b/packages/ast/src/infer.ts
@@ -16,7 +16,7 @@ import type {
 } from './nodes/index.ts'
 
 /**
- * Options that control how the adapter parser maps OpenAPI schemas to AST nodes.
+ * Options that control how the adapter parser maps source schemas to AST nodes.
  */
 export type ParserOptions = {
   /**

--- a/packages/ast/src/nodes/index.ts
+++ b/packages/ast/src/nodes/index.ts
@@ -17,7 +17,7 @@ export type { ExportNode, FileNode, ImportNode, SourceNode, UserFileNode } from 
 export type { InputMeta, InputNode } from './input.ts'
 export type { GenericOperationNode, HttpMethod, HttpOperationNode, OperationNode } from './operation.ts'
 export type { OutputNode } from './output.ts'
-export type { ParameterLocation, ParameterNode } from './parameter.ts'
+export type { ParameterLocation, ParameterNode, ParameterStyle } from './parameter.ts'
 export type { PropertyNode } from './property.ts'
 export type { RequestBodyNode } from './requestBody.ts'
 export type { ResponseNode, StatusCode } from './response.ts'

--- a/packages/ast/src/nodes/input.ts
+++ b/packages/ast/src/nodes/input.ts
@@ -13,7 +13,7 @@ import type { SchemaNode } from './schema.ts'
  *
  * @example
  * ```ts
- * const meta: InputMeta = { title: 'Pet Store', version: '1.0.0', baseURL: 'https://petstore.swagger.io/v2', circularNames: [], enumNames: [] }
+ * const meta: InputMeta = { title: 'Pet Store', version: '1.0.0', baseURL: 'https://api.example.com/v2', circularNames: [], enumNames: [] }
  * ```
  */
 export type InputMeta = {

--- a/packages/ast/src/nodes/operation.ts
+++ b/packages/ast/src/nodes/operation.ts
@@ -23,12 +23,11 @@ type OperationNodeBase = BaseNode & {
    */
   kind: 'Operation'
   /**
-   * Operation identifier, usually from OpenAPI `operationId`.
+   * Stable identifier for the operation.
    */
   operationId: string
   /**
    * Group labels for the operation.
-   * Usually copied from OpenAPI `tags`.
    */
   tags: Array<string>
   /**
@@ -58,7 +57,7 @@ type OperationNodeBase = BaseNode & {
 }
 
 /**
- * Operation served over HTTP/REST (OpenAPI). `method` and `path` are guaranteed.
+ * Operation served over HTTP. `method` and `path` are guaranteed.
  *
  * @example
  * ```ts
@@ -84,7 +83,7 @@ export type HttpOperationNode = OperationNodeBase & {
    */
   method: HttpMethod
   /**
-   * OpenAPI-style path string, for example `/pets/{petId}`, with `{param}` notation preserved.
+   * Path string, for example `/pets/{petId}`, with `{param}` notation preserved.
    */
   path: string
 }

--- a/packages/ast/src/nodes/parameter.ts
+++ b/packages/ast/src/nodes/parameter.ts
@@ -6,7 +6,7 @@ import type { SchemaNode } from './schema.ts'
 export type ParameterLocation = 'path' | 'query' | 'header' | 'cookie'
 
 /**
- * OpenAPI parameter serialization style, controlling how a parameter value is rendered into the URL.
+ * Parameter serialization style, controlling how a parameter value is rendered into the request.
  */
 export type ParameterStyle = 'matrix' | 'label' | 'form' | 'simple' | 'spaceDelimited' | 'pipeDelimited' | 'deepObject'
 
@@ -43,13 +43,13 @@ export type ParameterNode = BaseNode & {
    */
   required: boolean
   /**
-   * OpenAPI serialization style. Absent when the spec omits it, leaving consumers to apply the
-   * per-location default (`simple` for `path` / `header`, `form` for `query` / `cookie`).
+   * Serialization style. Absent when the source omits it, leaving consumers to apply the
+   * per-location default.
    */
   style?: ParameterStyle
   /**
-   * Whether array and object values expand into separate values. Absent when the spec omits it,
-   * leaving consumers to apply the OpenAPI default for the style.
+   * Whether array and object values expand into separate values. Absent when the source omits it,
+   * leaving consumers to apply the default for the style.
    */
   explode?: boolean
 }

--- a/packages/ast/src/nodes/parameter.ts
+++ b/packages/ast/src/nodes/parameter.ts
@@ -6,6 +6,11 @@ import type { SchemaNode } from './schema.ts'
 export type ParameterLocation = 'path' | 'query' | 'header' | 'cookie'
 
 /**
+ * OpenAPI parameter serialization style, controlling how a parameter value is rendered into the URL.
+ */
+export type ParameterStyle = 'matrix' | 'label' | 'form' | 'simple' | 'spaceDelimited' | 'pipeDelimited' | 'deepObject'
+
+/**
  * AST node representing one operation parameter.
  *
  * @example
@@ -37,6 +42,16 @@ export type ParameterNode = BaseNode & {
    * Whether the parameter is required.
    */
   required: boolean
+  /**
+   * OpenAPI serialization style. Absent when the spec omits it, leaving consumers to apply the
+   * per-location default (`simple` for `path` / `header`, `form` for `query` / `cookie`).
+   */
+  style?: ParameterStyle
+  /**
+   * Whether array and object values expand into separate values. Absent when the spec omits it,
+   * leaving consumers to apply the OpenAPI default for the style.
+   */
+  explode?: boolean
 }
 
 type UserParameterNode = Pick<ParameterNode, 'name' | 'in' | 'schema'> & Partial<Omit<ParameterNode, 'kind' | 'name' | 'in' | 'schema'>>

--- a/packages/ast/src/nodes/schema.ts
+++ b/packages/ast/src/nodes/schema.ts
@@ -148,7 +148,7 @@ type SchemaNodeBase = BaseNode & {
    */
   default?: unknown
   /**
-   * Example values (OAS 3.1 `examples` array).
+   * Example values from an `examples` array.
    */
   examples?: Array<unknown>
   /**
@@ -276,7 +276,7 @@ export type UnionSchemaNode = CompositeSchemaNodeBase & {
    */
   type: 'union'
   /**
-   * Discriminator property name from OpenAPI `discriminator.propertyName`.
+   * Discriminator property name for a polymorphic union.
    */
   discriminatorPropertyName?: string
   /**
@@ -385,7 +385,7 @@ export type RefSchemaNode = SchemaNodeBase & {
   pattern?: string
   /**
    * The fully-parsed schema this ref resolves to, so its structure (`primitive`, `properties`)
-   * can be read without following the reference. Populated during OAS parsing when the
+   * can be read without following the reference. Populated during parsing when the
    * definition resolves, `null` when it can't or the ref is circular, and `undefined` when
    * resolution has not been attempted.
    */
@@ -528,7 +528,7 @@ export type ScalarSchemaNode = SchemaNodeBase & {
 
 /**
  * URL schema node.
- * Can include an OpenAPI-style path template for template literal types.
+ * Can include a path template for template literal types.
  *
  * @example
  * ```ts
@@ -541,7 +541,7 @@ export type UrlSchemaNode = SchemaNodeBase & {
    */
   type: 'url'
   /**
-   * OpenAPI-style path template, for example, `'/pets/{petId}'`.
+   * Path template, for example, `'/pets/{petId}'`.
    */
   path?: string
   /**


### PR DESCRIPTION
## Capture parameter `style` / `explode` and keep the AST spec-neutral

The OpenAPI adapter dropped each parameter's `style` and `explode` during parsing, so generators had no way to honor anything past the default `simple` path serialization. This keeps that metadata on the AST so client generators can serialize a parameter the way its spec declares.

### Changes
- **`@kubb/ast`**: `ParameterNode` gains optional `style` (new exported `ParameterStyle` type) and `explode`.
- **`@kubb/adapter-oas`**: `parseParameter` reads `style` / `explode` from each parameter object, only when present, so absent stays `undefined` and parsed output for specs that omit them is unchanged.
- **`@kubb/ast` doc comments** no longer name OpenAPI / OAS / Swagger, so the package documents a source-agnostic model. These are comment-only edits with no type or behavior change.

### Tests
Parser tests assert `style` / `explode` are captured for path and query params and stay `undefined` when the spec omits them. `test`, `typecheck`, and `lint` pass for `@kubb/ast` and `@kubb/adapter-oas`, with no snapshot churn.

### Why
This is the foundation for full parameter serialization. The runtime in [kubb-labs/plugins#532](https://github.com/kubb-labs/plugins/pull/532) already honors `simple` / `label` / `matrix` for paths and `form` / `spaceDelimited` / `pipeDelimited` / `deepObject` for queries, plus header and cookie serialization. Once this ships in a beta and the catalog bumps, the client generators fill those metadata fields straight from the spec. A follow-up will also capture the request-body `encoding` object so urlencoded body serialization can wire through the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VPKfbKpWmr3dAKh543ahre