### PR TITLE
Bump peter-evans/repository-dispatch to v4.0.1 (Node 24)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   permissions: {}
   #   steps:
-  #     - uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
+  #     - uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
   #       with:
   #         token: ${{ secrets.PLATFORM_DISPATCH_TOKEN }}
   #         repository: kubb-labs/platform
@@ -201,7 +201,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3
+      - uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.PLATFORM_DISPATCH_TOKEN }}
           repository: kubb-labs/docs


### PR DESCRIPTION
## 🎯 Changes

CI was forcing `peter-evans/repository-dispatch@v3` (pinned to `ff45666`) to run on Node 24 because its bundled runtime targets the deprecated Node 20, per GitHub's [Node 20 deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). This bumps the action to `v4.0.1` (pinned to `28959ce8df70de7be546dd1250a005dd32156697`), which ships a native Node 24 runtime, removing the warning.

Updated both the active `sync-changelog-docs` job and the commented-out `deploy-platform` job in `release.yml` so the pin stays consistent if that job is re-enabled.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).


---
_Generated by [Claude Code](https://claude.ai/code/session_01JqyRtyp4HkZGptL5SHaeP3)_