### PR TITLE
fix(adapter-oas): resolve collision-renamed schema refs through nameMapping

### DIFF
--- a/.changeset/fix-collision-renamed-ref-imports.md
+++ b/.changeset/fix-collision-renamed-ref-imports.md
@@ -1,0 +1,7 @@
+---
+"@kubb/adapter-oas": patch
+---
+
+Fix `getImports` importing the un-renamed name for collision-renamed schemas.
+
+When two component schemas collide (case-insensitively, or across sources like `schemas` vs `requestBodies`), the schema is renamed (`Order` -> `OrderSchema`) and recorded in `nameMapping`. `getImports` looked that map up with the bare ref segment (`Order`), but its keys are full component pointers (`#/components/schemas/Order`), so every lookup missed and a `$ref` to a renamed schema imported the original name and path — a file the writer never emitted (`TS2307`). The lookup now uses the full `$ref`, so importers stay in sync with the renamed files.

--- a/packages/adapter-oas/src/adapter.test.ts
+++ b/packages/adapter-oas/src/adapter.test.ts
@@ -143,4 +143,41 @@ describe('adapterOas.getImports', () => {
 
     expect(imports).toMatchObject([{ kind: 'Import', name: ['PetType'], path: './pet.ts' }])
   })
+
+  it('resolves a collision-renamed schema ref to the renamed name', async () => {
+    const adapter = adapterOas()
+
+    // `Order` exists in both `schemas` and `requestBodies`, so the schema is renamed to `OrderSchema`.
+    // A `$ref` to it must import `OrderSchema`, not the bare `Order` (whose file is never emitted).
+    await adapter.parse({
+      type: 'data',
+      data: {
+        openapi: '3.0.0',
+        info: { title: 'test', version: '1.0.0' },
+        paths: {},
+        components: {
+          schemas: {
+            Order: { type: 'object', properties: { id: { type: 'string' } } },
+          },
+          requestBodies: {
+            Order: { content: { 'application/json': { schema: { type: 'object', properties: { userId: { type: 'string' } } } } } },
+          },
+        },
+      },
+    })
+
+    const imports = adapter.getImports(
+      ast.factory.createSchema({
+        type: 'ref',
+        ref: '#/components/schemas/Order',
+        name: 'Order',
+      }),
+      (schemaName) => ({
+        name: schemaName,
+        path: `./${schemaName}.ts`,
+      }),
+    )
+
+    expect(imports).toMatchObject([{ kind: 'Import', name: ['OrderSchema'], path: './OrderSchema.ts' }])
+  })
 })

--- a/packages/adapter-oas/src/adapter.ts
+++ b/packages/adapter-oas/src/adapter.ts
@@ -184,8 +184,11 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
           const schemaRef = narrowSchema(schemaNode, 'ref')
           if (!schemaRef?.ref) return null
 
-          const rawName = extractRefName(schemaRef.ref)
-          const schemaName = nameMapping.get(rawName) ?? rawName
+          // `nameMapping` is keyed by the full component pointer (e.g. `#/components/schemas/Order`),
+          // so look it up with the raw `$ref`. Collision-renamed schemas (`Order` -> `OrderSchema`)
+          // only resolve through this map; falling back to the bare segment would import a file that
+          // the writer never emitted.
+          const schemaName = nameMapping.get(schemaRef.ref) ?? extractRefName(schemaRef.ref)
           const result = resolve(schemaName)
           if (!result) return null
 


### PR DESCRIPTION
## 🎯 Changes

This is the root-cause fix for **bug class 2** of kubb-labs/plugins#567 — *dangling cross-file imports on case-colliding schema names (TS2307)*.

When two component schemas collide — case-insensitively (`Order` vs `order`) or across sources (`schemas/Order` vs `requestBodies/Order`) — `getSchemas` renames the loser (`Order` → `OrderSchema`) and records the rename in `nameMapping`. That map is keyed by the **full component pointer**:

```ts
nameMapping.get('#/components/schemas/Order') // 'OrderSchema'
```

But `getImports` looked it up with the **bare ref segment**:

```ts
const rawName = extractRefName(schemaRef.ref) // 'Order'
const schemaName = nameMapping.get(rawName) ?? rawName // miss → 'Order'
```

So every lookup missed, and a `$ref` to a renamed schema imported the original name and path — pointing at a file the writer never emitted (`import { snapshotsSchema } from './snapshotsSchema.ts'` while the file is `snapshotsSchemaSchema.ts`). That single miss accounts for the bulk of the failures in the issue (238 of digitalocean's 246 errors are `TS2307`).

The lookup now uses the full `$ref`, so importers stay in sync with the renamed files:

```ts
const schemaName = nameMapping.get(schemaRef.ref) ?? extractRefName(schemaRef.ref)
```

### Scope / follow-up

This fixes the **import** half of bug class 2 (the import name and path, resolved by the shared `getImports` chokepoint that every plugin uses). The **in-body type reference** is printed separately by `plugin-ts` / `plugin-zod` (`printerTs` / `printerZod`'s `ref` handler still derives the name from `extractRefName(node.ref)` without consulting `nameMapping`), so a companion change in `kubb-labs/plugins` is needed to fully clear the colliding specs. That change is release-coupled: the plugins repo consumes the published `@kubb/adapter-oas`, and its e2e snapshots regenerate live, so it lands once this patch ships and the plugins catalog bumps.

## ✅ Checklist

- [x] I have followed the steps in the Contributing guide.
- [x] I have tested this code locally with `pnpm run test` (`@kubb/adapter-oas` suite: 492 passing, plus a new `getImports` collision test; typecheck and lint clean).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a changeset (`@kubb/adapter-oas`: patch).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsZqk6FCUt1Ewsdbr5pmLG

---
_Generated by [Claude Code](https://claude.ai/code/session_01AsZqk6FCUt1Ewsdbr5pmLG)_