### PR TITLE
fix(cli): scaffold a v5 project from kubb init

### DIFF
--- a/.changeset/cli-init-v5-scaffold.md
+++ b/.changeset/cli-init-v5-scaffold.md
@@ -1,0 +1,5 @@
+---
+"@kubb/cli": patch
+---
+
+`kubb init` now scaffolds a working v5 project. The generated `kubb.config.ts` uses the v5 shape (`defineConfig` from `kubb/config` with a string `input` and no `root`), and the installed packages are pinned to the dist-tag of the running CLI, so a beta CLI installs `kubb@beta` and beta plugins instead of the older stable majors.

--- a/internals/shared/src/index.ts
+++ b/internals/shared/src/index.ts
@@ -1,4 +1,4 @@
 export type * from './types.ts'
 export { KUBB_CONFIG_FILENAME, initDefaults, availablePlugins } from './constants.ts'
-export { generateConfigFile, resolvePlugins } from './init.ts'
+export { generateConfigFile, resolvePlugins, withDistTag } from './init.ts'
 export { createModuleLoader } from './loader.ts'

--- a/internals/shared/src/init.test.ts
+++ b/internals/shared/src/init.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { availablePlugins } from './constants.ts'
-import { generateConfigFile, resolvePlugins } from './init.ts'
+import { generateConfigFile, resolvePlugins, withDistTag } from './init.ts'
 
 describe('resolvePlugins', () => {
   it('returns an empty list when no flag is given', () => {
@@ -33,14 +33,11 @@ describe('generateConfigFile', () => {
     const [pluginTs] = availablePlugins
     const result = generateConfigFile({ selectedPlugins: [pluginTs!], inputPath: './openapi.yaml', outputPath: './src/gen' })
     expect(result).toMatchInlineSnapshot(`
-      "import { defineConfig } from 'kubb'
+      "import { defineConfig } from 'kubb/config'
       import { pluginTs } from '@kubb/plugin-ts'
 
       export default defineConfig({
-        root: '.',
-        input: {
-          path: './openapi.yaml',
-        },
+        input: './openapi.yaml',
         output: {
           path: './src/gen',
           clean: true,
@@ -57,15 +54,12 @@ describe('generateConfigFile', () => {
     const selected = availablePlugins.filter((p) => ['plugin-ts', 'plugin-zod'].includes(p.value))
     const result = generateConfigFile({ selectedPlugins: selected, inputPath: './spec.json', outputPath: './out' })
     expect(result).toMatchInlineSnapshot(`
-      "import { defineConfig } from 'kubb'
+      "import { defineConfig } from 'kubb/config'
       import { pluginTs } from '@kubb/plugin-ts'
       import { pluginZod } from '@kubb/plugin-zod'
 
       export default defineConfig({
-        root: '.',
-        input: {
-          path: './spec.json',
-        },
+        input: './spec.json',
         output: {
           path: './out',
           clean: true,
@@ -89,14 +83,11 @@ describe('generateConfigFile', () => {
     }
     const result = generateConfigFile({ selectedPlugins: [unknown], inputPath: './a.yaml', outputPath: './b' })
     expect(result).toMatchInlineSnapshot(`
-      "import { defineConfig } from 'kubb'
+      "import { defineConfig } from 'kubb/config'
       import { pluginUnknown } from '@kubb/plugin-unknown'
 
       export default defineConfig({
-        root: '.',
-        input: {
-          path: './a.yaml',
-        },
+        input: './a.yaml',
         output: {
           path: './b',
           clean: true,
@@ -113,14 +104,11 @@ describe('generateConfigFile', () => {
     const [pluginTs] = availablePlugins
     const result = generateConfigFile({ selectedPlugins: [pluginTs!], inputPath: './api.yaml', outputPath: './gen' })
     expect(result).toMatchInlineSnapshot(`
-      "import { defineConfig } from 'kubb'
+      "import { defineConfig } from 'kubb/config'
       import { pluginTs } from '@kubb/plugin-ts'
 
       export default defineConfig({
-        root: '.',
-        input: {
-          path: './api.yaml',
-        },
+        input: './api.yaml',
         output: {
           path: './gen',
           clean: true,
@@ -136,14 +124,11 @@ describe('generateConfigFile', () => {
   it('handles an empty plugin list', () => {
     const result = generateConfigFile({ selectedPlugins: [], inputPath: './api.yaml', outputPath: './gen' })
     expect(result).toMatchInlineSnapshot(`
-      "import { defineConfig } from 'kubb'
+      "import { defineConfig } from 'kubb/config'
 
 
       export default defineConfig({
-        root: '.',
-        input: {
-          path: './api.yaml',
-        },
+        input: './api.yaml',
         output: {
           path: './gen',
           clean: true,
@@ -154,5 +139,22 @@ describe('generateConfigFile', () => {
       })
       "
     `)
+  })
+})
+
+describe('withDistTag', () => {
+  it('pins packages to the beta tag for a beta CLI version', () => {
+    const result = withDistTag({ packages: ['kubb', '@kubb/plugin-ts'], version: '5.0.0-beta.94' })
+    expect(result).toStrictEqual(['kubb@beta', '@kubb/plugin-ts@beta'])
+  })
+
+  it('pins packages to another prerelease tag when the version carries one', () => {
+    const result = withDistTag({ packages: ['kubb'], version: '5.0.0-alpha.1' })
+    expect(result).toStrictEqual(['kubb@alpha'])
+  })
+
+  it('pins packages to latest for a stable CLI version', () => {
+    const result = withDistTag({ packages: ['kubb', '@kubb/plugin-zod'], version: '5.0.0' })
+    expect(result).toStrictEqual(['kubb@latest', '@kubb/plugin-zod@latest'])
   })
 })

--- a/internals/shared/src/init.ts
+++ b/internals/shared/src/init.ts
@@ -30,14 +30,11 @@ export function generateConfigFile({
 
   const pluginConfigs = selectedPlugins.map((plugin) => `    ${plugin.importName}(),`).join('\n')
 
-  return `import { defineConfig } from 'kubb'
+  return `import { defineConfig } from 'kubb/config'
 ${imports}
 
 export default defineConfig({
-  root: '.',
-  input: {
-    path: '${inputPath}',
-  },
+  input: '${inputPath}',
   output: {
     path: '${outputPath}',
     clean: true,
@@ -47,4 +44,14 @@ ${pluginConfigs}
   ],
 })
 `
+}
+
+/**
+ * Appends the dist-tag matching the running CLI version to each package name,
+ * so a beta CLI scaffolds beta packages instead of the older stable majors.
+ */
+export function withDistTag({ packages, version }: { packages: Array<string>; version: string }): Array<string> {
+  const prerelease = version.match(/-([a-z]+)/)?.[1]
+  const tag = prerelease ?? 'latest'
+  return packages.map((name) => `${name}@${tag}`)
 }

--- a/packages/cli/src/runners/init/run.ts
+++ b/packages/cli/src/runners/init/run.ts
@@ -3,7 +3,7 @@ import path from 'node:path'
 import process from 'node:process'
 import { styleText } from 'node:util'
 import * as clack from '@clack/prompts'
-import { availablePlugins, generateConfigFile, initDefaults, KUBB_CONFIG_FILENAME, type PluginOption, resolvePlugins } from '@internals/shared'
+import { availablePlugins, generateConfigFile, initDefaults, KUBB_CONFIG_FILENAME, type PluginOption, resolvePlugins, withDistTag } from '@internals/shared'
 import { hasPackageJson, initPackageJson, installPackages } from './utils.ts'
 import { detectPackageManager } from '../../tools.ts'
 
@@ -141,8 +141,8 @@ export async function run({ yes, version, input: inputFlag, output: outputFlag, 
       return availablePlugins.filter((p) => (values as Array<string>).includes(p.value))
     })()
 
-    // Install packages
-    const packagesToInstall = ['kubb', ...selectedPlugins.map((p) => p.packageName)]
+    // Install packages, pinned to the dist-tag of the running CLI version
+    const packagesToInstall = withDistTag({ packages: ['kubb', ...selectedPlugins.map((p) => p.packageName)], version })
 
     const spinner = clack.spinner()
     spinner.start(`Installing ${packagesToInstall.length} packages with ${packageManager.name}`)


### PR DESCRIPTION
## 🎯 Changes

`kubb init` produced a broken project from the v5 beta CLI, in two ways:

1. The generated `kubb.config.ts` still used the v4 shape: `defineConfig` imported from `'kubb'`, a `root: '.'` field, and an object `input: { path }`. It now writes the v5 shape — `defineConfig` from `'kubb/config'` with a string `input` — matching the getting-started docs.
2. The wizard installed `kubb` and the selected plugins with no dist-tag, so npm resolved the older stable majors (`kubb@^3.2.2`, `@kubb/plugin-ts@^4.39.2`) that cannot run the scaffolded config. A new `withDistTag` helper in `@internals/shared` pins every installed package to the dist-tag matching the running CLI version: a beta CLI installs `@beta`, a stable CLI installs `@latest`.

Verified end to end: `kubb init --input ./petStore.yaml --plugins plugin-ts,plugin-zod` in a fresh project now installs `kubb@^5.0.0-beta.94` and `@kubb/plugin-*@^5.0.0-beta.87`, writes a v5 config, and `npx kubb generate` produces 73 files across 3 plugins.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWG738SfNK2KNk5E9JdNbS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWG738SfNK2KNk5E9JdNbS)_