### PR TITLE
fix(core): guard resolveOptions weak map cache against non-object options

### DIFF
--- a/.changeset/core-resolve-options-weak-map-guard.md
+++ b/.changeset/core-resolve-options-weak-map-guard.md
@@ -1,0 +1,5 @@
+---
+'@kubb/core': patch
+---
+
+Fix `resolveOptions` throwing `Invalid value used as weak map key` when a plugin's `options` is falsy but not `null`/`undefined` (for example `false`), such as a plugin re-instantiated by an external merge (Kubb Studio, custom tooling) with an unexpected options value. The memoization cache now only keys by `options` when it's actually an object, falling back to a direct (uncached) resolve otherwise.

--- a/packages/core/src/defineResolver.test.ts
+++ b/packages/core/src/defineResolver.test.ts
@@ -1,5 +1,5 @@
 import { camelCase } from '@internals/utils'
-import type { InputMeta } from '@kubb/ast'
+import { ast, type InputMeta } from '@kubb/ast'
 import { describe, expect, it } from 'vitest'
 import { defaultResolveBanner, defaultResolveFile, defaultResolveFooter, defaultResolvePath, defineResolver } from './defineResolver.ts'
 import type { Config, Resolver, ResolverContext } from './types.ts'
@@ -72,11 +72,13 @@ describe('defineResolver', () => {
       farewell: (name: string) => name,
     }))
 
+    const node = ast.factory.createFile({ baseName: 'pet.ts', path: 'src/pet.ts' })
+
     // A re-instantiated plugin can hand back a falsy-but-not-nullish `options` (e.g. `false`).
     // `resolveOptions` caches by `options` identity in a `WeakMap`, which only accepts object
     // keys, so this must fall back to computing directly instead of throwing.
-    expect(() => resolver.resolveOptions({} as never, { options: false as never })).not.toThrow()
-    expect(resolver.resolveOptions({} as never, { options: false as never })).toBe(false)
+    expect(() => resolver.resolveOptions<boolean>(node, { options: false })).not.toThrow()
+    expect(resolver.resolveOptions<boolean>(node, { options: false })).toBe(false)
   })
 })
 

--- a/packages/core/src/defineResolver.test.ts
+++ b/packages/core/src/defineResolver.test.ts
@@ -63,6 +63,21 @@ describe('defineResolver', () => {
     expect(resolver.default('hello')).toBe('HELLO')
     expect(resolver.greet('world')).toBe('WORLD')
   })
+
+  it('resolveOptions does not throw when options is not an object', () => {
+    const resolver = defineResolver<TestPluginFactory>(() => ({
+      pluginName: 'test',
+      name: 'test',
+      greet: (name: string) => name,
+      farewell: (name: string) => name,
+    }))
+
+    // A re-instantiated plugin can hand back a falsy-but-not-nullish `options` (e.g. `false`).
+    // `resolveOptions` caches by `options` identity in a `WeakMap`, which only accepts object
+    // keys, so this must fall back to computing directly instead of throwing.
+    expect(() => resolver.resolveOptions({} as never, { options: false as never })).not.toThrow()
+    expect(resolver.resolveOptions({} as never, { options: false as never })).toBe(false)
+  })
 })
 
 describe('defaultResolvePath', () => {

--- a/packages/core/src/defineResolver.ts
+++ b/packages/core/src/defineResolver.ts
@@ -356,11 +356,18 @@ function computeOptions<TOptions>(
 }
 
 function defaultResolveOptions<TOptions>(node: Node, { options, exclude = [], include, override = [] }: ResolveOptionsContext<TOptions>): TOptions | null {
-  const optionsKey = options as object
-  let byOptions = resolveOptionsCache.get(optionsKey)
+  // A plugin's `options` is normally an object, but a re-instantiated plugin (e.g. a
+  // Studio/agent merge) can hand back something falsy-but-not-nullish. `WeakMap` only
+  // accepts object keys, so cache only when `options` actually qualifies; otherwise fall
+  // back to computing directly instead of throwing "Invalid value used as weak map key".
+  if (typeof options !== 'object' || options === null) {
+    return computeOptions(node, options, exclude, include, override)
+  }
+
+  let byOptions = resolveOptionsCache.get(options)
   if (!byOptions) {
     byOptions = new WeakMap()
-    resolveOptionsCache.set(optionsKey, byOptions)
+    resolveOptionsCache.set(options, byOptions)
   }
   const cached = byOptions.get(node)
   if (cached !== undefined) return cached.value as TOptions | null


### PR DESCRIPTION
## 🎯 Changes

Kubb Studio generation could crash with `Invalid value used as weak map key` and produce 0 files. Root cause: `defaultResolveOptions` in `packages/core/src/defineResolver.ts` cast a plugin's `options` to `object` and used it directly as a `WeakMap` key without checking it was actually an object. Any plugin re-instantiated with a falsy-but-not-nullish `options` value (e.g. `false`) — which can happen when an external tool like Kubb Studio's agent merges disk and Studio plugin configs — trips `WeakMap.prototype.set`, which throws for any non-object key.

`resolveOptions` now only uses the memoization cache when `options` is an actual object, falling back to computing directly (uncached) otherwise, instead of crashing.

A companion fix in `kubb-labs/platform` (`mergePlugins`) addresses the specific trigger on the agent side.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RBYwuKgEFgPXgdx9VP25kS)_