### PR TITLE
test: cover anonymous security alternatives

### DIFF
--- a/packages/adapter-oas/src/factory.test.ts
+++ b/packages/adapter-oas/src/factory.test.ts
@@ -154,4 +154,35 @@ describe('validateDocument', () => {
   it('throws when throwOnError is enabled', async () => {
     await expect(validateDocument(invalidSchema, { throwOnError: true })).rejects.toThrow()
   })
+
+  it('accepts anonymous security alternatives', async () => {
+    await expect(
+      validateDocument(
+        {
+          openapi: '3.1.0',
+          info: { title: 'Optional Security API', version: '1.0.0' },
+          paths: {
+            '/public-or-keyed': {
+              get: {
+                security: [{ ApiKeyAuth: [] }, {}],
+                responses: {
+                  default: { description: 'ok' },
+                },
+              },
+            },
+          },
+          components: {
+            securitySchemes: {
+              ApiKeyAuth: {
+                type: 'apiKey',
+                in: 'header',
+                name: 'X-API-Key',
+              },
+            },
+          },
+        } as unknown as Document,
+        { throwOnError: true },
+      ),
+    ).resolves.toBeUndefined()
+  })
 })


### PR DESCRIPTION
## Changes

- Add adapter validation coverage for OpenAPI 3.1 anonymous security alternatives.
- The fixture combines an API key requirement with `{}` to represent optional auth.

## Checklist

- [x] I have followed the steps in the Contributing guide.
- [ ] I have tested this code locally with `pnpm run test`.

Focused validation:

- Adapter factory Vitest run passed locally.

## Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [ ] This change is for the docs.

Test-only change, no changeset.
