### PR TITLE
docs: add kubb kit to contributing and agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ Kubb is a code-generation toolkit for generating TypeScript, React-Query, Zod, F
 
 Kubb is built from:
 - Core engine (`@kubb/core`) runs the plugin system and orchestrates code generation
+- Authoring kit (`@kubb/kit`, reached through the `kubb/kit` subpath) bundles the helpers for building plugins, generators, adapters, resolvers, and renderers
 - Adapters (`@kubb/adapter-oas`) transform OpenAPI specs into an AST
 - Renderers and utilities turn the AST into code
 - The CLI is the entry point for code generation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ Kubb spans a few repositories. Knowing where code lives saves time:
 kubb/
 ├── packages/                # Published npm packages and core modules
 │   ├── core/                # Plugin system and code generation orchestration
+│   ├── kit/                 # Authoring toolkit re-exported through kubb/kit (definePlugin, ast, factories)
 │   ├── ast/                 # Spec-agnostic AST layer (nodes, visitors, factories)
 │   ├── adapter-oas/         # OpenAPI/Swagger adapter (OAS to AST)
 │   ├── parser-ts/           # TypeScript parser for AST manipulation

--- a/packages/kubb/README.md
+++ b/packages/kubb/README.md
@@ -61,7 +61,7 @@ See the [documentation](https://kubb.dev) for detailed usage and advanced featur
 - Read OpenAPI 2.0, 3.0, and 3.1 through adapters like [`@kubb/adapter-oas`](https://npmx.dev/package/@kubb/adapter-oas), with output for Node.js and Bun.
 - Enable only the [plugins](https://github.com/kubb-labs/plugins) you need: `plugin-ts`, `plugin-axios`, `plugin-fetch`, `plugin-react-query`, `plugin-vue-query`, `plugin-swr`, `plugin-zod`, `plugin-faker`, `plugin-msw`, `plugin-cypress`, `plugin-redoc`, `plugin-mcp`.
 - Shape the output by grouping files by tag, including or excluding operations, and writing to disk, memory, or a custom storage backend.
-- Build your own output with custom plugins, adapters, and the JSX renderer (`@kubb/renderer-jsx`).
+- Build your own plugins, generators, adapters, and renderers with the [`kubb/kit`](https://kubb.dev/docs/5.x/reference/kit) authoring toolkit, plus a JSX renderer for component-based output.
 - Run generation in your bundler with `unplugin-kubb` for [Vite](https://github.com/vitejs/vite), [Nuxt](https://github.com/nuxt/nuxt), [Astro](https://github.com/withastro/astro), [webpack](https://github.com/webpack/webpack), and more.
 - Drive generation from AI tools over the built-in MCP server ([Claude](https://claude.ai), [Cursor](https://cursor.sh)) or inside [Claude Code](https://kubb.dev/docs/5.x/ai/claude).
 


### PR DESCRIPTION
## 🎯 Changes

Document the `@kubb/kit` authoring toolkit across the repo docs so it sits next to core, the adapter, and the renderers everywhere the package layout is described.

- `AGENTS.md` high-level architecture gains a line for the authoring kit (`@kubb/kit`, reached through the `kubb/kit` subpath).
- `CONTRIBUTING.md` "What is inside this repo" tree gains a `kit/` entry.
- `packages/kubb/README.md` build-your-own feature bullet now points to the `kubb/kit` authoring toolkit.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).

---
_Generated by [Claude Code](https://claude.ai/code/session_01W42CTSrku9hBfzrtsksbJC)_