### PR TITLE
fix(ci): except bot-generated examples branches from merged-only cleanup guard

### DIFF
--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -8,7 +8,13 @@ permissions: {}
 
 jobs:
   delete-branch:
-    if: github.event.pull_request.merged == true
+    # Bot-generated `chore/update-generated-examples-*` branches are excepted from the
+    # merged-only guard: their PR targets the source PR's own branch (mirroring
+    # kubb-labs/plugins' pr.yml), so if that source branch merges or closes first, GitHub
+    # auto-closes this PR unmerged and the branch would otherwise never get cleaned up.
+    if: >-
+      github.event.pull_request.merged == true ||
+      startsWith(github.event.pull_request.head.ref, 'chore/update-generated-examples-')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## 🎯 Changes

Companion to kubb-labs/plugins#627.

In `kubb-labs/plugins`, `chore/update-generated-examples-<PR#>` branches weren't being removed by the cleanup action. Root cause: that repo's `update-examples` job opens its PR against the source PR's own branch, not `master`/`next`. When the source PR merges or closes first, GitHub auto-closes the stacked PR unmerged (its base branch is gone), so `cleanup-branches.yml`'s `if: github.event.pull_request.merged == true` guard skipped it and the branch was never deleted.

This repo doesn't run that generator today, so the bug doesn't currently manifest here, but this brings `cleanup-branches.yml`'s guard in line with the plugins repo fix for consistency and to future-proof against the same issue if a similar generator is added later.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).


---
_Generated by [Claude Code](https://claude.ai/code/session_01BvM21n8mNp3sMUDFQ6wm2j)_