### PR TITLE
ci: pin GitHub Actions to node 22.22.3

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
         with:
-          node-version: '22'
+          node-version: '22.22.3'
 
       - name: Fix formatting
         run: pnpm run format

--- a/.github/workflows/changeset-format.yml
+++ b/.github/workflows/changeset-format.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
         with:
-          node-version: '22'
+          node-version: '22.22.3'
 
       - name: Format
         run: pnpm run format

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
         with:
-          node-version: '22'
+          node-version: '22.22.3'
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
         with:
-          node-version: '22'
+          node-version: '22.22.3'
 
       - name: Build
         run: pnpm run build
@@ -49,7 +49,7 @@ jobs:
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
         with:
-          node-version: '22'
+          node-version: '22.22.3'
 
       - name: Build
         run: pnpm run build
@@ -74,7 +74,7 @@ jobs:
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
         with:
-          node-version: '22'
+          node-version: '22.22.3'
 
       - name: Build
         run: pnpm run build
@@ -104,7 +104,7 @@ jobs:
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
         with:
-          node-version: '22'
+          node-version: '22.22.3'
 
       - name: Linting
         env:
@@ -129,7 +129,7 @@ jobs:
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
         with:
-          node-version: '22'
+          node-version: '22.22.3'
 
       - name: Build
         run: pnpm run build
@@ -154,7 +154,7 @@ jobs:
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
         with:
-          node-version: '22'
+          node-version: '22.22.3'
 
       - name: Build
         run: pnpm run build
@@ -200,7 +200,7 @@ jobs:
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
         with:
-          node-version: '22'
+          node-version: '22.22.3'
 
       - name: Report compressed bundle size
         uses: preactjs/compressed-size-action@66325aad6443cb7cf89c4bfcd414aea2367cda94 # v2
@@ -226,7 +226,7 @@ jobs:
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@8508e66e6014b9ca1416591bc20791027b6ccf5c # main
         with:
-          node-version: '22'
+          node-version: '22.22.3'
 
       - name: Setup Bun
         run: |


### PR DESCRIPTION
## 🎯 Changes

Pin the `node-version` used by `actions/setup-node` in every workflow to `22.22.3` instead of the floating `22` tag, so CI runs a consistent, exact Node version.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVcqp7M2DJvuFrpMY8NULD)_