### PR TITLE
refactor(parser): move output.extension onto the parser

### DIFF
--- a/.changeset/move-extension-onto-parser.md
+++ b/.changeset/move-extension-onto-parser.md
@@ -24,4 +24,14 @@ export default defineConfig({
 })
 ```
 
-Custom parsers built with `defineParser` now implement `parse(file)` without the second `options` argument.
+`defineParser` now wraps a factory the same way `definePlugin` does, so custom parsers take options too:
+
+```ts
+// before
+export const parserText = defineParser({ name: 'parser-text', extNames: ['.txt'], parse, print })
+
+// after
+export const parserText = defineParser((options) => ({ name: 'parser-text', extNames: ['.txt'], parse, print }))
+```
+
+`parse(file)` also drops its second `options` argument, since the parser resolves options from its factory instead.

--- a/.changeset/move-extension-onto-parser.md
+++ b/.changeset/move-extension-onto-parser.md
@@ -1,0 +1,27 @@
+---
+'@kubb/parser-ts': major
+'@kubb/parser-md': major
+'@kubb/core': major
+'kubb': major
+'unplugin-kubb': major
+---
+
+Move import and export extension rewriting from `output.extension` onto the parser, and turn the built-in parsers into factories.
+
+`output.extension` only ever rewrote the extensions inside `import`/`export` statements, so it now lives on `parserTs`, the parser that does the work. `parserTs`, `parserTsx`, and `parserMd` are now factory functions you call, matching the plugin convention (`pluginTs()`), and `parserTs`/`parserTsx` accept an `extension` map. The `output.extension` option and the `extname` argument to `Parser.parse` are removed.
+
+```ts
+// before
+export default defineConfig({
+  output: { path: './src/gen', extension: { '.ts': '.js' } },
+  parsers: [parserTs, parserTsx, parserMd],
+})
+
+// after
+export default defineConfig({
+  output: { path: './src/gen' },
+  parsers: [parserTs({ extension: { '.ts': '.js' } }), parserTsx(), parserMd()],
+})
+```
+
+Custom parsers built with `defineParser` now implement `parse(file)` without the second `options` argument.

--- a/packages/core/src/FileManager.test.ts
+++ b/packages/core/src/FileManager.test.ts
@@ -191,7 +191,7 @@ describe('FileManager', () => {
       const parsers = new Map([['.ts' as const, parser]])
       const manager = new FileManager()
       const result = await manager.parse(file, { parsers })
-      expect(mockParse).toHaveBeenCalledWith(file, { extname: undefined })
+      expect(mockParse).toHaveBeenCalledWith(file)
       expect(result).toBe('// formatted\nconst a = 1')
     })
 

--- a/packages/core/src/FileManager.ts
+++ b/packages/core/src/FileManager.ts
@@ -15,7 +15,6 @@ export type FileManagerHooks = {
 
 type ParseOptions = {
   parsers?: Map<FileNode['extname'], Parser>
-  extension?: Record<FileNode['extname'], FileNode['extname'] | ''>
 }
 
 type WriteOptions = ParseOptions & {
@@ -157,12 +156,10 @@ export class FileManager {
   /**
    * Converts a file's AST sources (or its `copy` source) into the final on-disk string.
    */
-  async parse(file: FileNode, { parsers, extension }: ParseOptions = {}): Promise<string> {
+  async parse(file: FileNode, { parsers }: ParseOptions = {}): Promise<string> {
     if (file.copy) {
       return parseCopy(file)
     }
-
-    const parseExtName = extension?.[file.extname] || undefined
 
     if (!parsers || !file.extname) {
       return joinSources(file)
@@ -174,14 +171,14 @@ export class FileManager {
       return joinSources(file)
     }
 
-    return parser.parse(file, { extname: parseExtName })
+    return parser.parse(file)
   }
 
   /**
    * Converts and writes every file at once, letting `storage.setItem` decide how much of
    * that runs concurrently.
    */
-  async write(files: Array<FileNode>, { storage, parsers, extension }: WriteOptions): Promise<void> {
+  async write(files: Array<FileNode>, { storage, parsers }: WriteOptions): Promise<void> {
     if (files.length === 0) return
 
     await this.hooks.callHook('start', files)
@@ -190,7 +187,7 @@ export class FileManager {
     let processed = 0
     await Promise.all(
       files.map(async (file) => {
-        const source = await this.parse(file, { parsers, extension })
+        const source = await this.parse(file, { parsers })
         processed++
         await this.hooks.callHook('update', { file, source, processed, total, percentage: (processed / total) * 100 })
         if (source) await storage.setItem(file.path, source)

--- a/packages/core/src/KubbDriver.ts
+++ b/packages/core/src/KubbDriver.ts
@@ -369,7 +369,7 @@ export class KubbDriver {
           // Write every generated file once, after post-processing (barrel etc.) has had its
           // chance to add more. Writing mid-generation measured no faster in practice, so a
           // single pass keeps the pipeline simpler.
-          await fileManager.write(fileManager.files, { storage: config.storage, parsers: parsersMap, extension: config.output.extension })
+          await fileManager.write(fileManager.files, { storage: config.storage, parsers: parsersMap })
 
           await hooks.callHook('kubb:build:end', { files: this.fileManager.files, config, outputDir: outputRoot })
 

--- a/packages/core/src/createKubb.ts
+++ b/packages/core/src/createKubb.ts
@@ -16,7 +16,6 @@ function resolveConfig(userConfig: UserConfig): Config {
     output: {
       format: false,
       lint: false,
-      extension: { '.ts': '.ts' },
       defaultBanner: 'simple',
       ...userConfig.output,
     },

--- a/packages/core/src/defineParser.ts
+++ b/packages/core/src/defineParser.ts
@@ -32,28 +32,34 @@ export type Parser<TMeta extends object = object, TNode = unknown> = {
 }
 
 /**
- * Defines a parser with type-safe `this`. Used to register handlers for new
- * file extensions or to plug a non-TypeScript output into the build.
+ * Wraps a parser factory and returns a function that accepts user options and
+ * yields a typed {@link Parser}. Mirrors {@link definePlugin}: the factory
+ * receives the caller's options, and calling the returned function without
+ * options passes an empty object.
+ *
+ * Register the result in the `parsers` array on `defineConfig`, calling it to
+ * apply options (`parserTs({ extension: { '.ts': '.js' } })`).
  *
  * @example
  * ```ts
  * import { defineParser } from '@kubb/core'
  * import { extractStringsFromNodes } from '@kubb/ast'
  *
- * export const jsonParser = defineParser({
+ * export const parserJson = defineParser((options: { pretty?: boolean } = {}) => ({
  *   name: 'json',
  *   extNames: ['.json'],
  *   parse(file) {
- *     return file.sources
- *       .map((source) => extractStringsFromNodes(source.nodes ?? []))
- *       .join('\n')
+ *     const source = file.sources.map((source) => extractStringsFromNodes(source.nodes ?? [])).join('\n')
+ *     return options.pretty ? JSON.stringify(JSON.parse(source), null, 2) : source
  *   },
  *   print(...nodes) {
  *     return nodes.map(String).join('\n')
  *   },
- * })
+ * }))
  * ```
  */
-export function defineParser<T extends Parser>(parser: T): T {
-  return parser
+export function defineParser<TOptions extends object = object, TMeta extends object = object, TNode = unknown>(
+  factory: (options: TOptions) => Parser<TMeta, TNode>,
+): (options?: TOptions) => Parser<TMeta, TNode> {
+  return (options) => factory(options ?? ({} as TOptions))
 }

--- a/packages/core/src/defineParser.ts
+++ b/packages/core/src/defineParser.ts
@@ -1,9 +1,5 @@
 import type { FileNode } from '@kubb/ast'
 
-type PrintOptions = {
-  extname?: FileNode['extname']
-}
-
 /**
  * Converts a resolved {@link FileNode} into the final source string that gets
  * written to disk. Kubb ships with TypeScript and TSX parsers. Add your own
@@ -26,7 +22,7 @@ export type Parser<TMeta extends object = object, TNode = unknown> = {
   /**
    * Serialize the file's AST into source code.
    */
-  parse(file: FileNode<TMeta>, options?: PrintOptions): string
+  parse(file: FileNode<TMeta>): string
   /**
    * Render compiler AST nodes for this parser's language into source text.
    * Plugins call this to format the nodes they assemble before handing them

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -79,7 +79,7 @@ export type Config<TInput = Input> = {
    * set of file extensions, and a fallback parser handles anything else.
    *
    * Already resolved on the `Config` instance (see `UserConfig` for the
-   * optional form that defaults to `[parserTs, parserTsx, parserMd]`).
+   * optional form that defaults to `[parserTs(), parserTsx(), parserMd()]`).
    *
    * @example
    * ```ts
@@ -87,7 +87,7 @@ export type Config<TInput = Input> = {
    * import { parserTs, parserTsx } from '@kubb/parser-ts'
    *
    * export default defineConfig({
-   *   parsers: [parserTs, parserTsx],
+   *   parsers: [parserTs(), parserTsx()],
    * })
    * ```
    */
@@ -163,18 +163,6 @@ export type Config<TInput = Input> = {
      * ```
      */
     lint?: 'auto' | 'eslint' | 'biome' | 'oxlint' | false
-    /**
-     * Rewrite import extensions in generated files, e.g. emit `.js` imports from `.ts` sources for
-     * ESM dual packages. Keys are the source extension, values the output, and `''` drops it.
-     *
-     * @default { '.ts': '.ts' }
-     * @example
-     * ```ts
-     * extension: { '.ts': '.js' }      // generates import './api.js' instead of './api.ts'
-     * extension: { '.ts': '', '.tsx': '.jsx' }
-     * ```
-     */
-    extension?: Record<FileNode['extname'], FileNode['extname'] | ''>
     /**
      * Banner prepended to every generated file. `'simple'` is the basic Kubb notice, `'full'` adds
      * source, title, description, and API version, and `false` omits it.
@@ -298,7 +286,7 @@ export type UserConfig<TInput = Input> = Omit<Config<TInput>, 'root' | 'plugins'
   root?: string
   /**
    * Custom parsers that convert generated AST nodes to strings (TypeScript, JSON, markdown, etc.).
-   * @default [parserTs, parserTsx, parserMd]  // applied by `defineConfig` from the `kubb` package
+   * @default [parserTs(), parserTsx(), parserMd()]  // applied by `defineConfig` from the `kubb` package
    */
   parsers?: Array<Parser>
   /**

--- a/packages/kubb/src/defineConfig.ts
+++ b/packages/kubb/src/defineConfig.ts
@@ -20,7 +20,7 @@ type DefinedConfig<TConfig extends ConfigInput> = TConfig extends (cli: CLIOptio
  *
  * - `root` defaults to `process.cwd()`
  * - `adapter` defaults to `adapterOas()`
- * - `parsers` defaults to `[parserTs, parserTsx, parserMd]`
+ * - `parsers` defaults to `[parserTs(), parserTsx(), parserMd()]`
  * - `reporters` defaults to `[cliReporter, jsonReporter, fileReporter]`
  * - `plugins` gets `pluginBarrel()` appended when none is already present
  * - `output.barrel` defaults to `{ type: 'named' }` when not set (`pluginBarrel` is always present after the step above)
@@ -39,7 +39,7 @@ function applyDefaults<TInput>(config: UserConfig<TInput>): UserConfig<TInput> {
     ...config,
     root: config.root || process.cwd(),
     adapter,
-    parsers: config.parsers?.length ? config.parsers : [parserTs, parserTsx, parserMd],
+    parsers: config.parsers?.length ? config.parsers : [parserTs(), parserTsx(), parserMd()],
     reporters: config.reporters?.length ? config.reporters : [cliReporter, jsonReporter, fileReporter],
     plugins,
     output,
@@ -59,7 +59,7 @@ function normalizeConfig<TInput>(config: UserConfig<TInput> | Array<UserConfig<T
  *
  * Defaults applied when omitted:
  * - `adapter` → `adapterOas()` (OpenAPI 2.0/3.0/3.1).
- * - `parsers` → `[parserTs, parserTsx, parserMd]`.
+ * - `parsers` → `[parserTs(), parserTsx(), parserMd()]`.
  * - `reporters` → `[cliReporter, jsonReporter, fileReporter]`.
  * - `plugins` → `pluginBarrel()` is appended when not already present.
  * - `output.barrel` → `{ type: 'named' }` when not set.

--- a/packages/parser-md/README.md
+++ b/packages/parser-md/README.md
@@ -46,16 +46,16 @@ import { parserTs } from '@kubb/parser-ts'
 export default defineConfig({
   input: { path: './petstore.yaml' },
   output: { path: './src/gen' },
-  parsers: [parserTs, parserMd],
+  parsers: [parserTs(), parserMd()],
 })
 ```
 
-To convert a metadata object into a YAML frontmatter envelope from inside a plugin, call `print` on the parser instance:
+To convert a metadata object into a YAML frontmatter envelope from inside a plugin, call `print` on a parser instance:
 
 ```typescript
 import { parserMd } from '@kubb/parser-md'
 
-const source = parserMd.print({ title: 'Pets', layout: 'doc' })
+const source = parserMd().print({ title: 'Pets', layout: 'doc' })
 // → ---
 //   title: Pets
 //   layout: doc
@@ -64,12 +64,11 @@ const source = parserMd.print({ title: 'Pets', layout: 'doc' })
 
 ## API
 
-### `parserMd`
+### `parserMd()`
 
-Parser instance for `.md` and `.markdown` files. Pass to `defineConfig({ parsers: [...] })` to emit Markdown source files.
+Factory returning a parser instance for `.md` and `.markdown` files. Pass to `defineConfig({ parsers: [...] })` to emit Markdown source files.
 
-- `parserMd.parse(file)` — serialize a `FileNode` to Markdown source. When `file.meta.frontmatter` is set, the parser prepends the corresponding YAML envelope.
-- `parserMd.print(...parts)` — join markdown fragments separated by blank lines. Plain objects are serialized as YAML frontmatter; strings pass through unchanged.
+The returned instance exposes `parse(file)` to serialize a `FileNode` to Markdown source (prepending the YAML envelope when `file.meta.frontmatter` is set) and `print(...parts)` to join markdown fragments separated by blank lines, serializing plain objects as YAML frontmatter and passing strings through unchanged.
 
 ## Supporting Kubb
 

--- a/packages/parser-md/src/parserMd.test.ts
+++ b/packages/parser-md/src/parserMd.test.ts
@@ -15,7 +15,7 @@ describe('parserMd', () => {
       exports: [],
     })
 
-    expect(parserMd.parse(file)).toBe('# Hello\n\nBody paragraph.')
+    expect(parserMd().parse(file)).toBe('# Hello\n\nBody paragraph.')
   })
 
   it('emits frontmatter from file meta', () => {
@@ -28,7 +28,7 @@ describe('parserMd', () => {
       exports: [],
     })
 
-    expect(parserMd.parse(file)).toBe('---\ntitle: Hi\ntags:\n  - a\n  - b\n---\n\nBody.')
+    expect(parserMd().parse(file)).toBe('---\ntitle: Hi\ntags:\n  - a\n  - b\n---\n\nBody.')
   })
 
   it('omits frontmatter when meta is empty', () => {
@@ -40,7 +40,7 @@ describe('parserMd', () => {
       exports: [],
     })
 
-    expect(parserMd.parse(file)).toBe('Body only.')
+    expect(parserMd().parse(file)).toBe('Body only.')
   })
 
   it('respects banner and footer', () => {
@@ -54,7 +54,7 @@ describe('parserMd', () => {
       exports: [],
     })
 
-    expect(parserMd.parse(file)).toBe('<!-- generated -->\n\nBody.\n\n<!-- end -->')
+    expect(parserMd().parse(file)).toBe('<!-- generated -->\n\nBody.\n\n<!-- end -->')
   })
 
   it('returns empty string when nothing to render', () => {
@@ -66,28 +66,28 @@ describe('parserMd', () => {
       exports: [],
     })
 
-    expect(parserMd.parse(file)).toBe('')
+    expect(parserMd().parse(file)).toBe('')
   })
 })
 
 describe('parserMd.print', () => {
   it('serialize a plain object as a YAML frontmatter envelope', () => {
-    expect(parserMd.print({ title: 'Hi' })).toBe('---\ntitle: Hi\n---')
+    expect(parserMd().print({ title: 'Hi' })).toBe('---\ntitle: Hi\n---')
   })
 
   it('returns an empty string for an empty object', () => {
-    expect(parserMd.print({})).toBe('')
+    expect(parserMd().print({})).toBe('')
   })
 
   it('passes string fragments through and joins with blank lines', () => {
-    expect(parserMd.print('# Hello', 'World')).toBe('# Hello\n\nWorld')
+    expect(parserMd().print('# Hello', 'World')).toBe('# Hello\n\nWorld')
   })
 
   it('mixes frontmatter objects and markdown strings', () => {
-    expect(parserMd.print({ title: 'Hi' }, '# Hello')).toBe('---\ntitle: Hi\n---\n\n# Hello')
+    expect(parserMd().print({ title: 'Hi' }, '# Hello')).toBe('---\ntitle: Hi\n---\n\n# Hello')
   })
 
   it('skips falsy fragments', () => {
-    expect(parserMd.print('# Hello', '', undefined as unknown as string, null as unknown as string, 'World')).toBe('# Hello\n\nWorld')
+    expect(parserMd().print('# Hello', '', undefined as unknown as string, null as unknown as string, 'World')).toBe('# Hello\n\nWorld')
   })
 })

--- a/packages/parser-md/src/parserMd.ts
+++ b/packages/parser-md/src/parserMd.ts
@@ -32,30 +32,32 @@ export type MdMeta = {
  *   input: { path: './petStore.yaml' },
  *   output: { path: './src/gen' },
  *   adapter: adapterOas(),
- *   parsers: [parserTs, parserTsx, parserMd],
+ *   parsers: [parserTs(), parserTsx(), parserMd()],
  *   plugins: [],
  * })
  * ```
  */
-export const parserMd = defineParser({
-  name: 'markdown',
-  extNames: ['.md', '.markdown'],
-  print(...parts: Array<PrintInput>) {
-    return print(...parts)
-  },
-  parse(file) {
-    const sourceParts: Array<string> = []
-    for (const source of file.sources) {
-      const text = extractStringsFromNodes(source.nodes as Array<ast.CodeNode>)
-      if (text) sourceParts.push(text.trimEnd())
-    }
-    const body = sourceParts.join('\n\n')
+export function parserMd() {
+  return defineParser({
+    name: 'markdown',
+    extNames: ['.md', '.markdown'],
+    print(...parts: Array<PrintInput>) {
+      return print(...parts)
+    },
+    parse(file) {
+      const sourceParts: Array<string> = []
+      for (const source of file.sources) {
+        const text = extractStringsFromNodes(source.nodes as Array<ast.CodeNode>)
+        if (text) sourceParts.push(text.trimEnd())
+      }
+      const body = sourceParts.join('\n\n')
 
-    const meta = file.meta as MdMeta | undefined
-    const frontmatter = print(meta?.frontmatter ?? undefined)
+      const meta = file.meta as MdMeta | undefined
+      const frontmatter = print(meta?.frontmatter ?? undefined)
 
-    const parts = [file.banner, frontmatter, body, file.footer].filter((segment): segment is string => Boolean(segment)).map((segment) => segment.trimEnd())
+      const parts = [file.banner, frontmatter, body, file.footer].filter((segment): segment is string => Boolean(segment)).map((segment) => segment.trimEnd())
 
-    return parts.join('\n\n')
-  },
-})
+      return parts.join('\n\n')
+    },
+  })
+}

--- a/packages/parser-md/src/parserMd.ts
+++ b/packages/parser-md/src/parserMd.ts
@@ -37,8 +37,8 @@ export type MdMeta = {
  * })
  * ```
  */
-export function parserMd() {
-  return defineParser({
+export const parserMd = defineParser(() => {
+  return {
     name: 'markdown',
     extNames: ['.md', '.markdown'],
     print(...parts: Array<PrintInput>) {
@@ -59,5 +59,5 @@ export function parserMd() {
 
       return parts.join('\n\n')
     },
-  })
-}
+  }
+})

--- a/packages/parser-ts/README.md
+++ b/packages/parser-ts/README.md
@@ -45,17 +45,27 @@ import { parserTs, parserTsx } from '@kubb/parser-ts'
 export default defineConfig({
   input: { path: './petstore.yaml' },
   output: { path: './src/gen' },
-  parsers: [parserTs, parserTsx],
+  parsers: [parserTs(), parserTsx()],
 })
 ```
 
-To render compiler AST nodes to source text from inside a plugin, call `print` on the parser instance:
+Pass an `extension` map to rewrite the extensions emitted in `import`/`export` statements. Keys are the source extension, values the output, and an empty string drops it. Use `{ '.ts': '.js' }` for ESM when the consumer transpiles to JavaScript:
+
+```typescript
+export default defineConfig({
+  input: { path: './petstore.yaml' },
+  output: { path: './src/gen' },
+  parsers: [parserTs({ extension: { '.ts': '.js' } }), parserTsx()],
+})
+```
+
+To render compiler AST nodes to source text from inside a plugin, call `print` on a parser instance:
 
 ```typescript
 import { parserTs } from '@kubb/parser-ts'
 import ts from 'typescript'
 
-const source = parserTs.print(
+const source = parserTs().print(
   ts.factory.createVariableStatement(
     [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
     ts.factory.createVariableDeclarationList(
@@ -69,16 +79,15 @@ const source = parserTs.print(
 
 ## API
 
-### `parserTs`
+### `parserTs(options?)`
 
-Parser instance for `.ts` and `.js` files. Pass to `defineConfig({ parsers: [...] })` to emit TypeScript source files.
+Factory returning a parser instance for `.ts` and `.js` files. Pass to `defineConfig({ parsers: [...] })` to emit TypeScript source files. The optional `extension` map rewrites the extensions written in `import`/`export` statements and defaults to `{ '.ts': '.ts' }`.
 
-- `parserTs.parse(file, options?)` — serialize a `FileNode` to TypeScript source.
-- `parserTs.print(...nodes)` — convert TypeScript compiler `Node` instances to a formatted source string.
+The returned instance exposes `parse(file)` to serialize a `FileNode` to TypeScript source and `print(...nodes)` to convert TypeScript compiler `Node` instances to a formatted source string.
 
-### `parserTsx`
+### `parserTsx(options?)`
 
-Parser instance for `.tsx` and `.jsx` files. Same API as `parserTs` with JSX support.
+Factory returning a parser instance for `.tsx` and `.jsx` files. Same API and `extension` option as `parserTs`, with JSX support.
 
 ## Supporting Kubb
 

--- a/packages/parser-ts/src/index.ts
+++ b/packages/parser-ts/src/index.ts
@@ -1,2 +1,2 @@
-export { parserTs } from './parserTs.ts'
+export { parserTs, type ParserTsOptions } from './parserTs.ts'
 export { parserTsx } from './parserTsx.ts'

--- a/packages/parser-ts/src/parserTs.test.ts
+++ b/packages/parser-ts/src/parserTs.test.ts
@@ -22,7 +22,7 @@ describe('parserTs', () => {
       exports: [],
     })
 
-    const result = await parserTs.parse(file, { extname: '.ts' })
+    const result = await parserTs().parse(file)
     expect(result).toContain('export const schema = z.string()')
   })
 
@@ -50,8 +50,35 @@ describe('parserTs', () => {
       exports: [],
     })
 
-    const result = await parserTs.parse(file, { extname: '.ts' })
+    const result = await parserTs().parse(file)
     expect(result).toContain('export type Pet = { id: number }')
     expect(result).toContain('export const pet = {}')
+  })
+
+  describe('extension option', () => {
+    function createFileWithImport() {
+      return ast.factory.createFile({
+        baseName: 'test.ts',
+        path: '/src/test.ts',
+        sources: [],
+        imports: [ast.factory.createImport({ name: ['Pet'], path: '/src/models/pet.ts', root: '/src' })],
+        exports: [],
+      })
+    }
+
+    it('keeps the source extension by default', async () => {
+      const result = await parserTs().parse(createFileWithImport())
+      expect(result).toContain("import { Pet } from './models/pet.ts'")
+    })
+
+    it('rewrites the import extension to the mapped value', async () => {
+      const result = await parserTs({ extension: { '.ts': '.js' } }).parse(createFileWithImport())
+      expect(result).toContain("import { Pet } from './models/pet.js'")
+    })
+
+    it('drops the extension when the mapped value is an empty string', async () => {
+      const result = await parserTs({ extension: { '.ts': '' } }).parse(createFileWithImport())
+      expect(result).toContain("import { Pet } from './models/pet'")
+    })
   })
 })

--- a/packages/parser-ts/src/parserTs.ts
+++ b/packages/parser-ts/src/parserTs.ts
@@ -3,11 +3,32 @@ import { defineParser } from '@kubb/core'
 import type * as ts from 'typescript'
 import { getRelativePath, print, printExport, printImport, printSource, resolveOutputPath } from './utils.ts'
 
+const DEFAULT_EXTENSION: Record<FileNode['extname'], FileNode['extname'] | ''> = { '.ts': '.ts' }
+
+/**
+ * Options accepted by `parserTs` and `parserTsx`.
+ */
+export type ParserTsOptions = {
+  /**
+   * Rewrite the extensions emitted in `import`/`export` statements, e.g. emit `.js` imports from
+   * `.ts` sources for ESM dual packages. Keys are the source extension, values the output, and `''`
+   * drops it. Only the module-specifier string changes, never the on-disk filename.
+   *
+   * @default { '.ts': '.ts' }
+   * @example
+   * ```ts
+   * parserTs({ extension: { '.ts': '.js' } })         // import './api.js' instead of './api.ts'
+   * parserTs({ extension: { '.ts': '', '.tsx': '.jsx' } })
+   * ```
+   */
+  extension?: Record<FileNode['extname'], FileNode['extname'] | ''>
+}
+
 /**
  * Default Kubb parser for `.ts` and `.js` files. Takes the universal AST
  * produced by an adapter and prints it as TypeScript source using the official
  * TypeScript compiler. Imports and exports are rewritten based on each file's
- * metadata.
+ * metadata and the `extension` option.
  *
  * Used automatically when no `parsers` option is set on `defineConfig`. Use
  * `parserTsx` instead for React projects that emit JSX.
@@ -22,56 +43,60 @@ import { getRelativePath, print, printExport, printImport, printSource, resolveO
  *   input: { path: './petStore.yaml' },
  *   output: { path: './src/gen' },
  *   adapter: adapterOas(),
- *   parsers: [parserTs],
+ *   parsers: [parserTs()],
  *   plugins: [],
  * })
  * ```
  */
-export const parserTs = defineParser({
-  name: 'typescript',
-  extNames: ['.ts', '.js'],
-  print(...nodes: Array<ts.Node>) {
-    return print(...nodes)
-  },
-  parse(file, options = { extname: '.ts' }) {
-    const sourceParts: Array<string> = []
-    for (const item of file.sources) {
-      const sourceStr = printSource(item as SourceNode)
-      if (sourceStr) {
-        sourceParts.push(sourceStr.trimEnd())
+export function parserTs({ extension = DEFAULT_EXTENSION }: ParserTsOptions = {}) {
+  return defineParser({
+    name: 'typescript',
+    extNames: ['.ts', '.js'],
+    print(...nodes: Array<ts.Node>) {
+      return print(...nodes)
+    },
+    parse(file) {
+      const extname = extension[file.extname] || undefined
+
+      const sourceParts: Array<string> = []
+      for (const item of file.sources) {
+        const sourceStr = printSource(item as SourceNode)
+        if (sourceStr) {
+          sourceParts.push(sourceStr.trimEnd())
+        }
       }
-    }
-    const source = sourceParts.join('\n\n')
+      const source = sourceParts.join('\n\n')
 
-    const importLines: Array<string> = []
-    for (const item of (file as FileNode).imports) {
-      const importPath = item.root ? getRelativePath(item.root, item.path) : item.path
-      importLines.push(
-        printImport({
-          name: item.name as string | Array<string | { propertyName: string; name?: string }>,
-          path: resolveOutputPath(importPath, options, Boolean(item.root)),
-          isTypeOnly: item.isTypeOnly,
-          isNameSpace: item.isNameSpace,
-        }),
-      )
-    }
+      const importLines: Array<string> = []
+      for (const item of (file as FileNode).imports) {
+        const importPath = item.root ? getRelativePath(item.root, item.path) : item.path
+        importLines.push(
+          printImport({
+            name: item.name as string | Array<string | { propertyName: string; name?: string }>,
+            path: resolveOutputPath(importPath, { extname }, Boolean(item.root)),
+            isTypeOnly: item.isTypeOnly,
+            isNameSpace: item.isNameSpace,
+          }),
+        )
+      }
 
-    const exportLines: Array<string> = []
-    for (const item of (file as FileNode).exports) {
-      exportLines.push(
-        printExport({
-          name: item.name as string | Array<ts.Identifier | string> | null | undefined,
-          path: resolveOutputPath(item.path, options, true),
-          isTypeOnly: item.isTypeOnly,
-          asAlias: item.asAlias,
-        }),
-      )
-    }
+      const exportLines: Array<string> = []
+      for (const item of (file as FileNode).exports) {
+        exportLines.push(
+          printExport({
+            name: item.name as string | Array<ts.Identifier | string> | null | undefined,
+            path: resolveOutputPath(item.path, { extname }, true),
+            isTypeOnly: item.isTypeOnly,
+            asAlias: item.asAlias,
+          }),
+        )
+      }
 
-    const importExportBlock = [...importLines, ...exportLines].join('\n')
+      const importExportBlock = [...importLines, ...exportLines].join('\n')
 
-    const parts = [file.banner, importExportBlock, source, file.footer].filter((segment): segment is string => Boolean(segment)).map((s) => s.trimEnd())
+      const parts = [file.banner, importExportBlock, source, file.footer].filter((segment): segment is string => Boolean(segment)).map((s) => s.trimEnd())
 
-    return parts.join('\n\n')
-  },
-})
+      return parts.join('\n\n')
+    },
+  })
+}

--- a/packages/parser-ts/src/parserTs.ts
+++ b/packages/parser-ts/src/parserTs.ts
@@ -48,7 +48,7 @@ export type ParserTsOptions = {
  * })
  * ```
  */
-export const parserTs = defineParser(({ extension = DEFAULT_EXTENSION }: ParserTsOptions = {}) => {
+export const parserTs = defineParser<ParserTsOptions>(({ extension = DEFAULT_EXTENSION } = {}) => {
   return {
     name: 'typescript',
     extNames: ['.ts', '.js'],

--- a/packages/parser-ts/src/parserTs.ts
+++ b/packages/parser-ts/src/parserTs.ts
@@ -48,8 +48,8 @@ export type ParserTsOptions = {
  * })
  * ```
  */
-export function parserTs({ extension = DEFAULT_EXTENSION }: ParserTsOptions = {}) {
-  return defineParser({
+export const parserTs = defineParser(({ extension = DEFAULT_EXTENSION }: ParserTsOptions = {}) => {
+  return {
     name: 'typescript',
     extNames: ['.ts', '.js'],
     print(...nodes: Array<ts.Node>) {
@@ -98,5 +98,5 @@ export function parserTs({ extension = DEFAULT_EXTENSION }: ParserTsOptions = {}
 
       return parts.join('\n\n')
     },
-  })
-}
+  }
+})

--- a/packages/parser-ts/src/parserTsx.ts
+++ b/packages/parser-ts/src/parserTsx.ts
@@ -1,11 +1,12 @@
 import { defineParser } from '@kubb/core'
 import type * as ts from 'typescript'
-import { parserTs } from './parserTs.ts'
+import { parserTs, type ParserTsOptions } from './parserTs.ts'
 import { print } from './utils.ts'
 
 /**
  * Kubb parser for `.tsx` and `.jsx` files. Delegates to `parserTs` because the
- * TypeScript compiler handles JSX natively via `ScriptKind.TSX`.
+ * TypeScript compiler handles JSX natively via `ScriptKind.TSX`, so it shares the
+ * same `extension` option.
  *
  * Add to the `parsers` array on `defineConfig` when generating components for
  * React (or any framework that emits JSX).
@@ -20,18 +21,22 @@ import { print } from './utils.ts'
  *   input: { path: './petStore.yaml' },
  *   output: { path: './src/gen' },
  *   adapter: adapterOas(),
- *   parsers: [parserTsx],
+ *   parsers: [parserTsx()],
  *   plugins: [],
  * })
  * ```
  */
-export const parserTsx = defineParser({
-  name: 'tsx',
-  extNames: ['.tsx', '.jsx'],
-  print(...nodes: Array<ts.Node>) {
-    return print(...nodes)
-  },
-  parse(file, options = { extname: '.tsx' }) {
-    return parserTs.parse(file, options)
-  },
-})
+export function parserTsx(options: ParserTsOptions = {}) {
+  const parser = parserTs(options)
+
+  return defineParser({
+    name: 'tsx',
+    extNames: ['.tsx', '.jsx'],
+    print(...nodes: Array<ts.Node>) {
+      return print(...nodes)
+    },
+    parse(file) {
+      return parser.parse(file)
+    },
+  })
+}

--- a/packages/parser-ts/src/parserTsx.ts
+++ b/packages/parser-ts/src/parserTsx.ts
@@ -26,10 +26,10 @@ import { print } from './utils.ts'
  * })
  * ```
  */
-export function parserTsx(options: ParserTsOptions = {}) {
+export const parserTsx = defineParser((options: ParserTsOptions = {}) => {
   const parser = parserTs(options)
 
-  return defineParser({
+  return {
     name: 'tsx',
     extNames: ['.tsx', '.jsx'],
     print(...nodes: Array<ts.Node>) {
@@ -38,5 +38,5 @@ export function parserTsx(options: ParserTsOptions = {}) {
     parse(file) {
       return parser.parse(file)
     },
-  })
-}
+  }
+})

--- a/packages/parser-ts/src/parserTsx.ts
+++ b/packages/parser-ts/src/parserTsx.ts
@@ -26,7 +26,7 @@ import { print } from './utils.ts'
  * })
  * ```
  */
-export const parserTsx = defineParser((options: ParserTsOptions = {}) => {
+export const parserTsx = defineParser<ParserTsOptions>((options = {}) => {
   const parser = parserTs(options)
 
   return {

--- a/packages/unplugin-kubb/src/unpluginFactory.ts
+++ b/packages/unplugin-kubb/src/unpluginFactory.ts
@@ -89,7 +89,7 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, m
     const config = {
       ...options.config,
       adapter,
-      parsers: options.config.parsers?.length ? options.config.parsers : [parserTs, parserTsx],
+      parsers: options.config.parsers?.length ? options.config.parsers : [parserTs(), parserTsx()],
       plugins,
       output,
     }


### PR DESCRIPTION
## 🎯 Changes

`output.extension` only ever rewrote the extensions inside `import` and `export` statements, never the on-disk filename, so it now lives on the parser that does the work.

- `parserTs`, `parserTsx`, and `parserMd` are now factory functions, matching the plugin convention (`pluginTs()`).
- `parserTs` and `parserTsx` accept an `extension` map (default `{ '.ts': '.ts' }`).
- Removed `output.extension` from the config type and defaults, and stopped threading it through `KubbDriver` → `FileManager`.
- Dropped the `extname` argument from `Parser.parse`; each parser resolves the extension from its own option.
- `defineConfig` and `unplugin-kubb` now apply `[parserTs(), parserTsx(), parserMd()]`.

Migration:

```ts
// before
output: { path: './src/gen', extension: { '.ts': '.js' } },
parsers: [parserTs, parserTsx, parserMd],

// after
output: { path: './src/gen' },
parsers: [parserTs({ extension: { '.ts': '.js' } }), parserTsx(), parserMd()],
```

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test` (1323 passed, plus typecheck and lint clean).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (`major`).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M1vHsoHZJrQLbLWeZtUJ9F

---
_Generated by [Claude Code](https://claude.ai/code/session_01M1vHsoHZJrQLbLWeZtUJ9F)_