### PR TITLE
feat: add deslop skill and /deslop command

### DIFF
--- a/.agents/skills/deslop/SKILL.md
+++ b/.agents/skills/deslop/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: deslop
+description: Remove AI-generated code slop from a branch or diff. Use after writing or generating code to strip unnecessary comments, defensive checks, `any` casts, and style that does not match the surrounding file. For prose and markdown, use the humanizer skill instead.
+---
+
+# Deslop
+
+Remove AI-generated code slop introduced in a branch so the diff reads like a human wrote it and
+matches the surrounding file and this repo's conventions.
+
+## When to use
+
+- After writing or generating a batch of code, before opening a PR.
+- When a diff shows the tells of AI generation: over-commenting, defensive scaffolding, or style
+  that fights the existing file.
+- Prose and user-facing markdown are out of scope. Run the `humanizer` skill over those instead.
+
+## What to remove
+
+- Comments a human would not add: restating what the code already says, or inconsistent with the
+  comment density of the rest of the file.
+- Defensive checks and `try/catch` blocks abnormal for the area, especially on trusted or
+  already-validated code paths. The `security` rule puts validation at trust boundaries, not in
+  internal code.
+- Casts to `any` used only to bypass a type error. Fix the type instead.
+- Deep nesting that early returns would flatten.
+- Naming, import, or export style inconsistent with the file and the `code-style` rule.
+
+## Guardrails
+
+- Keep behavior unchanged unless you are fixing a clear bug.
+- Prefer minimal, surgical edits over broad rewrites.
+- Never remove a check that guards a real trust boundary or real error handling. When unsure
+  whether a check is slop or load-bearing, leave it.
+- Do not weaken types, lint rules, or tests to make the edit pass. Fix the root cause.
+- After editing, run `pnpm format && pnpm lint:fix` and let the tests pass.
+- Report a 1-3 sentence summary of what changed.
+
+## Related skills
+
+| Skill | Use for |
+| --- | --- |
+| [humanizer](../humanizer/SKILL.md) | Removing AI tells from prose and user-facing markdown |

--- a/.claude/commands/deslop.md
+++ b/.claude/commands/deslop.md
@@ -1,0 +1,20 @@
+---
+argument-hint: [path]
+description: Remove AI-generated code slop from the current branch's changes
+---
+
+!`git diff --stat HEAD`
+
+Remove AI-generated code slop from the changes on this branch.
+
+1. Review the branch's changes: the diff against the default branch, narrowed to `$ARGUMENTS`
+   when a path or glob is given.
+2. Strip the AI tells: unnecessary or inconsistent comments, defensive checks and `try/catch` on
+   trusted code paths, `any` casts that only dodge a type error, and deep nesting that early
+   returns would flatten.
+3. Keep behavior unchanged unless fixing a clear bug. Make minimal, surgical edits and do not
+   weaken types, lint rules, or tests.
+4. Run `pnpm format && pnpm lint:fix` and report a 1-3 sentence summary.
+
+Follow the `deslop` skill for the full checklist. For prose and user-facing markdown, use the
+`humanizer` skill instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ subagents, output styles, and hooks.
 You have new skills. If any skill might be relevant then you MUST read it.
 
 - [changelog](.agents/skills/changelog/SKILL.md) - Automatically creates user-facing changelogs from git commits by analyzing commit history, categorizing changes, and transforming technical commits into clear, customer-friendly release notes. Turns hours of manual changelog writing into minutes of automated generation.
+- [deslop](.agents/skills/deslop/SKILL.md) - Remove AI-generated code slop from a branch or diff. Use after writing or generating code to strip unnecessary comments, defensive checks, `any` casts, and style that does not match the surrounding file. For prose and markdown, use the humanizer skill instead.
 - [documentation](.agents/skills/documentation/SKILL.md) - Use when writing blog posts or documentation markdown files - provides writing style guide (active voice, present tense), content structure patterns, and SEO optimization. Overrides brevity rules for proper grammar.
 - [humanizer](.agents/skills/humanizer/SKILL.md) - Remove AI writing patterns to make documentation sound natural, specific, and human. Covers content patterns, language patterns, style patterns, and communication patterns.
 - [jsdoc](.agents/skills/jsdoc/SKILL.md) - Full JSDoc format guide for TypeScript, covering @example formats (short, multi-line, multi-variant), tag usage (@default, @deprecated, what to avoid), documentation patterns for properties/enums/functions, and tag order.


### PR DESCRIPTION
## 🎯 Changes

Add a `deslop` skill and a matching `/deslop` slash command. `deslop` reviews the branch diff and removes AI-generated code slop: comments a human would not add, defensive checks and `try/catch` on trusted code paths, `any` casts that only dodge a type error, and deep nesting that early returns would flatten. It is the code counterpart to the existing `humanizer` skill, which handles prose, and points at `humanizer` for user-facing markdown.

New files:

- `.agents/skills/deslop/SKILL.md` (surfaced through the `.claude/skills` symlink)
- `.claude/commands/deslop.md`

The `AGENTS.md` `<skills>` block now lists `deslop`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

Markdown-only tooling change, so no code tests apply.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RKWAmu5zVBmX33w1rZKkdR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKWAmu5zVBmX33w1rZKkdR)_