### PR TITLE
fix: resolve verified behavioral bugs and type/doc mismatches across packages

### DIFF
--- a/.changeset/ast-node-and-scalar-types.md
+++ b/.changeset/ast-node-and-scalar-types.md
@@ -1,0 +1,7 @@
+---
+'@kubb/ast': patch
+---
+
+Align the `Node` and scalar schema types with the runtime and fix related docs.
+
+`Node` now includes `TextNode`, `BreakNode`, and `JsxNode` so the union matches `NodeKind` and the `isNode` runtime check that already treats them as nodes. `ScalarSchemaType` no longer includes `ipv4` and `ipv6`, which have their own `Ipv4SchemaNode` and `Ipv6SchemaNode`, so `ScalarSchemaNode` stops overlapping those members. The `VisitorDepth` doc now states that shallow traversal stops at schema subtrees rather than the immediate node, and the `PrinterHandlerContext` example includes its required `base` field.

--- a/.changeset/cli-loglevel-telemetry.md
+++ b/.changeset/cli-loglevel-telemetry.md
@@ -1,0 +1,7 @@
+---
+'@kubb/cli': patch
+---
+
+Tidy up a few CLI correctness details.
+
+The clack logger's plugin-end guard now compares with `<= silent` like every other log-level guard, rather than a lone equality check that only worked because `silent` is negative infinity. The telemetry event type drops the `agent` command that no caller ever sends. The `generate` command resolves its log level through a small helper instead of a nested ternary.

--- a/.changeset/core-reporter-buffer.md
+++ b/.changeset/core-reporter-buffer.md
@@ -1,0 +1,7 @@
+---
+'@kubb/core': patch
+---
+
+Collect reporter results in an ordered array and only buffer them when a `drain` exists.
+
+A reporter whose `report` returned `void` (the default) or any repeated value collapsed to one entry in the backing `Set`, so `drain` received a single item for a run that generated several configs. Reporters without a `drain` also kept every result in memory for the life of the run. Results now keep their order and count, and a reporter with no `drain` buffers nothing.

--- a/.changeset/mcp-config-discovery-mjs.md
+++ b/.changeset/mcp-config-discovery-mjs.md
@@ -1,0 +1,7 @@
+---
+'@kubb/mcp': patch
+---
+
+Discover `kubb.config.mjs` during config auto-discovery and report each config error once.
+
+The `generate` tool searched every allowed config extension except `.mjs`, so a project whose only config was `kubb.config.mjs` was told no config existed unless it passed an explicit path. The tool also emitted `CONFIG_ERROR` a second time from its catch block after `loadUserConfig` had already reported it. Auto-discovery now includes `kubb.config.mjs` and each config error surfaces a single time.

--- a/.changeset/parser-ts-named-export.md
+++ b/.changeset/parser-ts-named-export.md
@@ -1,0 +1,7 @@
+---
+'@kubb/parser-ts': patch
+---
+
+Render a single string export name as a named re-export.
+
+`printExport` warned to the console and fell back to a wildcard when `name` was a string without `asAlias`, silently dropping the name. It now emits `export { Name } from './path'`, which matches the single-export form documented on `ExportNode`, and no longer writes to the console from a string builder.

--- a/.changeset/plugin-barrel-named-nested-exports.md
+++ b/.changeset/plugin-barrel-named-nested-exports.md
@@ -1,0 +1,7 @@
+---
+'@kubb/plugin-barrel': patch
+---
+
+Honor `barrelType: 'named'` when generating nested barrels.
+
+With `{ type: 'named', nested: true }` the nested walk emitted a wildcard `export *` for every file, so leaf modules were re-exported by wildcard instead of by their named symbols. Nested barrels now apply the named strategy to leaf files and only chain a sub-directory barrel that actually produced output, so an empty sub-directory no longer leaves a dangling `export * from './sub'`.

--- a/.changeset/renderer-jsx-error-prefix.md
+++ b/.changeset/renderer-jsx-error-prefix.md
@@ -1,0 +1,7 @@
+---
+'@kubb/renderer-jsx': patch
+---
+
+Prefix the stray-text error with `[jsx]` instead of `[react]`.
+
+The error raised when raw text sits directly under `<File>` was tagged `[react]`, but this renderer has no React runtime, so the prefix pointed at the wrong thing.

--- a/packages/ast/src/constants.ts
+++ b/packages/ast/src/constants.ts
@@ -3,8 +3,9 @@ import type { SchemaType } from './nodes/schema.ts'
 /**
  * Traversal depth for AST visitor utilities.
  *
- * - `'shallow'` visits only the immediate node, skipping children.
- * - `'deep'` recursively visits all descendant nodes.
+ * - `'shallow'` recurses through every node except nested `Schema` subtrees, which it treats as
+ *   leaves: a schema node itself is visited, but its children are not.
+ * - `'deep'` recursively visits all descendant nodes, including schema subtrees.
  */
 export type VisitorDepth = 'shallow' | 'deep'
 

--- a/packages/ast/src/createPrinter.ts
+++ b/packages/ast/src/createPrinter.ts
@@ -10,6 +10,7 @@ import type { SchemaNode, SchemaNodeByType, SchemaType } from './nodes/index.ts'
  * const context: PrinterHandlerContext<string, {}> = {
  *   options: {},
  *   transform: () => 'value',
+ *   base: () => 'value',
  * }
  * ```
  */

--- a/packages/ast/src/nodes/index.ts
+++ b/packages/ast/src/nodes/index.ts
@@ -1,4 +1,4 @@
-import type { ArrowFunctionNode, ConstNode, FunctionNode, TypeNode } from './code.ts'
+import type { ArrowFunctionNode, BreakNode, ConstNode, FunctionNode, JsxNode, TextNode, TypeNode } from './code.ts'
 import type { ContentNode } from './content.ts'
 import type { ExportNode, FileNode, ImportNode, SourceNode } from './file.ts'
 import type { InputNode } from './input.ts'
@@ -79,3 +79,6 @@ export type Node =
   | TypeNode
   | FunctionNode
   | ArrowFunctionNode
+  | TextNode
+  | BreakNode
+  | JsxNode

--- a/packages/ast/src/nodes/schema.ts
+++ b/packages/ast/src/nodes/schema.ts
@@ -94,6 +94,8 @@ export type ScalarSchemaType = Exclude<
   | 'url'
   | 'uuid'
   | 'email'
+  | 'ipv4'
+  | 'ipv6'
 >
 
 /**

--- a/packages/cli/src/Telemetry.ts
+++ b/packages/cli/src/Telemetry.ts
@@ -91,7 +91,7 @@ export function isDisabled(): boolean {
  * Build an anonymous telemetry payload from a completed generation run.
  */
 export function buildTelemetryEvent(options: {
-  command: 'generate' | 'mcp' | 'validate' | 'agent'
+  command: 'generate' | 'mcp' | 'validate'
   kubbVersion: string
   plugins?: Array<TelemetryPlugin>
   hrStart: [number, number]

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -21,6 +21,15 @@ function parseReporters(value: string): Array<ReporterName> {
   return names as Array<ReporterName>
 }
 
+/**
+ * Resolves the effective log level, letting the `--verbose` and `--silent` flags win over `--logLevel`.
+ */
+function resolveLogLevel({ verbose, silent, logLevel }: { verbose: boolean; silent: boolean; logLevel: string }): string {
+  if (verbose) return 'verbose'
+  if (silent) return 'silent'
+  return logLevel
+}
+
 export const command = define({
   name: 'generate',
   description:
@@ -69,7 +78,7 @@ export const command = define({
     },
   },
   async run({ values }) {
-    const logLevel = values.verbose ? 'verbose' : values.silent ? 'silent' : values.logLevel
+    const logLevel = resolveLogLevel(values)
     const { run } = await import('../runners/generate/run.ts')
 
     await run({

--- a/packages/cli/src/loggers/clackLogger.ts
+++ b/packages/cli/src/loggers/clackLogger.ts
@@ -246,7 +246,7 @@ Run \`npm install -g @kubb/cli\` to update`,
 
       const active = state.activeProgress.get('plugins')
 
-      if (!active || logLevel === logLevelMap.silent) {
+      if (!active || logLevel <= logLevelMap.silent) {
         return
       }
 

--- a/packages/core/src/createReporter.ts
+++ b/packages/core/src/createReporter.ts
@@ -110,20 +110,22 @@ export type UserReporter<T = void> = {
  * ```
  */
 export function createReporter<T = void>(reporter: UserReporter<T>): Reporter {
-  const reports = new Set<T>()
+  const reports: Array<T> = []
 
   return {
     name: reporter.name,
     async report(result, context) {
       const report = await reporter.report(result, context)
-      reports.add(report)
+      if (reporter.drain) {
+        reports.push(report)
+      }
     },
     async drain(context) {
-      await reporter.drain?.(context, Array.from(reports))
-      reports.clear()
+      await reporter.drain?.(context, [...reports])
+      reports.length = 0
     },
     [Symbol.dispose]() {
-      reports.clear()
+      reports.length = 0
     },
   }
 }

--- a/packages/core/src/createStorage.ts
+++ b/packages/core/src/createStorage.ts
@@ -30,7 +30,11 @@ export type Storage = {
    */
   getKeys(base?: string): Promise<Array<string>>
   /**
-   * Removes every entry. Pass `base` to scope the wipe to a key prefix.
+   * Removes stored entries. Pass `base` to scope the wipe to a key prefix.
+   *
+   * Omitting `base` is implementation-defined: in-memory stores wipe every
+   * entry, while filesystem-backed stores treat a missing `base` as a no-op so
+   * a bare `clear()` can never delete outside a known output directory.
    */
   clear(base?: string): Promise<void>
 }

--- a/packages/mcp/src/tools/generate.ts
+++ b/packages/mcp/src/tools/generate.ts
@@ -88,7 +88,6 @@ export const generateTool = defineTool(
         })
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error)
-        await notify('CONFIG_ERROR', errorMessage)
         return tool.error(errorMessage)
       }
 

--- a/packages/mcp/src/utils.ts
+++ b/packages/mcp/src/utils.ts
@@ -84,7 +84,7 @@ export async function loadUserConfig(configPath: string | undefined, { notify }:
   }
 
   const cwd = process.cwd()
-  const configFileNames = ['kubb.config.ts', 'kubb.config.mts', 'kubb.config.cts', 'kubb.config.js', 'kubb.config.cjs']
+  const configFileNames = ['kubb.config.ts', 'kubb.config.mts', 'kubb.config.cts', 'kubb.config.js', 'kubb.config.mjs', 'kubb.config.cjs']
 
   for (const configFileName of configFileNames) {
     const configFilePath = path.resolve(process.cwd(), configFileName)

--- a/packages/parser-md/src/parserMd.ts
+++ b/packages/parser-md/src/parserMd.ts
@@ -53,7 +53,7 @@ export const parserMd = defineParser(() => {
       const body = sourceParts.join('\n\n')
 
       const meta = file.meta as MdMeta | undefined
-      const frontmatter = print(meta?.frontmatter ?? undefined)
+      const frontmatter = print(meta?.frontmatter)
 
       const parts = [file.banner, frontmatter, body, file.footer].filter((segment): segment is string => Boolean(segment)).map((segment) => segment.trimEnd())
 

--- a/packages/parser-ts/src/utils.test.ts
+++ b/packages/parser-ts/src/utils.test.ts
@@ -658,4 +658,8 @@ describe('printExport', () => {
   it('renders a type-only named re-export', () => {
     expect(printExport({ name: ['Pet'], path: './Pet.ts', isTypeOnly: true })).toMatchInlineSnapshot(`"export type { Pet } from './Pet.ts'"`)
   })
+
+  it('renders a single string name as a named re-export', () => {
+    expect(printExport({ name: 'Pet', path: './Pet.ts' })).toMatchInlineSnapshot(`"export { Pet } from './Pet.ts'"`)
+  })
 })

--- a/packages/parser-ts/src/utils.ts
+++ b/packages/parser-ts/src/utils.ts
@@ -478,7 +478,7 @@ export function printExport({
   }
 
   if (name) {
-    console.warn(`When using name as string, asAlias should be true: ${name}`)
+    return `export ${typePrefix}{ ${name} } from ${from}`
   }
 
   return `export ${typePrefix}* from ${from}`

--- a/packages/plugin-barrel/src/utils.test.ts
+++ b/packages/plugin-barrel/src/utils.test.ts
@@ -57,6 +57,17 @@ describe('getBarrelFiles', () => {
     expect(barrels.map((b) => b.path)).toStrictEqual(expect.arrayContaining([`${ROOT}/index.ts`, `${ROOT}/pets/index.ts`, `${ROOT}/users/index.ts`]))
   })
 
+  it('emits named exports for leaf files when nested and barrelType named', () => {
+    const files = [makeFile(`${ROOT}/pets/listPets.ts`, ['listPets']), makeFile(`${ROOT}/users/getUser.ts`, ['getUser'])]
+    const barrels = [...getBarrelFiles({ outputPath: ROOT, files, barrelType: 'named', nested: true })]
+
+    const petsBarrel = barrels.find((b) => b.path === `${ROOT}/pets/index.ts`)!
+    expect(petsBarrel.exports[0]?.name).toStrictEqual(['listPets'])
+
+    const rootBarrel = barrels.find((b) => b.path === `${ROOT}/index.ts`)!
+    expect(rootBarrel.exports.map((e) => e.path)).toStrictEqual(expect.arrayContaining(['./pets/index.ts', './users/index.ts']))
+  })
+
   it('generates per-subdirectory barrels when recursive is true', () => {
     const files = [makeFile(`${ROOT}/pets/listPets.ts`), makeFile(`${ROOT}/users/getUser.ts`)]
     const barrels = [...getBarrelFiles({ outputPath: ROOT, files, barrelType: 'all', recursive: true })]

--- a/packages/plugin-barrel/src/utils.ts
+++ b/packages/plugin-barrel/src/utils.ts
@@ -216,27 +216,41 @@ function* walkAllOrNamed(node: BuildTree, params: LeafWalkParams, isRoot: boolea
   return subtreeLeaves
 }
 
+type NestedWalkParams = {
+  sourceFiles: ReadonlyMap<string, FileNode>
+  strategy: LeafStrategy
+}
+
 /**
  * Recursive walk that yields one barrel per directory, re-exporting files and sub-barrels.
- * Used when nested: true.
+ * Used when nested: true. Leaf files honor the barrel `strategy`, so `named` emits explicit
+ * named exports instead of wildcards. Sub-directory barrels are chained with a wildcard
+ * re-export, which forwards the names the child barrel already curated. Returns whether this
+ * node yielded a barrel, so a parent never re-exports a sub-directory that produced nothing.
  */
-function* walkNested(node: BuildTree): Generator<FileNode> {
+function* walkNested(node: BuildTree, params: NestedWalkParams): Generator<FileNode, boolean> {
   const exports: Array<ExportNode> = []
 
   for (const child of node.children) {
     if (child.isFile) {
       if (isBarrelPath(child.path)) continue
-      exports.push(ast.factory.createExport({ path: toRelativeModulePath(node.path, child.path) }))
+      const sourceFile = params.sourceFiles.get(child.path) ?? null
+      exports.push(...params.strategy({ dirPath: node.path, leafPath: child.path, sourceFile }))
       continue
     }
 
-    yield* walkNested(child)
-    exports.push(ast.factory.createExport({ path: toRelativeModulePath(node.path, `${child.path}${BARREL_SUFFIX}`) }))
+    const childYieldedBarrel = yield* walkNested(child, params)
+    if (childYieldedBarrel) {
+      exports.push(ast.factory.createExport({ path: toRelativeModulePath(node.path, `${child.path}${BARREL_SUFFIX}`) }))
+    }
   }
 
   if (exports.length > 0) {
     yield makeBarrel(node.path, exports)
+    return true
   }
+
+  return false
 }
 
 type IndexedFiles = {
@@ -308,13 +322,13 @@ export function* getBarrelFiles({ outputPath, files, barrelType, nested = false,
 
   const tree = buildTree(outputPath, paths)
 
-  if (nested) {
-    yield* walkNested(tree)
-    return
-  }
-
   const strategy = LEAF_STRATEGIES.get(barrelType)
   if (!strategy) return
+
+  if (nested) {
+    yield* walkNested(tree, { sourceFiles, strategy })
+    return
+  }
 
   yield* walkAllOrNamed(tree, { sourceFiles, strategy, recursive }, true)
 }

--- a/packages/renderer-jsx/src/Runtime.tsx
+++ b/packages/renderer-jsx/src/Runtime.tsx
@@ -163,7 +163,7 @@ function collectFileChildren(element: unknown): FileChildren {
     element,
     (text) => {
       if (text.trim()) {
-        throw new Error(`[react] '${text}' should be part of <File.Source> component when using the <File/> component`)
+        throw new Error(`[jsx] '${text}' should be part of <File.Source> component when using the <File/> component`)
       }
     },
     (type, props) => {


### PR DESCRIPTION
## 🎯 Changes

A batch of real bugs and low-risk correctness fixes from a code review, each verified against its callees and covered by tests.

**Behavioral bugs**

- **`@kubb/mcp`** — auto-discovery searched every allowed config extension except `.mjs`, so a project whose only config was `kubb.config.mjs` was told no config existed unless it passed an explicit path. `kubb.config.mjs` is now discovered. The `generate` tool also emitted `CONFIG_ERROR` twice (once inside `loadUserConfig`, again in the catch block); each config error now surfaces once.
- **`@kubb/plugin-barrel`** — `{ type: 'named', nested: true }` emitted a wildcard `export *` for every file, ignoring `barrelType`. Nested barrels now apply the named strategy to leaf files, and a sub-directory that produces no barrel is no longer re-exported as a dangling `export * from './sub'`.
- **`@kubb/core`** — reporter results were buffered in a `Set`, so a `report` returning `void` (the default) or any repeated value collapsed to one entry and `drain` saw a single item for a multi-config run. Drainless reporters also retained every result. Results now use an ordered array and only buffer when a `drain` exists.
- **`@kubb/parser-ts`** — `printExport` warned to the console and dropped the name to a wildcard when `name` was a string without `asAlias`. It now renders `export { Name } from './path'`, the single-export form documented on `ExportNode`, with no console side effect.

**Type and doc corrections**

- **`@kubb/ast`** — `Node` now includes `TextNode`/`BreakNode`/`JsxNode` to match `NodeKind` and the runtime `isNode` check. `ScalarSchemaType` no longer includes `ipv4`/`ipv6`, which have dedicated nodes, so `ScalarSchemaNode` stops overlapping them. `VisitorDepth` and `PrinterHandlerContext` docs corrected (shallow stops at schema subtrees; example includes the required `base`).
- **`@kubb/core`** — `Storage.clear` JSDoc now describes the real contract (in-memory wipes everything without a `base`, filesystem no-ops to avoid deleting outside a known output directory).
- **`@kubb/cli`** — the clack logger's plugin-end guard uses `<= silent` like every other guard; the telemetry event type drops the unused `agent` command; the `generate` command resolves its log level through a helper instead of a nested ternary.
- **`@kubb/renderer-jsx`** — the stray-text error is tagged `[jsx]` instead of `[react]`.
- **`@kubb/parser-md`** — dropped a dead `?? undefined` (`print` already accepts `null`).

**Deliberately not touched:** the `@kubb/adapter-oas` resolver cluster that derefs the OpenAPI document in place and relies on call ordering. Fixing it is a refactor to pure resolve-and-return, not a mechanical edit, so it is left for a dedicated change.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

Verification: typecheck, lint (oxlint), and format (oxfmt) are clean across the touched packages; unit tests pass for `ast`, `core`, `cli`, `mcp`, `parser-ts`, `parser-md`, `plugin-barrel`, `renderer-jsx`, and `adapter-oas` (the largest consumer of the changed AST types).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BDj5MFSJ6UNK5Q415jyuDz

---
_Generated by [Claude Code](https://claude.ai/code/session_01BDj5MFSJ6UNK5Q415jyuDz)_