### PR TITLE
Trim redundant @example blocks from guards.ts JSDoc

### DIFF
--- a/packages/adapter-oas/src/guards.ts
+++ b/packages/adapter-oas/src/guards.ts
@@ -5,13 +5,6 @@ import type { DiscriminatorObject, ReferenceObject, SchemaObject } from './types
  *
  * Recognizes all nullable signals across OAS versions: `nullable: true` (OAS 3.0),
  * `x-nullable: true` (vendor extension), `type: 'null'`, and `type: ['null', ...]` (OAS 3.1).
- *
- * @example
- * ```ts
- * isNullable({ type: 'string', nullable: true }) // true
- * isNullable({ type: ['string', 'null'] })       // true
- * isNullable({ type: 'string' })                 // false
- * ```
  */
 export function isNullable(schema?: SchemaObject & { 'x-nullable'?: boolean }): boolean {
   const explicitNullable = schema?.nullable ?? schema?.['x-nullable']
@@ -26,25 +19,14 @@ export function isNullable(schema?: SchemaObject & { 'x-nullable'?: boolean }): 
 
 /**
  * Returns `true` when `obj` is an OpenAPI `$ref` pointer object.
- *
- * @example
- * ```ts
- * isReference({ $ref: '#/components/schemas/Pet' }) // true
- * isReference({ type: 'string' })                   // false
- * ```
  */
 export function isReference(obj?: unknown): obj is ReferenceObject {
   return !!obj && typeof obj === 'object' && '$ref' in obj
 }
 
 /**
- * Returns `true` when `obj` is a schema with a structured OAS 3.x `discriminator` object.
- *
- * @example
- * ```ts
- * isDiscriminator({ discriminator: { propertyName: 'type', mapping: {} } }) // true
- * isDiscriminator({ discriminator: 'type' })                                 // false (Swagger 2 string form)
- * ```
+ * Returns `true` when `obj` is a schema with a structured OAS 3.x `discriminator` object,
+ * excluding the Swagger 2 string form.
  */
 export function isDiscriminator(obj?: unknown): obj is SchemaObject & { discriminator: DiscriminatorObject } {
   const record = obj as Record<string, unknown>
@@ -53,12 +35,6 @@ export function isDiscriminator(obj?: unknown): obj is SchemaObject & { discrimi
 
 /**
  * Returns `true` when a schema is a binary payload: an octet-stream string body.
- *
- * @example
- * ```ts
- * isBinary({ type: 'string', contentMediaType: 'application/octet-stream' }) // true
- * isBinary({ type: 'string' })                                               // false
- * ```
  */
 export function isBinary(schema: SchemaObject): boolean {
   return schema.type === 'string' && schema.contentMediaType === 'application/octet-stream'


### PR DESCRIPTION
## 🎯 Changes

Follows up on a review of `packages/adapter-oas/src/guards.ts`. The `@example` blocks on `isNullable`, `isReference`, `isDiscriminator`, and `isBinary` restated what the one-sentence descriptions and type signatures already conveyed, so they're removed from all four guards for consistency (rather than trimming just one and leaving the others inconsistent).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).


---
_Generated by [Claude Code](https://claude.ai/code/session_01E4FRRDikoCesLqVcCqqzYi)_