### PR TITLE
Frame @kubb/core and @kubb/ast READMEs as internal libraries

### DIFF
--- a/.changeset/core-ast-readme-internal-library.md
+++ b/.changeset/core-ast-readme-internal-library.md
@@ -1,0 +1,6 @@
+---
+'@kubb/core': patch
+'@kubb/ast': patch
+---
+
+Frame `@kubb/core` and `@kubb/ast` as internal libraries in their READMEs. Plugin authors import from `kubb/kit`, which re-exports the authoring surface of both packages, instead of depending on them directly.

--- a/packages/ast/README.md
+++ b/packages/ast/README.md
@@ -35,7 +35,7 @@ Defines the node tree, visitor pattern, factory functions, and type guards used 
 | `@kubb/ast/types`               | Types only: all node interfaces, type aliases, visitor types                                                      |
 | `kubb/kit`                      | Re-exports the `ast` and `factory` namespaces, the way most Kubb code reaches the AST without a direct dependency |
 
-Install `@kubb/ast` when you want the AST on its own. Inside the Kubb ecosystem the same surface travels on the `ast` namespace from `kubb/kit`, so plugins and generators reach it there. The examples below import from `@kubb/ast`; through `kubb/kit` the same calls read as `ast.walk`, `ast.factory.createSchema`, and so on.
+`@kubb/ast` is an internal library. Inside the Kubb ecosystem the whole surface travels on the `ast` namespace from `kubb/kit`, so plugins and generators reach it there instead of depending on this package directly. The examples below import from `@kubb/ast` for clarity; through `kubb/kit` the same calls read as `ast.walk`, `ast.factory.createSchema`, and so on.
 
 The macro presets (`macroDiscriminatorEnum`, `macroSimplifyUnion`, `macroEnumName`) and the string, identifier, and ref helpers live on the root `@kubb/ast` export. They no longer ship as separate `@kubb/ast/macros` and `@kubb/ast/utils` subpaths.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -26,7 +26,7 @@
 
 Core engine for Kubb's plugin-based code generation system. Provides the plugin driver, file manager, `defineConfig`, `definePlugin`, `defineMiddleware`, and the build orchestration layer used by every Kubb plugin.
 
-> **Note:** Most users should install the [`kubb`](https://npmx.dev/package/kubb) meta-package instead of `@kubb/core` directly. Install `@kubb/core` only when building custom plugins or extending the Kubb internals.
+> **Note:** `@kubb/core` is an internal library. Install the [`kubb`](https://npmx.dev/package/kubb) meta-package instead and author plugins, generators, resolvers, parsers, and adapters through its `kubb/kit` subpath, which re-exports the authoring surface of this package.
 
 ## Installation
 


### PR DESCRIPTION
## 🎯 Changes

`kubb/kit` is the supported surface for authoring plugins and custom logic, so the READMEs of the two packages behind it now say so:

- `packages/core/README.md`: the note no longer suggests installing `@kubb/core` to build custom plugins. It now describes the package as an internal library and points authors at the `kubb` meta-package and its `kubb/kit` subpath.
- `packages/ast/README.md`: "Install `@kubb/ast` when you want the AST on its own" is replaced with the internal-library framing. The `ast` namespace from `kubb/kit` is the way to reach the AST, and the `@kubb/ast` imports in the examples are kept for clarity only.

This matches the docs restructure in kubb-labs/docs#84, which merges the core, AST, adapters, and parsers references into the single Kit API page.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test` (README-only change, no code affected).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (patch, so the updated READMEs ship to npm).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhTREyjaTCgGVVhb5jtKkL

---
_Generated by [Claude Code](https://claude.ai/code/session_01BhTREyjaTCgGVVhb5jtKkL)_