### PR TITLE
docs(ast): correct README import paths after subpath fold

### DIFF
--- a/.changeset/ast-readme-import-paths.md
+++ b/.changeset/ast-readme-import-paths.md
@@ -1,0 +1,5 @@
+---
+'@kubb/ast': patch
+---
+
+Update the README to match the current export map. The imports table no longer lists the removed `@kubb/ast/utils` and `@kubb/ast/macros` subpaths, the Refs example imports `extractRefName` from the root `@kubb/ast`, and new rows cover the `kubb/kit` namespaces and the flat `kubb/ast` subpath.

--- a/.changeset/ast-readme-import-paths.md
+++ b/.changeset/ast-readme-import-paths.md
@@ -2,4 +2,4 @@
 '@kubb/ast': patch
 ---
 
-Update the README to match the current export map. The imports table no longer lists the removed `@kubb/ast/utils` and `@kubb/ast/macros` subpaths, the Refs example imports `extractRefName` from the root `@kubb/ast`, and new rows cover the `kubb/kit` namespaces and the flat `kubb/ast` subpath.
+Update the README to match the current export map. The imports table no longer lists the removed `@kubb/ast/utils` and `@kubb/ast/macros` subpaths, the Refs example imports `extractRefName` from the root `@kubb/ast`, and new rows cover the `kubb/kit` namespaces and the flat `kubb/ast` subpath. A note now spells out that `@kubb/ast` is internal to the kubb monorepo, so plugins and user code reach the same surface through `kubb/kit` or `kubb/ast`.

--- a/packages/ast/README.md
+++ b/packages/ast/README.md
@@ -28,12 +28,12 @@ Defines the node tree, visitor pattern, factory functions, and type guards used 
 
 ## Imports
 
-| Path                            | Contents                                                                                                |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `@kubb/ast`                     | Runtime: node definitions, guards, visitor, macro engine, string and ref helpers, constants             |
-| `ast.factory` (via `@kubb/ast`) | Node constructors (`createSchema`, `createFile`, and friends), the `ts.factory` analogue                |
-| `@kubb/ast/types`               | Types only: all node interfaces, type aliases, visitor types                                            |
-| `kubb/kit`                      | Re-exports the `ast` and `factory` namespaces, so plugin authors reach the AST without a direct dependency |
+| Path                            | Contents                                                                                                     |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `@kubb/ast`                     | Runtime: node definitions, guards, visitor, macro engine, string and ref helpers, constants                  |
+| `ast.factory` (via `@kubb/ast`) | Node constructors (`createSchema`, `createFile`, and friends), the `ts.factory` analogue                     |
+| `@kubb/ast/types`               | Types only: all node interfaces, type aliases, visitor types                                                 |
+| `kubb/kit`                      | Re-exports the `ast` and `factory` namespaces, so plugin authors reach the AST without a direct dependency   |
 | `kubb/ast`                      | The flat runtime and types bundled in the top-level `kubb` package, without the `ast` / `factory` namespaces |
 
 The macro presets (`macroDiscriminatorEnum`, `macroSimplifyUnion`, `macroEnumName`) and the string, identifier, and ref helpers live on the root `@kubb/ast` export. They no longer ship as separate `@kubb/ast/macros` and `@kubb/ast/utils` subpaths.

--- a/packages/ast/README.md
+++ b/packages/ast/README.md
@@ -28,13 +28,15 @@ Defines the node tree, visitor pattern, factory functions, and type guards used 
 
 ## Imports
 
-| Path                            | Contents                                                                                 |
-| ------------------------------- | ---------------------------------------------------------------------------------------- |
-| `@kubb/ast`                     | Runtime: node definitions, guards, visitor, macro engine, constants                      |
-| `ast.factory` (via `@kubb/ast`) | Node constructors (`createSchema`, `createFile`, and friends), the `ts.factory` analogue |
-| `@kubb/ast/macros`              | Built-in macro presets: `macroDiscriminatorEnum`, `macroSimplifyUnion`, `macroEnumName`  |
-| `@kubb/ast/types`               | Types only: all node interfaces, type aliases, visitor types                             |
-| `@kubb/ast/utils`               | Spec-agnostic string and identifier helpers, ref helpers                                 |
+| Path                            | Contents                                                                                                |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `@kubb/ast`                     | Runtime: node definitions, guards, visitor, macro engine, string and ref helpers, constants             |
+| `ast.factory` (via `@kubb/ast`) | Node constructors (`createSchema`, `createFile`, and friends), the `ts.factory` analogue                |
+| `@kubb/ast/types`               | Types only: all node interfaces, type aliases, visitor types                                            |
+| `kubb/kit`                      | Re-exports the `ast` and `factory` namespaces, so plugin authors reach the AST without a direct dependency |
+| `kubb/ast`                      | The flat runtime and types bundled in the top-level `kubb` package, without the `ast` / `factory` namespaces |
+
+The macro presets (`macroDiscriminatorEnum`, `macroSimplifyUnion`, `macroEnumName`) and the string, identifier, and ref helpers live on the root `@kubb/ast` export. They no longer ship as separate `@kubb/ast/macros` and `@kubb/ast/utils` subpaths.
 
 ## Node tree
 
@@ -132,7 +134,7 @@ function process(node: Node) {
 ### Refs
 
 ```ts
-import { extractRefName } from '@kubb/ast/utils'
+import { extractRefName } from '@kubb/ast'
 
 extractRefName('#/components/schemas/Pet') // 'Pet'
 ```

--- a/packages/ast/README.md
+++ b/packages/ast/README.md
@@ -36,6 +36,8 @@ Defines the node tree, visitor pattern, factory functions, and type guards used 
 | `kubb/kit`                      | Re-exports the `ast` and `factory` namespaces, so plugin authors reach the AST without a direct dependency   |
 | `kubb/ast`                      | The flat runtime and types bundled in the top-level `kubb` package, without the `ast` / `factory` namespaces |
 
+`@kubb/ast` is internal to the kubb monorepo. Import it directly only from inside kubb itself. Plugins and user code reach the same surface through `kubb/kit` (the `ast` and `factory` namespaces) or `kubb/ast` (the flat runtime and types), so the `@kubb/ast` examples below map to those paths outside the monorepo.
+
 The macro presets (`macroDiscriminatorEnum`, `macroSimplifyUnion`, `macroEnumName`) and the string, identifier, and ref helpers live on the root `@kubb/ast` export. They no longer ship as separate `@kubb/ast/macros` and `@kubb/ast/utils` subpaths.
 
 ## Node tree


### PR DESCRIPTION
## 🎯 Changes

The `@kubb/ast` README was stale after the `@kubb/ast/utils` and `@kubb/ast/macros` subpaths were folded into the root export. Its imports table still listed both subpaths and the Refs example still imported `extractRefName` from `@kubb/ast/utils`, so those imports no longer resolve.

This updates `packages/ast/README.md` to match the current export map:

- drops the `@kubb/ast/utils` and `@kubb/ast/macros` rows from the imports table and notes that the macro presets and string, identifier, and ref helpers now live on the root `@kubb/ast` export
- fixes the Refs example to `import { extractRefName } from '@kubb/ast'`
- adds rows for `kubb/kit` (the `ast` and `factory` namespaces) and `kubb/ast` (the flat runtime bundled in the top-level `kubb` package) so the README reflects how the package is actually consumed

`@kubb/ast/types` is unchanged and stays in the table.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCSYy6fJUJ32P7Qqmyb5F9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WCSYy6fJUJ32P7Qqmyb5F9)_