### PR TITLE
docs: correct CONTRIBUTING.md to match current repo structure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,7 @@ kubb/
 │   ├── ast/                 # Spec-agnostic AST layer (nodes, visitors, factories)
 │   ├── adapter-oas/         # OpenAPI/Swagger adapter (OAS to AST)
 │   ├── parser-ts/           # TypeScript parser for AST manipulation
+│   ├── parser-md/           # Markdown parser (AST to .md source, YAML frontmatter)
 │   ├── renderer-jsx/        # JSX renderer for component-based output
 │   ├── plugin-barrel/       # Barrel export generation (enforce: 'post' plugin)
 │   ├── unplugin-kubb/       # Bundler integration (Vite, Nuxt, Astro, webpack)
@@ -51,9 +52,8 @@ kubb/
 │   ├── mcp/                 # Model Context Protocol server for AI assistants
 │   └── kubb/                # Main package, re-exports the public APIs
 ├── internals/               # Non-published helpers (changelog, shared logic, utils)
-├── schemas/                 # JSON/YAML schemas for configuration
 ├── configs/                 # Shared build and test configuration
-├── docs/                    # Architecture notes and guides
+├── scripts/                 # Release and maintenance scripts
 └── .agents/skills/          # Cross-provider agent skills
 ```
 


### PR DESCRIPTION
## 🎯 Changes

Validated `CONTRIBUTING.md` against the current repository layout and fixed the drift in the "What is inside this repo" tree.

- Added the `parser-md` package, which exists in `packages/` but was missing from the tree.
- Removed the `schemas/` and `docs/` entries, which no longer exist at the repo root (docs live in `kubb-labs/docs`).
- Added the `scripts/` directory, which holds the release scripts referenced in the Releasing section.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).

---
_Generated by [Claude Code](https://claude.ai/code/session_01K33US8TsjvdWT2ungdVPC3)_