### PR TITLE
fix(core): keep resolver file override across @kubb/core copies

### DIFF
--- a/.changeset/resolver-merge-realm-safe.md
+++ b/.changeset/resolver-merge-realm-safe.md
@@ -1,0 +1,9 @@
+---
+'@kubb/core': patch
+---
+
+Keep a resolver's `file` override when a plugin resolver and the CLI load different copies of `@kubb/core`.
+
+A CommonJS `kubb.config.cjs` loads `@kubb/core` as CommonJS while the CLI runs the ESM build, so a plugin's resolver is not `instanceof` the driver's `Resolver`. `Resolver.merge` relied on that check and fell back to the instance's enumerable fields, which drop `file` (it is bound through `#baseName`, not set as an own property). The merged resolver then used the built-in `toFilePath` casing, so generated file names lost their plugin casing (`Pet.ts` became `pet.ts`) even though the identifiers stayed correct.
+
+`Resolver.merge` now reads a resolver's build options through a shared `Symbol.for` brand instead of `instanceof`, so the `file` override survives across `@kubb/core` copies.

--- a/packages/core/src/Resolver.ts
+++ b/packages/core/src/Resolver.ts
@@ -254,10 +254,6 @@ function isNamespace(value: unknown): value is Record<string, unknown> {
  */
 const resolverOptions: unique symbol = Symbol.for('@kubb/core/resolver/options')
 
-function hasResolverOptions(value: object): value is { readonly [resolverOptions]: ResolverBuildOptions } {
-  return resolverOptions in value
-}
-
 /**
  * Built-in `file.baseName`: casts the identifier with `toFilePath` and appends the extension.
  */
@@ -311,10 +307,7 @@ export class Resolver {
     this.#apply(options)
   }
 
-  /**
-   * Exposes the raw build options so `Resolver.merge` can read them across `@kubb/core` copies.
-   * Keyed by a shared `Symbol.for`, so it stays off the public API.
-   */
+  /** Exposes the raw build options so `Resolver.merge` can read them across `@kubb/core` copies. */
   get [resolverOptions](): ResolverBuildOptions {
     return this.#options
   }
@@ -350,7 +343,7 @@ export class Resolver {
    * survives even when `base` and `override` come from different `@kubb/core` copies.
    */
   static merge<T extends Resolver>(base: T, override: ResolverPatch<T> | Resolver): T {
-    const patch = hasResolverOptions(override) ? override[resolverOptions] : override
+    const patch = resolverOptions in override ? override[resolverOptions] : override
     const merged: Record<string, unknown> = { ...base[resolverOptions] }
     for (const [key, value] of Object.entries(patch)) {
       if (value === undefined) continue

--- a/packages/core/src/Resolver.ts
+++ b/packages/core/src/Resolver.ts
@@ -247,6 +247,18 @@ function isNamespace(value: unknown): value is Record<string, unknown> {
 }
 
 /**
+ * Shared brand for reaching a resolver's build options. `Resolver.merge` reads this instead of
+ * relying on `instanceof`, which fails when a CommonJS config and the ESM CLI each load their own
+ * copy of `@kubb/core`. `Symbol.for` resolves to one key across those copies, so the options stay
+ * reachable and a `file` override is never dropped.
+ */
+const resolverOptions: unique symbol = Symbol.for('@kubb/core/resolver/options')
+
+function hasResolverOptions(value: object): value is { readonly [resolverOptions]: ResolverBuildOptions } {
+  return resolverOptions in value
+}
+
+/**
  * Built-in `file.baseName`: casts the identifier with `toFilePath` and appends the extension.
  */
 function toBaseName({ name, extname }: Pick<ResolverFileParams, 'name' | 'extname'>): FileNode['baseName'] {
@@ -300,6 +312,14 @@ export class Resolver {
   }
 
   /**
+   * Exposes the raw build options so `Resolver.merge` can read them across `@kubb/core` copies.
+   * Keyed by a shared `Symbol.for`, so it stays off the public API.
+   */
+  get [resolverOptions](): ResolverBuildOptions {
+    return this.#options
+  }
+
+  /**
    * The built-in resolution machinery. Always reaches the untouched defaults, even when a
    * plugin overrides the top-level `name` or `file`.
    */
@@ -325,11 +345,13 @@ export class Resolver {
   /**
    * Merges `override` over `base` and returns a new resolver with helpers re-bound. Top-level
    * keys replace, and a namespace (or `file`) merges per method, so overriding `query.name`
-   * keeps the base `query.keyName`. Used when applying `setResolver` partial overrides.
+   * keeps the base `query.keyName`. Used when applying `setResolver` partial overrides. Reads a
+   * resolver's options through the shared brand rather than `instanceof`, so a `file` override
+   * survives even when `base` and `override` come from different `@kubb/core` copies.
    */
   static merge<T extends Resolver>(base: T, override: ResolverPatch<T> | Resolver): T {
-    const patch = override instanceof Resolver ? override.#options : override
-    const merged: Record<string, unknown> = { ...base.#options }
+    const patch = hasResolverOptions(override) ? override[resolverOptions] : override
+    const merged: Record<string, unknown> = { ...base[resolverOptions] }
     for (const [key, value] of Object.entries(patch)) {
       if (value === undefined) continue
       const current = merged[key]

--- a/packages/core/src/createResolver.test.ts
+++ b/packages/core/src/createResolver.test.ts
@@ -280,6 +280,24 @@ describe('createResolver', () => {
     expect(merged.query.keyName({ operationId: 'get pet' })).toBe('getPetKey')
   })
 
+  it('Resolver.merge() keeps a file override from a resolver in another @kubb/core copy', () => {
+    type TestFactory = { name: 'test'; options: {}; resolvedOptions: {}; resolver: Resolver }
+    const base = createResolver<TestFactory>({ pluginName: 'test' })
+
+    // A resolver loaded from a second @kubb/core copy (a CommonJS config next to the ESM CLI) is not
+    // `instanceof Resolver`, but shares the brand, so its `file` override must still be honored.
+    const foreign = {
+      [Symbol.for('@kubb/core/resolver/options')]: {
+        pluginName: 'test',
+        file: { baseName: ({ name, extname }: { name: string; extname: string }) => `${name}Faker${extname}` },
+      },
+    } as unknown as Resolver
+
+    const merged = Resolver.merge(base, foreign)
+
+    expect(merged.file({ name: 'pet', extname: '.ts', root: '/root', output: { path: 'mocks' }, group: undefined }).baseName).toBe('petFaker.ts')
+  })
+
   it('supports top-level helpers like typeName', () => {
     type TypeResolver = Resolver & { typeName(name: string): string }
     type TypeFactory = { name: 'test'; options: {}; resolvedOptions: {}; resolver: TypeResolver }


### PR DESCRIPTION
## 🎯 Changes

Fixes a regression where a resolver's `file` override was dropped whenever a plugin resolver and the CLI loaded different copies of `@kubb/core` — most visibly with a CommonJS `kubb.config.cjs` next to the ESM CLI.

`Resolver.merge` decided how to read the incoming resolver's build options with `override instanceof Resolver`. Across a CJS/ESM boundary the plugin's resolver is an instance of a *different* `Resolver` class, so that check is `false` and merge fell back to the instance's own enumerable fields. `file` is not one of them (it drives naming through the private `#baseName`, not an own property), so it was lost. The merged resolver then used the built-in `toFilePath` casing, and generated file names dropped their plugin casing (`Pet.ts` became `pet.ts`) even though the identifiers stayed correct.

`Resolver.merge` now reads a resolver's build options through a shared `Symbol.for('@kubb/core/resolver/options')` brand instead of `instanceof`. `Symbol.for` resolves to one key across every `@kubb/core` copy, so the `file` override survives. A regression test simulates a resolver from a second copy (shared brand, not `instanceof`) and asserts the override is honored.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GLasBimvF3Fg37TQ9zrGyM)_