### PR TITLE
ci(release): make npm verify polling interval configurable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,10 @@ jobs:
         run: node scripts/verifyRegistry.mjs
         env:
           STAGED_PACKAGES: ${{ needs.release.outputs.staged_packages }}
+          # How often to re-poll npm while waiting for a staged version to
+          # propagate, and how many times to try before giving up.
+          VERIFY_INTERVAL_SECONDS: '10'
+          VERIFY_RETRY_ATTEMPTS: '6'
 
       # Tags are created here, not at stage time, so a rejected or expired
       # staged package never leaves a dangling tag behind (see

--- a/scripts/verifyRegistry.mjs
+++ b/scripts/verifyRegistry.mjs
@@ -2,8 +2,8 @@
 import { spawnSync } from 'node:child_process'
 import { appendFileSync } from 'node:fs'
 
-const RETRY_ATTEMPTS = 6
-const RETRY_DELAY_MS = 10_000
+const RETRY_ATTEMPTS = Number(process.env.VERIFY_RETRY_ATTEMPTS) || 6
+const RETRY_DELAY_MS = (Number(process.env.VERIFY_INTERVAL_SECONDS) || 10) * 1_000
 
 function isLiveOnRegistry(pkg) {
   const result = spawnSync('npm', ['view', `${pkg.name}@${pkg.version}`, '--json'], { encoding: 'utf8' })


### PR DESCRIPTION
## 🎯 Changes

The `promote` job's "Verify staged versions are live on npm" step polled npm every 10 seconds for 6 attempts, with both values hardcoded as constants in `scripts/verifyRegistry.mjs`. This makes the polling cadence configurable:

- `scripts/verifyRegistry.mjs` now reads the interval and attempt count from `VERIFY_INTERVAL_SECONDS` and `VERIFY_RETRY_ATTEMPTS` environment variables, falling back to the same defaults as before (10 seconds, 6 attempts).
- `.github/workflows/release.yml` sets these explicitly on the verify step, so the polling cadence is visible in the workflow and can be tuned without touching the script.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).

This is a CI/tooling-only change (root `scripts/` and `.github/workflows/`), not a published package, so no changeset is needed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Udf3hSXHm2qLxYe5p95s9d)_