### PR TITLE
Drop storage argument from KubbDriver.run()

### DIFF
--- a/.changeset/kubbdriver-run-drop-storage-param.md
+++ b/.changeset/kubbdriver-run-drop-storage-param.md
@@ -1,0 +1,7 @@
+---
+"@kubb/core": major
+---
+
+`KubbDriver.run()` no longer takes a `storage` argument.
+
+`Config.storage` was already required and passed into the driver's constructor, so `run({ storage })` was redundant. `run()` now reads `config.storage` directly, so callers should switch to `driver.run()`.

--- a/packages/core/src/KubbDriver.ts
+++ b/packages/core/src/KubbDriver.ts
@@ -4,7 +4,6 @@ import { ast, collectUsedSchemaNames, type Enforce, type FileNode, type InputMet
 import { OPERATION_FILTER_TYPES } from './constants.ts'
 import { type Diagnostic, Diagnostics, type ProblemDiagnostic } from './Diagnostics.ts'
 import type { RendererFactory } from './createRenderer.ts'
-import type { Storage } from './createStorage.ts'
 import type { Generator } from './defineGenerator.ts'
 import type { Parser } from './defineParser.ts'
 import type { Plugin } from './definePlugin.ts'
@@ -281,7 +280,7 @@ export class KubbDriver {
    * the failure as a {@link Diagnostic} instead of propagating. Each plugin also
    * contributes a `timing` diagnostic for the run summary.
    */
-  async run({ storage }: { storage: Storage }): Promise<{ diagnostics: Array<Diagnostic> }> {
+  async run(): Promise<{ diagnostics: Array<Diagnostic> }> {
     const { hooks, config, fileManager } = this
     const diagnostics: Array<Diagnostic> = []
     const parsersMap = new Map<FileNode['extname'], Parser>()
@@ -373,7 +372,7 @@ export class KubbDriver {
           // Write every generated file once, after post-processing (barrel etc.) has had its
           // chance to add more. Writing mid-generation measured no faster in practice, so a
           // single pass keeps the pipeline simpler.
-          await fileManager.write(fileManager.files, { storage, parsers: parsersMap, extension: config.output.extension })
+          await fileManager.write(fileManager.files, { storage: config.storage, parsers: parsersMap, extension: config.output.extension })
 
           await hooks.callHook('kubb:build:end', { files: this.fileManager.files, config, outputDir: outputRoot })
 

--- a/packages/core/src/createKubb.ts
+++ b/packages/core/src/createKubb.ts
@@ -116,7 +116,7 @@ export class Kubb {
     using self = this
     const driver = self.driver
     const storage = self.storage
-    const { diagnostics } = await driver.run({ storage })
+    const { diagnostics } = await driver.run()
 
     return { diagnostics, files: driver.fileManager.files, driver, storage }
   }


### PR DESCRIPTION
## 🎯 Changes

`KubbDriver.run()` took `{ storage }` as an argument, but `Config.storage` is already required and resolved before the driver's constructor runs (`createKubb.ts` always passes the same `config.storage` value through). The parameter duplicated data the driver already had.

`run()` now reads `config.storage` directly, so it takes no arguments. `createKubb.ts`'s `safeBuild()` calls `driver.run()` instead of `driver.run({ storage })`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (major bump for `@kubb/core`, since `KubbDriver` is a public export and `run()`'s signature changed).
- [ ] This change is for the docs (no release).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NjmVH9APp1BYg1U2pXRwhm)_