### PR TITLE
fix(adapter-oas): resolve collision-renamed component imports

### DIFF
--- a/.changeset/adapter-oas-name-collision-mapping.md
+++ b/.changeset/adapter-oas-name-collision-mapping.md
@@ -1,0 +1,9 @@
+---
+'@kubb/adapter-oas': patch
+---
+
+Resolve imports to the renamed target when a component name collides.
+
+When two components share a name across sections or by case (e.g. `#/components/schemas/Order` and `#/components/requestBodies/Order`), `getSchemas` disambiguates them (`OrderSchema`, `OrderRequest`) and records the rename in a `nameMapping` keyed by the full `$ref` path. `getImports` looked the map up by the short ref name, always missed, and emitted an import for the un-disambiguated name — a dangling import that did not match the generated file.
+
+`getImports` now resolves the collision-renamed name via `nameMapping.get(schemaRef.ref)` before falling back to the short ref name, so the import targets the file that was actually generated. The map is already exposed on `adapter.options.nameMapping` for plugins that resolve a reference's type/schema name through it.

--- a/packages/adapter-oas/src/adapter.test.ts
+++ b/packages/adapter-oas/src/adapter.test.ts
@@ -143,4 +143,31 @@ describe('adapterOas.getImports', () => {
 
     expect(imports).toMatchObject([{ kind: 'Import', name: ['PetType'], path: './pet.ts' }])
   })
+
+  it('resolves a $ref to a collision-renamed component name', async () => {
+    const adapter = adapterOas()
+
+    // schemas/Order and requestBodies/Order collide, so getSchemas renames the schema OrderSchema.
+    await adapter.parse({
+      type: 'data',
+      data: {
+        openapi: '3.0.0',
+        info: { title: 'test', version: '1.0.0' },
+        paths: {},
+        components: {
+          schemas: { Order: { type: 'object', properties: { id: { type: 'string' } } } },
+          requestBodies: {
+            Order: { description: 'body', content: { 'application/json': { schema: { type: 'object' } } } },
+          },
+        },
+      },
+    })
+
+    const imports = adapter.getImports(
+      ast.factory.createSchema({ type: 'ref', ref: '#/components/schemas/Order', name: 'Order' }),
+      (schemaName) => ({ name: schemaName, path: `./${schemaName}.ts` }),
+    )
+
+    expect(imports).toMatchObject([{ kind: 'Import', name: ['OrderSchema'], path: './OrderSchema.ts' }])
+  })
 })

--- a/packages/adapter-oas/src/adapter.ts
+++ b/packages/adapter-oas/src/adapter.ts
@@ -184,8 +184,9 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
           const schemaRef = narrowSchema(schemaNode, 'ref')
           if (!schemaRef?.ref) return null
 
-          const rawName = extractRefName(schemaRef.ref)
-          const schemaName = nameMapping.get(rawName) ?? rawName
+          // `nameMapping` is keyed by the full `$ref` path, so look up the collision-resolved name
+          // by `schemaRef.ref` first; fall back to the short ref name for refs with no mapping.
+          const schemaName = nameMapping.get(schemaRef.ref) ?? extractRefName(schemaRef.ref)
           const result = resolve(schemaName)
           if (!result) return null
 


### PR DESCRIPTION
## 🎯 Changes

When two components share a name across sections or by case (for example `#/components/schemas/Order` and `#/components/requestBodies/Order`, or `Variant`/`variant`), `getSchemas` disambiguates them into distinct emitted files (`OrderSchema`, `OrderRequest`, `Variant2`) and records each rename in a `nameMapping` keyed by the **full `$ref` path** (already exposed on `adapter.options.nameMapping`).

`getImports` looked the map up by the **short** ref name (`extractRefName(...)`), so it always missed and emitted an import for the un-disambiguated name — a dangling import that did not match the file actually generated (`TS2307` in downstream output).

`getImports` now resolves the collision-renamed name via `nameMapping.get(schemaRef.ref)` (the full `$ref` path) before falling back to the short ref name, so the import targets the generated file. One-line root-cause fix; no new public API.

This is the import half of a coordinated fix. The plugin printers (plugin-ts / plugin-zod / plugin-faker) read the same `adapter.options.nameMapping` to resolve the type/schema **reference** name; that side lives in the paired plugins-repo PR ([kubb-labs/plugins#579](https://github.com/kubb-labs/plugins/pull/579)).

Verified end-to-end with a linked build against the `caseSensitivity` and `digitalocean` fixtures: the previously dangling `import { Order } from './Order.ts'` now resolves to `OrderSchema`, taking the strict-typecheck collision errors (240 across the two specs) to 0.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test` (adapter-oas suite green, new collision test passing).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CAfw3gfcB2XXbCuuQVrvLB