### PR TITLE
feat(ast): let printer node overrides call the replaced handler via this.base

### DIFF
--- a/.changeset/ast-printer-base.md
+++ b/.changeset/ast-printer-base.md
@@ -1,0 +1,17 @@
+---
+"@kubb/ast": minor
+---
+
+Let a printer node override reuse the handler it replaces. A printer builder can now pass user handlers through the new `overrides` field instead of spreading them into `nodes`, and an override can call `this.base(node)` to get the built-in output and wrap it:
+
+```ts
+pluginZod({
+  printer: {
+    nodes: {
+      object(node) {
+        return `${this.base(node)}.openapi(${JSON.stringify({ description: node.description })})`
+      },
+    },
+  },
+})
+```

--- a/.changeset/parser-md-default-jsdoc.md
+++ b/.changeset/parser-md-default-jsdoc.md
@@ -1,0 +1,5 @@
+---
+"@kubb/parser-md": patch
+---
+
+Correct the `parserMd` JSDoc: the parser runs by default next to `parserTs` and `parserTsx` instead of being opt-in, and a custom `parsers` array replaces the default set.

--- a/packages/ast/src/createPrinter.test.ts
+++ b/packages/ast/src/createPrinter.test.ts
@@ -128,6 +128,100 @@ describe('createPrinter', () => {
     expect(zodPrinter().print(node)).toBe('z.union([z.string(), z.number()])')
   })
 
+  it('dispatches overrides before nodes handlers', () => {
+    type P = PrinterFactoryOptions<'zod', object, string>
+
+    const zodPrinter = createPrinter<P>(() => ({
+      name: 'zod',
+      options: {},
+      nodes: {
+        string() {
+          return 'z.string()'
+        },
+      },
+      overrides: {
+        string() {
+          return 'z.string().trim()'
+        },
+      },
+    }))
+
+    expect(zodPrinter().print(createSchema({ type: 'string' }))).toBe('z.string().trim()')
+  })
+
+  it('lets an override wrap the replaced handler via this.base()', () => {
+    type P = PrinterFactoryOptions<'zod', object, string>
+
+    const zodPrinter = createPrinter<P>(() => ({
+      name: 'zod',
+      options: {},
+      nodes: {
+        string() {
+          return 'z.string()'
+        },
+      },
+      overrides: {
+        string(node) {
+          return `${this.base(node)}.describe('wrapped')`
+        },
+      },
+    }))
+
+    expect(zodPrinter().print(createSchema({ type: 'string' }))).toBe("z.string().describe('wrapped')")
+  })
+
+  it('dispatches nested nodes through overrides when a base handler recurses', () => {
+    type P = PrinterFactoryOptions<'zod', object, string>
+
+    const zodPrinter = createPrinter<P>(() => ({
+      name: 'zod',
+      options: {},
+      nodes: {
+        string() {
+          return 'z.string()'
+        },
+        object(node) {
+          const props = node.properties.map((p) => `${p.name}: ${this.transform(p.schema)}`).join(', ')
+          return `z.object({ ${props} })`
+        },
+      },
+      overrides: {
+        string(node) {
+          return `${this.base(node)}.min(1)`
+        },
+      },
+    }))
+
+    const node = createSchema({
+      type: 'object',
+      properties: [
+        createProperty({
+          name: 'label',
+          schema: createSchema({ type: 'string' }),
+        }),
+      ],
+    })
+
+    expect(zodPrinter().print(node)).toBe('z.object({ label: z.string().min(1) })')
+  })
+
+  it('returns null from this.base() when no base handler exists for the type', () => {
+    type P = PrinterFactoryOptions<'zod', object, string>
+
+    const zodPrinter = createPrinter<P>(() => ({
+      name: 'zod',
+      options: {},
+      nodes: {},
+      overrides: {
+        string(node) {
+          return this.base(node) ?? 'z.string()'
+        },
+      },
+    }))
+
+    expect(zodPrinter().print(createSchema({ type: 'string' }))).toBe('z.string()')
+  })
+
   it('infers the Printer type correctly', () => {
     type P = PrinterFactoryOptions<'zod', object, string>
     const zodPrinter = createPrinter<P>(() => ({

--- a/packages/ast/src/createPrinter.ts
+++ b/packages/ast/src/createPrinter.ts
@@ -20,6 +20,13 @@ type PrinterHandlerContext<TOutput, TOptions extends object> = {
    */
   transform: (node: SchemaNode) => TOutput | null
   /**
+   * Run the printer's built-in handler for the node, ignoring any override for its type.
+   * Inside an override, `this.base(node)` returns what the printer would have emitted,
+   * so the override can wrap it instead of re-implementing the handler. Nested nodes
+   * still dispatch through the overrides.
+   */
+  base: (node: SchemaNode) => TOutput | null
+  /**
    * Options for this printer instance.
    */
   options: TOptions
@@ -141,6 +148,14 @@ type PrinterBuilder<T extends PrinterFactoryOptions> = (options: T['options']) =
     [K in SchemaType]: PrinterHandler<T['output'], T['options'], K>
   }>
   /**
+   * User-supplied handler overrides. An override wins over the matching `nodes` handler,
+   * and can call `this.base(node)` to reuse the handler it replaced. Pass overrides here
+   * instead of spreading them into `nodes`, otherwise `this.base` cannot find the original.
+   */
+  overrides?: Partial<{
+    [K in SchemaType]: PrinterHandler<T['output'], T['options'], K>
+  }>
+  /**
    * Optional root-level print override. When provided, becomes the public `printer.print`.
    * Use `this.transform(node)` inside this function to dispatch to the node-level handlers (`nodes`),
    * not the override itself, so recursion is safe.
@@ -159,6 +174,8 @@ type PrinterBuilder<T extends PrinterFactoryOptions> = (options: T['options']) =
  * - `options` stored on the returned printer instance.
  * - `nodes` map of `SchemaType` → handler. Handlers return the rendered
  *   output (a string, a TypeScript AST node, ...) for that schema type.
+ * - `overrides` (optional), user-supplied handlers that win over `nodes`.
+ *   An override can call `this.base(node)` to reuse the handler it replaced.
  * - `print` (optional), top-level override exposed as `printer.print`.
  *   Use `this.transform(node)` inside it to dispatch to `nodes` recursively.
  *
@@ -188,11 +205,18 @@ type PrinterBuilder<T extends PrinterFactoryOptions> = (options: T['options']) =
  */
 export function createPrinter<T extends PrinterFactoryOptions = PrinterFactoryOptions>(build: PrinterBuilder<T>): (options?: T['options']) => Printer<T> {
   return (options) => {
-    const { name, options: resolvedOptions, nodes, print: printOverride } = build(options ?? ({} as T['options']))
+    const { name, options: resolvedOptions, nodes, overrides, print: printOverride } = build(options ?? ({} as T['options']))
+    const merged = overrides ? { ...nodes, ...overrides } : nodes
 
     const context = {
       options: resolvedOptions,
       transform: (node: SchemaNode): T['output'] | null => {
+        const handler = merged[node.type]
+        if (!handler) return null
+
+        return (handler as (this: typeof context, node: SchemaNode) => T['output'] | null).call(context, node)
+      },
+      base: (node: SchemaNode): T['output'] | null => {
         const handler = nodes[node.type]
         if (!handler) return null
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -66,7 +66,7 @@
     "@tmcp/transport-stdio": "^0.4.3",
     "jiti": "^2.7.0",
     "tmcp": "^1.19.4",
-    "valibot": "^1.4.1"
+    "valibot": "^1.4.2"
   },
   "devDependencies": {
     "@internals/shared": "workspace:*",

--- a/packages/parser-md/src/parserMd.ts
+++ b/packages/parser-md/src/parserMd.ts
@@ -17,20 +17,23 @@ export type MdMeta = {
  * markdown (separated by blank lines) and, when `file.meta.frontmatter` is set,
  * prepends a YAML frontmatter envelope produced by `parserMd.print`.
  *
- * Add to the `parsers` array on `defineConfig` to opt in. `parserTs` keeps
- * handling `.ts`/`.js` files, `parserMd` claims `.md`/`.markdown`.
+ * Runs by default next to `parserTs` and `parserTsx`. Add it to a custom
+ * `parsers` array yourself, since a custom list replaces the default set.
+ * `parserTs` keeps handling `.ts`/`.js` files, `parserMd` claims
+ * `.md`/`.markdown`.
  *
  * @example
  * ```ts
  * import { defineConfig } from 'kubb'
  * import { adapterOas } from '@kubb/adapter-oas'
  * import { parserMd } from '@kubb/parser-md'
+ * import { parserTs, parserTsx } from '@kubb/parser-ts'
  *
  * export default defineConfig({
  *   input: { path: './petStore.yaml' },
  *   output: { path: './src/gen' },
  *   adapter: adapterOas(),
- *   parsers: [parserMd],
+ *   parsers: [parserTs, parserTsx, parserMd],
  *   plugins: [],
  * })
  * ```

--- a/packages/unplugin-kubb/package.json
+++ b/packages/unplugin-kubb/package.json
@@ -115,7 +115,7 @@
     "@kubb/core": "workspace:*",
     "@kubb/parser-ts": "workspace:*",
     "@kubb/plugin-barrel": "workspace:*",
-    "unplugin": "^3.2.0"
+    "unplugin": "^3.3.0"
   },
   "devDependencies": {
     "@farmfe/core": "^1.7.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,7 +230,7 @@ importers:
         version: link:../core
       '@tmcp/adapter-valibot':
         specifier: ^0.1.6
-        version: 0.1.6(tmcp@1.19.4(typescript@6.0.3))(valibot@1.4.1(typescript@6.0.3))
+        version: 0.1.6(tmcp@1.19.4(typescript@6.0.3))(valibot@1.4.2(typescript@6.0.3))
       '@tmcp/transport-stdio':
         specifier: ^0.4.3
         version: 0.4.3(tmcp@1.19.4(typescript@6.0.3))
@@ -241,8 +241,8 @@ importers:
         specifier: ^1.19.4
         version: 1.19.4(typescript@6.0.3)
       valibot:
-        specifier: ^1.4.1
-        version: 1.4.1(typescript@6.0.3)
+        specifier: ^1.4.2
+        version: 1.4.2(typescript@6.0.3)
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -327,8 +327,8 @@ importers:
         specifier: workspace:*
         version: link:../plugin-barrel
       unplugin:
-        specifier: ^3.2.0
-        version: 3.2.0(@farmfe/core@1.7.11(@types/node@26.0.1))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.108.1(esbuild@0.28.1))
+        specifier: ^3.3.0
+        version: 3.3.0(@farmfe/core@1.7.11(@types/node@26.0.1))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.108.1(esbuild@0.28.1))
     devDependencies:
       '@farmfe/core':
         specifier: ^1.7.11
@@ -3122,8 +3122,8 @@ packages:
     resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
     engines: {node: '>=18.12.0'}
 
-  unplugin@3.2.0:
-    resolution: {integrity: sha512-6nGlT7EHsS+tTcTdAkYFqXIUwDrMJyJvHFNYGSr4x2/2ySIcV4f5e1RAJUeDyfOJPR8TF0auE8l+82PLhKjqsA==}
+  unplugin@3.3.0:
+    resolution: {integrity: sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       '@farmfe/core': '*'
@@ -3174,6 +3174,14 @@ packages:
 
   valibot@1.4.1:
     resolution: {integrity: sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  valibot@1.4.2:
+    resolution: {integrity: sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -4175,12 +4183,12 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tmcp/adapter-valibot@0.1.6(tmcp@1.19.4(typescript@6.0.3))(valibot@1.4.1(typescript@6.0.3))':
+  '@tmcp/adapter-valibot@0.1.6(tmcp@1.19.4(typescript@6.0.3))(valibot@1.4.2(typescript@6.0.3))':
     dependencies:
       '@standard-schema/spec': 1.1.0
-      '@valibot/to-json-schema': 1.7.1(valibot@1.4.1(typescript@6.0.3))
+      '@valibot/to-json-schema': 1.7.1(valibot@1.4.2(typescript@6.0.3))
       tmcp: 1.19.4(typescript@6.0.3)
-      valibot: 1.4.1(typescript@6.0.3)
+      valibot: 1.4.2(typescript@6.0.3)
 
   '@tmcp/transport-stdio@0.4.3(tmcp@1.19.4(typescript@6.0.3))':
     dependencies:
@@ -4242,9 +4250,9 @@ snapshots:
 
   '@types/ua-parser-js@0.7.39': {}
 
-  '@valibot/to-json-schema@1.7.1(valibot@1.4.1(typescript@6.0.3))':
+  '@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3))':
     dependencies:
-      valibot: 1.4.1(typescript@6.0.3)
+      valibot: 1.4.2(typescript@6.0.3)
 
   '@vitest/coverage-v8@4.1.9(vitest@4.1.9)':
     dependencies:
@@ -5890,7 +5898,7 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  unplugin@3.2.0(@farmfe/core@1.7.11(@types/node@26.0.1))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.108.1(esbuild@0.28.1)):
+  unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@26.0.1))(esbuild@0.28.1)(rolldown@1.1.3)(rollup@4.62.2)(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.108.1(esbuild@0.28.1)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.4
@@ -5922,6 +5930,10 @@ snapshots:
   uri-template-matcher@1.1.2: {}
 
   valibot@1.4.1(typescript@6.0.3):
+    optionalDependencies:
+      typescript: 6.0.3
+
+  valibot@1.4.2(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
 


### PR DESCRIPTION
## 🎯 Changes

A printer node override previously replaced the built-in handler for that schema type with no way to reuse it: `this.transform` dispatches back into the merged handler map, so "default output plus a wrapper" meant re-implementing the handler (impractical for `object`). This blocked replacing plugin-zod's `wrapOutput` option with printer overrides.

`createPrinter` now accepts an `overrides` field on the builder return next to `nodes`. Handlers in `overrides` win over `nodes`, and every handler's context gains `base(node)`, which runs the built-in handler for the node while nested nodes still dispatch through the overrides:

```ts
printer: {
  nodes: {
    object(node) {
      return `${this.base(node)}.openapi(${JSON.stringify({ description: node.description })})`
    },
  },
}
```

Backward compatible: builders that keep spreading user handlers into `nodes` behave exactly as before (`this.base` then sees the merged handler). The companion change adopting this in `@kubb/plugin-zod` (removing `wrapOutput`) lands in kubb-labs/plugins on the same branch name.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ue7brDb41jzLRK9EWtU4Ep

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ue7brDb41jzLRK9EWtU4Ep)_