### PR TITLE
fix(core,renderer-jsx): brand DiagnosticError and JSX elements with Symbol.for

### DIFF
--- a/.changeset/symbol-for-brand-diagnostics-jsx.md
+++ b/.changeset/symbol-for-brand-diagnostics-jsx.md
@@ -1,0 +1,10 @@
+---
+'@kubb/renderer-jsx': patch
+'@kubb/core': patch
+---
+
+Harden two more cross-copy identity checks with a shared `Symbol.for` brand, matching the resolver fix.
+
+`Diagnostics.isError` now brands `Diagnostics.Error` with `Symbol.for('@kubb/core/diagnostics/error')`, so a structured error thrown from an adapter or plugin that bundles its own `@kubb/core` keeps its `code` through the throw/catch path instead of collapsing to `KUBB_UNKNOWN`. The previous `name`/shape check stays as a fallback for errors thrown by an older copy that predates the brand.
+
+The JSX renderer now checks an element's `$$typeof` against `Symbol.for('kubb.element')` instead of accepting any object that carries a `$$typeof` field, so a stray React element (which brands its own `$$typeof`) is no longer mistaken for a Kubb element.

--- a/packages/core/src/Diagnostics.test.ts
+++ b/packages/core/src/Diagnostics.test.ts
@@ -98,6 +98,33 @@ describe('Diagnostics.from', () => {
   })
 })
 
+describe('Diagnostics.isError', () => {
+  it('recognizes a locally thrown DiagnosticError', () => {
+    expect(Diagnostics.isError(new Diagnostics.Error({ code: 'KUBB_REF_NOT_FOUND', severity: 'error', message: 'missing' }))).toBe(true)
+  })
+
+  it('recognizes a DiagnosticError from a duplicated core copy through the shared brand', () => {
+    // A different `@kubb/core` copy fails `instanceof` but sets the same `Symbol.for` brand.
+    const foreign = { [Symbol.for('@kubb/core/diagnostics/error')]: true }
+
+    expect(Diagnostics.isError(foreign)).toBe(true)
+  })
+
+  it('recognizes a DiagnosticError structurally when it predates the brand', () => {
+    // An older duplicated copy carries no brand, only the `name` and a `diagnostic` with a code.
+    const foreign = Object.assign(new Error('missing'), {
+      name: 'DiagnosticError',
+      diagnostic: { code: 'KUBB_INPUT_NOT_FOUND', severity: 'error', message: 'missing' },
+    })
+
+    expect(Diagnostics.isError(foreign)).toBe(true)
+  })
+
+  it('rejects a plain error', () => {
+    expect(Diagnostics.isError(new Error('boom'))).toBe(false)
+  })
+})
+
 describe('Diagnostics.count', () => {
   it('counts problems by severity and ignores performance', () => {
     const counts = Diagnostics.count([

--- a/packages/core/src/Diagnostics.ts
+++ b/packages/core/src/Diagnostics.ts
@@ -353,6 +353,14 @@ const diagnosticCatalog: Record<DiagnosticCode, DiagnosticDoc> = {
 }
 
 /**
+ * Shared brand marking a {@link Diagnostics.Error}. `Diagnostics.isError` reads this instead of
+ * relying on `instanceof`, which fails when an adapter or plugin bundles its own `@kubb/core` copy.
+ * `Symbol.for` resolves to one key across those copies, so a structured error keeps its identity
+ * and its `code` survives the throw/catch path.
+ */
+const diagnosticError: unique symbol = Symbol.for('@kubb/core/diagnostics/error')
+
+/**
  * Static helpers for working with {@link Diagnostic}s, plus the run-scoped sink
  * that lets deep code report a diagnostic without threading a callback.
  *
@@ -399,6 +407,7 @@ export class Diagnostics {
    * ```
    */
   static Error = class DiagnosticError extends Error {
+    readonly [diagnosticError] = true
     diagnostic: ProblemDiagnostic
 
     constructor(diagnostic: ProblemDiagnostic) {
@@ -409,12 +418,15 @@ export class Diagnostics {
   }
 
   /**
-   * Structural check for a {@link Diagnostics.Error}, including one thrown from a duplicated
-   * `@kubb/core` copy where `instanceof` fails. Matches on the `name` and a `diagnostic`
-   * that carries a `code`.
+   * Checks for a {@link Diagnostics.Error}, including one thrown from a duplicated `@kubb/core`
+   * copy where `instanceof` fails. The shared brand resolves across copies; the structural
+   * fallback still recognizes an error thrown by an older copy that predates the brand.
    */
   static isError(error: unknown): error is InstanceType<typeof Diagnostics.Error> {
-    if (error instanceof Diagnostics.Error) {
+    if (typeof error !== 'object' || error === null) {
+      return false
+    }
+    if ((error as Record<PropertyKey, unknown>)[diagnosticError] === true) {
       return true
     }
     return (

--- a/packages/renderer-jsx/src/Runtime.tsx
+++ b/packages/renderer-jsx/src/Runtime.tsx
@@ -1,6 +1,6 @@
 import { ast, type ArrowFunctionNode, type CodeNode, type ExportNode, type FileNode, type ImportNode, type JSDocNode, type SourceNode } from '@kubb/ast'
 import { KUBB_ARROW_FUNCTION, KUBB_CONST, KUBB_EXPORT, KUBB_FILE, KUBB_FUNCTION, KUBB_IMPORT, KUBB_JSX, KUBB_SOURCE, KUBB_TYPE } from './constants.ts'
-import { Fragment } from './jsx-runtime.ts'
+import { Fragment, KUBB_ELEMENT } from './jsx-runtime.ts'
 import type { KubbReactElement } from './types.ts'
 
 type OnText = (text: string) => void
@@ -25,7 +25,7 @@ function walkElement(element: unknown, onText: OnText, onHost: OnHost): void {
     return
   }
 
-  if (typeof element === 'object' && '$$typeof' in element) {
+  if (typeof element === 'object' && (element as { $$typeof?: unknown }).$$typeof === KUBB_ELEMENT) {
     const el = element as unknown as KubbReactElement
     const { type } = el
     const props = el.props as Record<string, unknown>
@@ -216,7 +216,7 @@ function* walkFiles(element: unknown): Generator<FileNode> {
     return
   }
 
-  if (typeof element === 'object' && '$$typeof' in element) {
+  if (typeof element === 'object' && (element as { $$typeof?: unknown }).$$typeof === KUBB_ELEMENT) {
     const el = element as unknown as KubbReactElement
     const { type } = el
     const props = el.props as Record<string, unknown>

--- a/packages/renderer-jsx/src/jsx-runtime.ts
+++ b/packages/renderer-jsx/src/jsx-runtime.ts
@@ -1,6 +1,11 @@
 import type { Key, KubbReactElement, KubbReactNode } from './types.ts'
 
-const KUBB_ELEMENT = Symbol.for('kubb.element')
+/**
+ * Brand marking a Kubb JSX element's `$$typeof`. `Symbol.for` resolves to one key across
+ * duplicated `@kubb/renderer-jsx` copies, and its value tells a Kubb element apart from a React
+ * element (which brands its own `$$typeof`), so the renderer never walks a foreign tree.
+ */
+export const KUBB_ELEMENT = Symbol.for('kubb.element')
 
 /**
  * Fragment marker. A `<>…</>` compiles to `jsx(Fragment, …)`, and the renderer

--- a/packages/renderer-jsx/src/jsxRenderer.test.tsx
+++ b/packages/renderer-jsx/src/jsxRenderer.test.tsx
@@ -87,4 +87,41 @@ describe('jsxRenderer', () => {
     expect(renderer.files.find((f) => f.baseName === 'first.ts')).toBeDefined()
     expect(renderer.files.find((f) => f.baseName === 'second.ts')).toBeDefined()
   })
+
+  it('ignores a foreign element whose $$typeof is not the Kubb brand', async () => {
+    const renderer = jsxRenderer()
+    // A React element carries `Symbol.for('react.element')`, not the Kubb brand, so the renderer
+    // must skip it instead of mistaking it for a `<File>`.
+    const reactElement = {
+      $$typeof: Symbol.for('react.element'),
+      type: 'kubb-file',
+      props: { baseName: 'foreign.ts', path: 'src/foreign.ts', children: [] },
+      key: null,
+    }
+
+    await renderer.render(reactElement)
+
+    expect(renderer.files).toHaveLength(0)
+  })
+
+  it('skips a foreign child element inside a File', async () => {
+    const renderer = jsxRenderer()
+    // The same foreign brand nested as a child: the child walk must not collect it as an import.
+    const foreignImport = {
+      $$typeof: Symbol.for('react.element'),
+      type: 'kubb-import',
+      props: { name: ['z'], path: 'zod' },
+      key: null,
+    }
+
+    await renderer.render(
+      <File baseName="models.ts" path="src/models.ts">
+        {foreignImport}
+      </File>,
+    )
+
+    const file = renderer.files.find((f) => f.baseName === 'models.ts')
+    expect(file).toBeDefined()
+    expect(file?.imports).toHaveLength(0)
+  })
 })


### PR DESCRIPTION
## 🎯 Changes

Extends the realm-safe `Symbol.for` brand pattern (introduced for `Resolver.merge` in #3733) to two more cross-copy identity checks. Both `instanceof`/duck-typing checks break when an adapter or plugin bundles its own copy of a `@kubb/*` package, so a shared `Symbol.for` key — which resolves to one identity across every copy — makes them robust.

**`@kubb/core` — `Diagnostics.Error`**
- Brands the error with `Symbol.for('@kubb/core/diagnostics/error')` and checks it in `Diagnostics.isError` before the existing `name`/shape sniff.
- A structured error thrown from a duplicated `@kubb/core` copy now keeps its `code` through the throw/catch path instead of collapsing to `KUBB_UNKNOWN`.
- The structural check stays as a fallback for errors thrown by an older copy that predates the brand.

**`@kubb/renderer-jsx` — JSX elements**
- The renderer already stamped every element's `$$typeof` with `Symbol.for('kubb.element')`, but the walkers only checked that a `$$typeof` field was *present*.
- They now validate `$$typeof === KUBB_ELEMENT`, so a stray React element (which brands its own `$$typeof`) is no longer mistaken for a Kubb element and walked as a `<File>`/import.

Deliberately left alone: AST nodes discriminate on a string `kind`, which already compares by value across copies — a symbol there would be a regression (breaks serialization/snapshots) for no gain.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

Added tests: `Diagnostics.isError` (local, brand-only foreign, structural-fallback, plain-error rejection) and two `jsxRenderer` cases (foreign top-level element ignored, foreign child element skipped). `@kubb/core` (227) and `@kubb/renderer-jsx` (24) suites pass; both packages typecheck and lint clean.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M78xyMPhUwJjCcCNBPSh8D

---
_Generated by [Claude Code](https://claude.ai/code/session_01M78xyMPhUwJjCcCNBPSh8D)_