### PR TITLE
ci: reuse the Turbo cache in build-dependent jobs + fix Vite 8.1.1 test regression

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -191,6 +191,7 @@ jobs:
       contents: read
       pull-requests: write
     if: github.actor != 'github-actions[bot]' && github.event_name == 'pull_request'
+    needs: build
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/configs/vitest.config.ts
+++ b/configs/vitest.config.ts
@@ -4,6 +4,14 @@ export default defineConfig({
   test: {
     testTimeout: 30_000,
     exclude: ['**/node_modules/**', '**/dist/**', '**/mocks/**', '**/*.bench.ts'],
+    server: {
+      deps: {
+        // Keep the TypeScript compiler external so Vite never runs it through
+        // import-analysis. Its bundle ships a sourceMappingURL without a .map,
+        // which Vite 8.1.1 fails to read.
+        external: ['typescript'],
+      },
+    },
     coverage: {
       exclude: [
         '**/**/plugin.ts', // exclude because we have e2e


### PR DESCRIPTION
## 🎯 Changes

Two CI-health changes so PRs run reliably and reuse the warm Turbo cache.

### 1. Wait on the `build` job to reuse the Turbo cache

Aligns the PR workflow with the platform repo: every job that runs a build should wait on the `build` job so it reuses the warm Turbo cache instead of building from a cold cache in parallel.

The setup action (`kubb-labs/config/.github/setup`) wires up `rharkor/caching-for-turbo`, which backs Turbo's remote cache with the GitHub Actions cache. That cache is shared across jobs in a run, so once the `build` job populates it, downstream jobs get a Turbo cache hit for their build step.

`typecheck`, `tests`, `benchmarks`, `prerelease`, and `bun` already declared `needs: build`. `compressed-size` was the only job that ran a build (via the action's `build-script: 'build'`) without depending on `build`. It now does, so its build of the PR branch is a cache hit.

### 2. Keep `typescript` external in Vitest

`main` (the `update packages` commit) bumped Vite `8.1.0 → 8.1.1`. The newer Vite runs the full `typescript.js` through `import-analysis` in the SSR test pipeline; that bundle ships a `sourceMappingURL` comment without a matching `.js.map`, which Vite 8.1.1 fails to read. Four suites (`parser-ts`, `defineConfig`, `unplugin-kubb`) failed to load as a result.

`configs/vitest.config.ts` now externalizes the TypeScript compiler so it loads natively in the Node test environment instead of being transformed — where it belongs, and forward-compatible with the Vite update.

Verified locally against the CI command: **91 files, 1391 tests passing** (previously 4 suites failed to load).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] No published code changes (CI workflow + test config only, no changeset needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AjAAnmLMBPiKJKZb1RoYa

---
_Generated by [Claude Code](https://claude.ai/code/session_017AjAAnmLMBPiKJKZb1RoYa)_