### PR TITLE
refactor(core): replace adapter.getImports with resolver.imports

### DIFF
--- a/.changeset/resolver-imports.md
+++ b/.changeset/resolver-imports.md
@@ -1,0 +1,12 @@
+---
+"@kubb/core": minor
+"@kubb/ast": minor
+"@kubb/adapter-oas": minor
+"@kubb/kit": minor
+---
+
+Move import resolution from the adapter to the resolver: `adapter.getImports` is replaced by `resolver.imports`.
+
+`resolver.imports({ node, meta, root, output, group })` builds one import entry per `$ref` in a schema tree, resolving names and paths through the resolver's own `name` and `file` conventions. A per-call `name` callback overrides the imported identifier, for example to point enum refs at a suffixed type name.
+
+The adapter now records its collision renames in `meta.nameMapping` (raw ref pointer to emitted schema name) instead of exposing a `getImports` hook, so custom adapters only implement `parse` and `validate`.

--- a/.changeset/resolver-imports.md
+++ b/.changeset/resolver-imports.md
@@ -9,4 +9,4 @@ Move import resolution from the adapter to the resolver: `adapter.getImports` is
 
 `resolver.imports({ node, meta, root, output, group })` builds one import entry per `$ref` in a schema tree, resolving names and paths through the resolver's own `name` and `file` conventions. A per-call `name` callback overrides the imported identifier, for example to point enum refs at a suffixed type name.
 
-The adapter now records its collision renames in `meta.nameMapping` (raw ref pointer to emitted schema name) instead of exposing a `getImports` hook, so custom adapters only implement `parse` and `validate`.
+The adapter now records its collision renames in `meta.nameMapping` (renamed ref pointer to emitted schema name, empty when nothing is renamed) instead of exposing a `getImports` hook, so custom adapters only implement `parse` and `validate`. Refs that keep their pointer's last segment need no entry, since `resolver.imports` falls back to it.

--- a/.changeset/resolver-imports.md
+++ b/.changeset/resolver-imports.md
@@ -5,8 +5,10 @@
 "@kubb/kit": minor
 ---
 
-Move import resolution from the adapter to the resolver: `adapter.getImports` is replaced by `resolver.imports`.
+Move import resolution from the adapter to the resolver: `adapter.getImports` is replaced by `resolver.imports`, and ref nodes carry their target's emitted name.
 
-`resolver.imports({ node, meta, root, output, group })` builds one import entry per `$ref` in a schema tree, resolving names and paths through the resolver's own `name` and `file` conventions. A per-call `name` callback overrides the imported identifier, for example to point enum refs at a suffixed type name.
+`resolver.imports({ node, root, output, group })` builds one import entry per `$ref` in a schema tree, resolving names and paths through the resolver's own `name` and `file` conventions. A per-call `name` callback overrides the imported identifier, for example to point enum refs at a suffixed type name.
 
-The adapter now records its collision renames in `meta.nameMapping` (renamed ref pointer to emitted schema name, empty when nothing is renamed) instead of exposing a `getImports` hook, so custom adapters only implement `parse` and `validate`. Refs that keep their pointer's last segment need no entry, since `resolver.imports` falls back to it.
+`RefSchemaNode` gains `targetName`: the emitted name of the referenced schema when it differs from the pointer's last segment. The adapter stamps it during parsing for collision-renamed schemas, and `resolveRefName` prefers it, so refs resolve without a side-channel map. `adapter.getImports` and the `nameMapping` surfaces (`adapter.options.nameMapping`, `meta.nameMapping`) are removed, and custom adapters only implement `parse` and `validate`.
+
+The new `macroRenameSchema({ from, to })` macro renames a schema consistently: the declaration and every ref pointing at it change together, so imports stay in sync.

--- a/.changeset/resolver-imports.md
+++ b/.changeset/resolver-imports.md
@@ -5,10 +5,10 @@
 "@kubb/kit": minor
 ---
 
-Move import resolution from the adapter to the resolver: `adapter.getImports` is replaced by `resolver.imports`, and ref nodes carry their target's emitted name.
+Move import resolution from the adapter to the resolver: `resolver.imports` replaces `adapter.getImports`, and ref nodes carry their target's emitted name.
 
 `resolver.imports({ node, root, output, group })` builds one import entry per `$ref` in a schema tree, resolving names and paths through the resolver's own `name` and `file` conventions. A per-call `name` callback overrides the imported identifier, for example to point enum refs at a suffixed type name.
 
-`RefSchemaNode` gains `targetName`: the emitted name of the referenced schema when it differs from the pointer's last segment. The adapter stamps it during parsing for collision-renamed schemas, and `resolveRefName` prefers it, so refs resolve without a side-channel map. `adapter.getImports` and the `nameMapping` surfaces (`adapter.options.nameMapping`, `meta.nameMapping`) are removed, and custom adapters only implement `parse` and `validate`.
+`RefSchemaNode` gains `targetName`: the emitted name of the referenced schema when it differs from the pointer's last segment. The adapter stamps it during parsing for collision-renamed schemas, and `resolveRefName` prefers it, so refs resolve without a side-channel map. `adapter.getImports` and the `nameMapping` side channels (`adapter.options.nameMapping`, `meta.nameMapping`) are gone, and custom adapters only implement `parse` and `validate`.
 
 The new `macroRenameSchema({ from, to })` macro renames a schema consistently: the declaration and every ref pointing at it change together, so imports stay in sync.

--- a/packages/adapter-oas/src/adapter.test.ts
+++ b/packages/adapter-oas/src/adapter.test.ts
@@ -1,4 +1,5 @@
 import { ast } from '@kubb/ast'
+import { Resolver } from '@kubb/core'
 import { describe, expect, it } from 'vitest'
 import { adapterOas } from './adapter.ts'
 
@@ -78,11 +79,11 @@ describe('adapterOas.parse', () => {
   })
 })
 
-describe('adapterOas.getImports', () => {
-  it('returns named imports as string arrays', async () => {
+describe('adapterOas meta.nameMapping', () => {
+  it('maps each component pointer to its emitted schema name', async () => {
     const adapter = adapterOas()
 
-    await adapter.parse({
+    const node = await adapter.parse({
       type: 'data',
       data: {
         openapi: '3.0.0',
@@ -101,27 +102,15 @@ describe('adapterOas.getImports', () => {
       },
     })
 
-    const imports = adapter.getImports(
-      ast.factory.createSchema({
-        type: 'ref',
-        ref: '#/components/schemas/Pet',
-        name: 'Pet',
-      }),
-      () => ({
-        name: 'PetType',
-        path: './pet.ts',
-      }),
-    )
-
-    expect(imports).toMatchObject([{ kind: 'Import', name: ['PetType'], path: './pet.ts' }])
+    expect(node.meta.nameMapping).toStrictEqual({ '#/components/schemas/Pet': 'Pet' })
   })
 
-  it('resolves a collision-renamed schema ref to the renamed name', async () => {
+  it('maps a collision-renamed schema ref to the renamed name', async () => {
     const adapter = adapterOas()
 
     // `Order` exists in both `schemas` and `requestBodies`, so the schema is renamed to `OrderSchema`.
-    // A `$ref` to it must import `OrderSchema`, not the bare `Order` (whose file is never emitted).
-    await adapter.parse({
+    // A `$ref` to it must resolve to `OrderSchema`, not the bare `Order` (whose file is never emitted).
+    const node = await adapter.parse({
       type: 'data',
       data: {
         openapi: '3.0.0',
@@ -138,18 +127,19 @@ describe('adapterOas.getImports', () => {
       },
     })
 
-    const imports = adapter.getImports(
-      ast.factory.createSchema({
-        type: 'ref',
-        ref: '#/components/schemas/Order',
-        name: 'Order',
-      }),
-      (schemaName) => ({
-        name: schemaName,
-        path: `./${schemaName}.ts`,
-      }),
-    )
+    expect(node.meta.nameMapping).toStrictEqual({
+      '#/components/schemas/Order': 'OrderSchema',
+      '#/components/requestBodies/Order': 'OrderRequest',
+    })
 
-    expect(imports).toMatchObject([{ kind: 'Import', name: ['OrderSchema'], path: './OrderSchema.ts' }])
+    const resolver = new Resolver({ pluginName: 'test' })
+    const imports = resolver.imports({
+      node: ast.factory.createSchema({ type: 'ref', ref: '#/components/schemas/Order', name: 'Order' }),
+      meta: node.meta,
+      root: '/root',
+      output: { path: 'types' },
+    })
+
+    expect(imports).toMatchObject([{ kind: 'Import', name: ['orderSchema'], path: '/root/types/orderSchema.ts' }])
   })
 })

--- a/packages/adapter-oas/src/adapter.test.ts
+++ b/packages/adapter-oas/src/adapter.test.ts
@@ -1,4 +1,4 @@
-import { ast } from '@kubb/ast'
+import { narrowSchema, resolveRefName } from '@kubb/ast'
 import { Resolver } from '@kubb/core'
 import { describe, expect, it } from 'vitest'
 import { adapterOas } from './adapter.ts'
@@ -79,8 +79,8 @@ describe('adapterOas.parse', () => {
   })
 })
 
-describe('adapterOas meta.nameMapping', () => {
-  it('stays empty when no schema is renamed', async () => {
+describe('adapterOas ref targetName', () => {
+  it('leaves refs unstamped when no schema is renamed', async () => {
     const adapter = adapterOas()
 
     const node = await adapter.parse({
@@ -91,21 +91,22 @@ describe('adapterOas meta.nameMapping', () => {
         paths: {},
         components: {
           schemas: {
-            Pet: {
-              type: 'object',
-              properties: {
-                id: { type: 'string' },
-              },
-            },
+            Pet: { type: 'object', properties: { id: { type: 'string' } } },
+            PetList: { type: 'array', items: { $ref: '#/components/schemas/Pet' } },
           },
         },
       },
     })
 
-    expect(node.meta.nameMapping).toStrictEqual({})
+    const petList = node.schemas.find((schema) => schema.name === 'PetList')
+    const items = narrowSchema(petList!, 'array')?.items ?? []
+    const ref = narrowSchema(items[0]!, 'ref')
+
+    expect(ref?.ref).toBe('#/components/schemas/Pet')
+    expect(ref?.targetName).toBeUndefined()
   })
 
-  it('maps a collision-renamed schema ref to the renamed name', async () => {
+  it('stamps refs to a collision-renamed schema with the renamed name', async () => {
     const adapter = adapterOas()
 
     // `Order` exists in both `schemas` and `requestBodies`, so the schema is renamed to `OrderSchema`.
@@ -119,6 +120,7 @@ describe('adapterOas meta.nameMapping', () => {
         components: {
           schemas: {
             Order: { type: 'object', properties: { id: { type: 'string' } } },
+            OrderList: { type: 'array', items: { $ref: '#/components/schemas/Order' } },
           },
           requestBodies: {
             Order: { content: { 'application/json': { schema: { type: 'object', properties: { userId: { type: 'string' } } } } } },
@@ -127,18 +129,17 @@ describe('adapterOas meta.nameMapping', () => {
       },
     })
 
-    expect(node.meta.nameMapping).toStrictEqual({
-      '#/components/schemas/Order': 'OrderSchema',
-      '#/components/requestBodies/Order': 'OrderRequest',
-    })
+    expect(node.schemas.map((schema) => schema.name)).toContain('OrderSchema')
+
+    const orderList = node.schemas.find((schema) => schema.name === 'OrderList')
+    const items = narrowSchema(orderList!, 'array')?.items ?? []
+    const ref = narrowSchema(items[0]!, 'ref')
+
+    expect(ref?.targetName).toBe('OrderSchema')
+    expect(resolveRefName(ref)).toBe('OrderSchema')
 
     const resolver = new Resolver({ pluginName: 'test' })
-    const imports = resolver.imports({
-      node: ast.factory.createSchema({ type: 'ref', ref: '#/components/schemas/Order', name: 'Order' }),
-      meta: node.meta,
-      root: '/root',
-      output: { path: 'types' },
-    })
+    const imports = resolver.imports({ node: orderList!, root: '/root', output: { path: 'types' } })
 
     expect(imports).toMatchObject([{ kind: 'Import', name: ['orderSchema'], path: '/root/types/orderSchema.ts' }])
   })

--- a/packages/adapter-oas/src/adapter.test.ts
+++ b/packages/adapter-oas/src/adapter.test.ts
@@ -1,5 +1,4 @@
 import { narrowSchema, resolveRefName } from '@kubb/ast'
-import { Resolver } from '@kubb/core'
 import { describe, expect, it } from 'vitest'
 import { adapterOas } from './adapter.ts'
 
@@ -106,7 +105,7 @@ describe('adapterOas ref targetName', () => {
     expect(ref?.targetName).toBeUndefined()
   })
 
-  it('stamps refs to a collision-renamed schema with the renamed name', async () => {
+  it('stamps schema and operation refs to a collision-renamed schema with the renamed name', async () => {
     const adapter = adapterOas()
 
     // `Order` exists in both `schemas` and `requestBodies`, so the schema is renamed to `OrderSchema`.
@@ -116,7 +115,19 @@ describe('adapterOas ref targetName', () => {
       data: {
         openapi: '3.0.0',
         info: { title: 'test', version: '1.0.0' },
-        paths: {},
+        paths: {
+          '/orders/{orderId}': {
+            get: {
+              operationId: 'getOrder',
+              responses: {
+                '200': {
+                  description: 'ok',
+                  content: { 'application/json': { schema: { $ref: '#/components/schemas/Order' } } },
+                },
+              },
+            },
+          },
+        },
         components: {
           schemas: {
             Order: { type: 'object', properties: { id: { type: 'string' } } },
@@ -133,14 +144,14 @@ describe('adapterOas ref targetName', () => {
 
     const orderList = node.schemas.find((schema) => schema.name === 'OrderList')
     const items = narrowSchema(orderList!, 'array')?.items ?? []
-    const ref = narrowSchema(items[0]!, 'ref')
+    const schemaRef = narrowSchema(items[0]!, 'ref')
 
-    expect(ref?.targetName).toBe('OrderSchema')
-    expect(resolveRefName(ref)).toBe('OrderSchema')
+    expect(schemaRef?.targetName).toBe('OrderSchema')
+    expect(resolveRefName(schemaRef)).toBe('OrderSchema')
 
-    const resolver = new Resolver({ pluginName: 'test' })
-    const imports = resolver.imports({ node: orderList!, root: '/root', output: { path: 'types' } })
+    const responseRef = narrowSchema(node.operations[0]!.responses[0]!.content![0]!.schema!, 'ref')
 
-    expect(imports).toMatchObject([{ kind: 'Import', name: ['orderSchema'], path: '/root/types/orderSchema.ts' }])
+    expect(responseRef?.targetName).toBe('OrderSchema')
+    expect(resolveRefName(responseRef)).toBe('OrderSchema')
   })
 })

--- a/packages/adapter-oas/src/adapter.test.ts
+++ b/packages/adapter-oas/src/adapter.test.ts
@@ -80,7 +80,7 @@ describe('adapterOas.parse', () => {
 })
 
 describe('adapterOas meta.nameMapping', () => {
-  it('maps each component pointer to its emitted schema name', async () => {
+  it('stays empty when no schema is renamed', async () => {
     const adapter = adapterOas()
 
     const node = await adapter.parse({
@@ -102,7 +102,7 @@ describe('adapterOas meta.nameMapping', () => {
       },
     })
 
-    expect(node.meta.nameMapping).toStrictEqual({ '#/components/schemas/Pet': 'Pet' })
+    expect(node.meta.nameMapping).toStrictEqual({})
   })
 
   it('maps a collision-renamed schema ref to the renamed name', async () => {

--- a/packages/adapter-oas/src/adapter.ts
+++ b/packages/adapter-oas/src/adapter.ts
@@ -1,4 +1,4 @@
-import { ast, findCircularSchemas, narrowSchema } from '@kubb/ast'
+import { ast, extractRefName, findCircularSchemas, narrowSchema } from '@kubb/ast'
 import { createAdapter } from '@kubb/core'
 import type { AdapterSource } from '@kubb/core'
 import { DEFAULT_PARSER_OPTIONS } from './constants.ts'
@@ -184,6 +184,10 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
 
     const operations = promotedEnums ? operationNodes.map((node) => refPromotedEnums(node, promotedEnums!)) : operationNodes
 
+    // Only renames matter downstream: `resolver.imports` falls back to the pointer's last
+    // segment, so identity entries would be dead weight in every document's meta.
+    const nameMapping = Object.fromEntries([...refNameMapping].filter(([pointer, name]) => extractRefName(pointer) !== name))
+
     return ast.factory.createInput({
       schemas: schemaNodes,
       operations,
@@ -194,7 +198,7 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
         baseURL: resolveBaseUrl({ document, server }),
         circularNames,
         enumNames,
-        nameMapping: Object.fromEntries(refNameMapping),
+        nameMapping,
       },
     })
   }

--- a/packages/adapter-oas/src/adapter.ts
+++ b/packages/adapter-oas/src/adapter.ts
@@ -1,4 +1,4 @@
-import { ast, extractRefName, findCircularSchemas, narrowSchema, transform } from '@kubb/ast'
+import { ast, findCircularSchemas, narrowSchema, transform } from '@kubb/ast'
 import { createAdapter } from '@kubb/core'
 import type { AdapterSource } from '@kubb/core'
 import { DEFAULT_PARSER_OPTIONS } from './constants.ts'
@@ -113,12 +113,12 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
   function parseInput({
     document,
     schemas,
-    refNameMapping,
+    renames,
     parser,
   }: {
     document: Document
     schemas: Record<string, SchemaObject>
-    refNameMapping: Map<string, string>
+    renames: Map<string, string>
     parser: ReturnType<typeof ensureSchemaParser>
   }): ast.InputNode {
     const { parseSchema, parseOperation } = parser
@@ -126,7 +126,6 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
     // Refs whose target was collision-renamed carry the emitted name on the node itself
     // (`targetName`), so `resolveRefName` works without a side-channel map. Stamped before
     // circular-ref detection, so the schema graph also sees the corrected edges.
-    const renames = new Map([...refNameMapping].filter(([pointer, name]) => extractRefName(pointer) !== name))
     const stampTargetNames = <T extends ast.SchemaNode | ast.OperationNode>(node: T): T => {
       if (renames.size === 0) return node
       return transform(node, {
@@ -233,10 +232,10 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
     },
     async parse(source) {
       const document = await ensureDocument(source)
-      const { schemas, nameMapping: refNameMapping } = ensureSchemas(document)
+      const { schemas, renames } = ensureSchemas(document)
       const parser = ensureSchemaParser(document)
 
-      return parseInput({ document, schemas, refNameMapping, parser })
+      return parseInput({ document, schemas, renames, parser })
     },
   }
 })

--- a/packages/adapter-oas/src/adapter.ts
+++ b/packages/adapter-oas/src/adapter.ts
@@ -1,4 +1,4 @@
-import { ast, extractRefName, findCircularSchemas, narrowSchema } from '@kubb/ast'
+import { ast, extractRefName, findCircularSchemas, narrowSchema, transform } from '@kubb/ast'
 import { createAdapter } from '@kubb/core'
 import type { AdapterSource } from '@kubb/core'
 import { DEFAULT_PARSER_OPTIONS } from './constants.ts'
@@ -67,7 +67,6 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
     enumSuffix,
   }
 
-  let nameMapping = new Map<string, string>()
   let parsedDocument: Document | null = null
 
   // Cache per source and per document so one adapter instance reused across a `defineConfig` array
@@ -92,16 +91,10 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
   }
 
   function ensureSchemas(document: Document): ReturnType<typeof getSchemas> {
-    // Re-assign `nameMapping` on cache hits too, so `options.nameMapping` tracks the document
-    // last parsed instead of the document last computed.
     const cached = schemasCache.get(document)
-    if (cached) {
-      nameMapping = cached.nameMapping
-      return cached
-    }
+    if (cached) return cached
 
     const result = getSchemas(document, { contentType })
-    nameMapping = result.nameMapping
     schemasCache.set(document, result)
     return result
   }
@@ -130,13 +123,29 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
   }): ast.InputNode {
     const { parseSchema, parseOperation } = parser
 
+    // Refs whose target was collision-renamed carry the emitted name on the node itself
+    // (`targetName`), so `resolveRefName` works without a side-channel map. Stamped before
+    // circular-ref detection, so the schema graph also sees the corrected edges.
+    const renames = new Map([...refNameMapping].filter(([pointer, name]) => extractRefName(pointer) !== name))
+    const stampTargetNames = <T extends ast.SchemaNode | ast.OperationNode>(node: T): T => {
+      if (renames.size === 0) return node
+      return transform(node, {
+        schema(child) {
+          const refNode = narrowSchema(child, 'ref')
+          if (!refNode?.ref) return undefined
+          const targetName = renames.get(refNode.ref)
+          return targetName ? { ...refNode, targetName } : undefined
+        },
+      }) as T
+    }
+
     const parsedByName = new Map<string, ast.SchemaNode>()
     const refAliasMap = new Map<string, ast.SchemaNode>()
     const enumNames: Array<string> = []
     const discriminatorParentNodes: Array<ast.SchemaNode> = []
 
     for (const [name, schema] of Object.entries(schemas)) {
-      const node = parseSchema({ schema, name }, parserOptions)
+      const node = stampTargetNames(parseSchema({ schema, name }, parserOptions))
       parsedByName.set(name, node)
       reportSchemaDiagnostics({ node, name })
       if (node.type === 'ref' && node.name && node.name !== name) {
@@ -157,7 +166,7 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
     const operationNodes: Array<ast.OperationNode> = []
     for (const operation of getOperations(document)) {
       const operationNode = parseOperation(parserOptions, operation)
-      if (operationNode) operationNodes.push(operationNode)
+      if (operationNode) operationNodes.push(stampTargetNames(operationNode))
     }
 
     let promotedEnums: Map<string, ast.SchemaNode> | null = null
@@ -184,10 +193,6 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
 
     const operations = promotedEnums ? operationNodes.map((node) => refPromotedEnums(node, promotedEnums!)) : operationNodes
 
-    // Only renames matter downstream: `resolver.imports` falls back to the pointer's last
-    // segment, so identity entries would be dead weight in every document's meta.
-    const nameMapping = Object.fromEntries([...refNameMapping].filter(([pointer, name]) => extractRefName(pointer) !== name))
-
     return ast.factory.createInput({
       schemas: schemaNodes,
       operations,
@@ -198,7 +203,6 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
         baseURL: resolveBaseUrl({ document, server }),
         circularNames,
         enumNames,
-        nameMapping,
       },
     })
   }
@@ -217,7 +221,6 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
         unknownType,
         emptySchemaType,
         enumSuffix,
-        nameMapping,
       }
     },
     get document() {

--- a/packages/adapter-oas/src/adapter.ts
+++ b/packages/adapter-oas/src/adapter.ts
@@ -1,4 +1,4 @@
-import { ast, findCircularSchemas, narrowSchema, transform } from '@kubb/ast'
+import { ast, findCircularSchemas, narrowSchema } from '@kubb/ast'
 import { createAdapter } from '@kubb/core'
 import type { AdapterSource } from '@kubb/core'
 import { DEFAULT_PARSER_OPTIONS } from './constants.ts'
@@ -99,11 +99,11 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
     return result
   }
 
-  function ensureSchemaParser(document: Document): ReturnType<typeof createSchemaParser> {
+  function ensureSchemaParser(document: Document, renames: Map<string, string>): ReturnType<typeof createSchemaParser> {
     const cached = schemaParserCache.get(document)
     if (cached) return cached
 
-    const parser = createSchemaParser({ document, contentType })
+    const parser = createSchemaParser({ document, contentType, renames })
     schemaParserCache.set(document, parser)
     return parser
   }
@@ -113,30 +113,13 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
   function parseInput({
     document,
     schemas,
-    renames,
     parser,
   }: {
     document: Document
     schemas: Record<string, SchemaObject>
-    renames: Map<string, string>
     parser: ReturnType<typeof ensureSchemaParser>
   }): ast.InputNode {
     const { parseSchema, parseOperation } = parser
-
-    // Refs whose target was collision-renamed carry the emitted name on the node itself
-    // (`targetName`), so `resolveRefName` works without a side-channel map. Stamped before
-    // circular-ref detection, so the schema graph also sees the corrected edges.
-    const stampTargetNames = <T extends ast.SchemaNode | ast.OperationNode>(node: T): T => {
-      if (renames.size === 0) return node
-      return transform(node, {
-        schema(child) {
-          const refNode = narrowSchema(child, 'ref')
-          if (!refNode?.ref) return undefined
-          const targetName = renames.get(refNode.ref)
-          return targetName ? { ...refNode, targetName } : undefined
-        },
-      }) as T
-    }
 
     const parsedByName = new Map<string, ast.SchemaNode>()
     const refAliasMap = new Map<string, ast.SchemaNode>()
@@ -144,7 +127,7 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
     const discriminatorParentNodes: Array<ast.SchemaNode> = []
 
     for (const [name, schema] of Object.entries(schemas)) {
-      const node = stampTargetNames(parseSchema({ schema, name }, parserOptions))
+      const node = parseSchema({ schema, name }, parserOptions)
       parsedByName.set(name, node)
       reportSchemaDiagnostics({ node, name })
       if (node.type === 'ref' && node.name && node.name !== name) {
@@ -165,7 +148,7 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
     const operationNodes: Array<ast.OperationNode> = []
     for (const operation of getOperations(document)) {
       const operationNode = parseOperation(parserOptions, operation)
-      if (operationNode) operationNodes.push(stampTargetNames(operationNode))
+      if (operationNode) operationNodes.push(operationNode)
     }
 
     let promotedEnums: Map<string, ast.SchemaNode> | null = null
@@ -233,9 +216,9 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
     async parse(source) {
       const document = await ensureDocument(source)
       const { schemas, renames } = ensureSchemas(document)
-      const parser = ensureSchemaParser(document)
+      const parser = ensureSchemaParser(document, renames)
 
-      return parseInput({ document, schemas, renames, parser })
+      return parseInput({ document, schemas, parser })
     },
   }
 })

--- a/packages/adapter-oas/src/adapter.ts
+++ b/packages/adapter-oas/src/adapter.ts
@@ -99,7 +99,7 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
     return result
   }
 
-  function ensureSchemaParser(document: Document, renames: Map<string, string>): ReturnType<typeof createSchemaParser> {
+  function ensureSchemaParser({ document, renames }: { document: Document; renames: Map<string, string> }): ReturnType<typeof createSchemaParser> {
     const cached = schemaParserCache.get(document)
     if (cached) return cached
 
@@ -216,7 +216,7 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
     async parse(source) {
       const document = await ensureDocument(source)
       const { schemas, renames } = ensureSchemas(document)
-      const parser = ensureSchemaParser(document, renames)
+      const parser = ensureSchemaParser({ document, renames })
 
       return parseInput({ document, schemas, parser })
     },

--- a/packages/adapter-oas/src/adapter.ts
+++ b/packages/adapter-oas/src/adapter.ts
@@ -1,4 +1,4 @@
-import { ast, collect, extractRefName, findCircularSchemas, narrowSchema } from '@kubb/ast'
+import { ast, findCircularSchemas, narrowSchema } from '@kubb/ast'
 import { createAdapter } from '@kubb/core'
 import type { AdapterSource } from '@kubb/core'
 import { DEFAULT_PARSER_OPTIONS } from './constants.ts'
@@ -74,7 +74,7 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
   // parses each config's spec instead of replaying the first one. The document-derived caches key
   // off the resulting document, so distinct configs (distinct documents) stay isolated.
   const documentCache = new WeakMap<AdapterSource, Promise<Document>>()
-  const schemasCache = new WeakMap<Document, ReturnType<typeof getSchemas>['schemas']>()
+  const schemasCache = new WeakMap<Document, ReturnType<typeof getSchemas>>()
   const schemaParserCache = new WeakMap<Document, ReturnType<typeof createSchemaParser>>()
 
   function ensureDocument(source: AdapterSource): Promise<Document> {
@@ -91,14 +91,19 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
     return promise
   }
 
-  function ensureSchemas(document: Document): ReturnType<typeof getSchemas>['schemas'] {
+  function ensureSchemas(document: Document): ReturnType<typeof getSchemas> {
+    // Re-assign `nameMapping` on cache hits too, so `options.nameMapping` tracks the document
+    // last parsed instead of the document last computed.
     const cached = schemasCache.get(document)
-    if (cached) return cached
+    if (cached) {
+      nameMapping = cached.nameMapping
+      return cached
+    }
 
     const result = getSchemas(document, { contentType })
     nameMapping = result.nameMapping
-    schemasCache.set(document, result.schemas)
-    return result.schemas
+    schemasCache.set(document, result)
+    return result
   }
 
   function ensureSchemaParser(document: Document): ReturnType<typeof createSchemaParser> {
@@ -115,10 +120,12 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
   function parseInput({
     document,
     schemas,
+    refNameMapping,
     parser,
   }: {
     document: Document
     schemas: Record<string, SchemaObject>
+    refNameMapping: Map<string, string>
     parser: ReturnType<typeof ensureSchemaParser>
   }): ast.InputNode {
     const { parseSchema, parseOperation } = parser
@@ -187,6 +194,7 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
         baseURL: resolveBaseUrl({ document, server }),
         circularNames,
         enumNames,
+        nameMapping: Object.fromEntries(refNameMapping),
       },
     })
   }
@@ -216,30 +224,12 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
       const document = await parseDocument(input)
       await validateDocument(document, options)
     },
-    getImports(node, resolve) {
-      return collect(node, {
-        schema(schemaNode) {
-          const schemaRef = narrowSchema(schemaNode, 'ref')
-          if (!schemaRef?.ref) return null
-
-          // `nameMapping` is keyed by the full component pointer (e.g. `#/components/schemas/Order`),
-          // so look it up with the raw `$ref`. Collision-renamed schemas (`Order` -> `OrderSchema`)
-          // only resolve through this map; falling back to the bare segment would import a file that
-          // the writer never emitted.
-          const schemaName = nameMapping.get(schemaRef.ref) ?? extractRefName(schemaRef.ref)
-          const result = resolve(schemaName)
-          if (!result) return null
-
-          return ast.factory.createImport({ name: [result.name], path: result.path })
-        },
-      })
-    },
     async parse(source) {
       const document = await ensureDocument(source)
-      const schemas = ensureSchemas(document)
+      const { schemas, nameMapping: refNameMapping } = ensureSchemas(document)
       const parser = ensureSchemaParser(document)
 
-      return parseInput({ document, schemas, parser })
+      return parseInput({ document, schemas, refNameMapping, parser })
     },
   }
 })

--- a/packages/adapter-oas/src/converters.ts
+++ b/packages/adapter-oas/src/converters.ts
@@ -48,6 +48,11 @@ export type ConverterDeps = {
    * Returns `true` when a `$ref` path resolves to a component the document actually defines.
    */
   refExists: (refPath: string) => boolean
+  /**
+   * Collision renames keyed by the original component pointer, used to stamp `targetName`
+   * on ref nodes whose target the adapter renamed.
+   */
+  renames?: ReadonlyMap<string, string>
 }
 
 /**
@@ -135,7 +140,7 @@ function nameEnums(node: ast.SchemaNode, options: { parentName: string | null | 
  * Use `syncSchemaRef(node)` in printers to get a merged view of both.
  * Circular refs are detected in `resolveRefNode` and leave `schema` as `null`.
  */
-export function convertRef({ schema, name, nullable, defaultValue, rawOptions, document, resolveRefNode, refExists }: ConvertContext): ast.SchemaNode {
+export function convertRef({ schema, name, nullable, defaultValue, rawOptions, document, resolveRefNode, refExists, renames }: ConvertContext): ast.SchemaNode {
   const refPath = schema.$ref
   const resolvedSchema = refPath ? resolveRefNode(refPath, rawOptions) : null
 
@@ -151,11 +156,14 @@ export function convertRef({ schema, name, nullable, defaultValue, rawOptions, d
     })
   }
 
+  const targetName = renames?.get(schema.$ref!)
+
   return ast.factory.createSchema({
     ...buildSchemaNode(schema, name, nullable, defaultValue),
     type: 'ref',
     name: extractRefName(schema.$ref!),
     ref: schema.$ref,
+    ...(targetName ? { targetName } : {}),
     schema: resolvedSchema,
   })
 }

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -26,17 +26,14 @@ function parseSchema(ctx: OasParserContext, { schema, name }: { schema: SchemaOb
  * Parses a full OpenAPI document into Kubb's universal `InputNode` AST, mirroring
  * `parseInput()` in `adapter.ts` for whole-spec test cases.
  */
-function parseOas(
-  document: Document,
-  options: Partial<ast.ParserOptions> & { contentType?: ContentType } = {},
-): { root: ast.InputNode; nameMapping: Map<string, string> } {
+function parseOas(document: Document, options: Partial<ast.ParserOptions> & { contentType?: ContentType } = {}): { root: ast.InputNode } {
   const { contentType, ...parserOptions } = options
   const mergedOptions: ast.ParserOptions = {
     ...DEFAULT_PARSER_OPTIONS,
     ...parserOptions,
   }
 
-  const { schemas: schemaObjects, nameMapping } = getSchemas(document, { contentType })
+  const { schemas: schemaObjects } = getSchemas(document, { contentType })
   const { parseSchema: _parseSchema, parseOperation: _parseOperation } = createSchemaParser({ document, contentType })
 
   const schemas: Array<ast.SchemaNode> = Object.entries(schemaObjects).map(([name, schema]) => _parseSchema({ schema, name }, mergedOptions))
@@ -47,7 +44,7 @@ function parseOas(
 
   const root = ast.factory.createInput({ schemas, operations })
 
-  return { root, nameMapping }
+  return { root }
 }
 
 describe('buildAst', () => {

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -26,7 +26,7 @@ function parseSchema(ctx: OasParserContext, { schema, name }: { schema: SchemaOb
  * Parses a full OpenAPI document into Kubb's universal `InputNode` AST, mirroring
  * `parseInput()` in `adapter.ts` for whole-spec test cases.
  */
-function parseOas(document: Document, options: Partial<ast.ParserOptions> & { contentType?: ContentType } = {}): { root: ast.InputNode } {
+function parseOas(document: Document, options: Partial<ast.ParserOptions> & { contentType?: ContentType } = {}): ast.InputNode {
   const { contentType, ...parserOptions } = options
   const mergedOptions: ast.ParserOptions = {
     ...DEFAULT_PARSER_OPTIONS,
@@ -44,13 +44,13 @@ function parseOas(document: Document, options: Partial<ast.ParserOptions> & { co
 
   const root = ast.factory.createInput({ schemas, operations })
 
-  return { root }
+  return root
 }
 
 describe('buildAst', () => {
   it('returns an InputNode', async () => {
     const oas = await buildMinimalOas()
-    const root = parseOas(oas).root
+    const root = parseOas(oas)
 
     expect(root.kind).toBe('Input')
   })
@@ -58,7 +58,7 @@ describe('buildAst', () => {
   describe('schemas', () => {
     it('converts named component schemas', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const names = root.schemas.map((s) => s.name)
 
       expect(names).toContain('Pet')
@@ -68,7 +68,7 @@ describe('buildAst', () => {
 
     it('converts object schema with properties', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const pet = ast.narrowSchema(
         root.schemas.find((s) => s.name === 'Pet'),
         'object',
@@ -80,7 +80,7 @@ describe('buildAst', () => {
 
     it('marks required properties', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const pet = ast.narrowSchema(
         root.schemas.find((s) => s.name === 'Pet'),
         'object',
@@ -94,7 +94,7 @@ describe('buildAst', () => {
 
     it('converts array schema', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const list = ast.narrowSchema(
         root.schemas.find((s) => s.name === 'PetList'),
         'array',
@@ -107,7 +107,7 @@ describe('buildAst', () => {
 
     it('converts enum schema', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const status = ast.narrowSchema(
         root.schemas.find((s) => s.name === 'Status'),
         'enum',
@@ -119,7 +119,7 @@ describe('buildAst', () => {
 
     it('converts oneOf to union', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const petOrError = ast.narrowSchema(
         root.schemas.find((s) => s.name === 'PetOrError'),
         'union',
@@ -135,14 +135,14 @@ describe('buildAst', () => {
         info: { title: '', version: '' },
         paths: {},
         components: { schemas: { NullEnum: { enum: [null] } } },
-      } as unknown as Document).root
+      } as unknown as Document)
 
       expect(root.schemas.find((s) => s.name === 'NullEnum')?.type).toBe('null')
     })
 
     it('converts allOf to intersection', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const fullPet = ast.narrowSchema(
         root.schemas.find((s) => s.name === 'FullPet'),
         'intersection',
@@ -154,7 +154,7 @@ describe('buildAst', () => {
 
     it('flattens single-member allOf and propagates nullable', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const nullableString = root.schemas.find((s) => s.name === 'NullableString')
 
       // Should be flattened to 'string' — not an intersection
@@ -166,7 +166,7 @@ describe('buildAst', () => {
 
     it('flattens single-member allOf for nullable $ref', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const nullableRef = ast.narrowSchema(
         root.schemas.find((s) => s.name === 'NullableRef'),
         'ref',
@@ -181,7 +181,7 @@ describe('buildAst', () => {
 
     it('maps format date-time to datetime SchemaType', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const fullPet = ast.narrowSchema(
         root.schemas.find((s) => s.name === 'FullPet'),
         'intersection',
@@ -198,7 +198,7 @@ describe('buildAst', () => {
 
     it('maps format email to email SchemaType', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const fullPet = ast.narrowSchema(
         root.schemas.find((s) => s.name === 'FullPet'),
         'intersection',
@@ -237,14 +237,14 @@ describe('buildAst', () => {
   describe('operations', () => {
     it('converts all operations', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
 
       expect(root.operations).toHaveLength(4)
     })
 
     it('sets operationId, method, path, tags', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const listPets = root.operations.find((op) => op.operationId === 'listPets')
 
       expect(listPets?.method).toBe('GET')
@@ -256,7 +256,7 @@ describe('buildAst', () => {
 
     it('sets deprecated flag', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const createPet = root.operations.find((op) => op.operationId === 'createPet')
 
       expect(createPet?.deprecated).toBe(true)
@@ -264,7 +264,7 @@ describe('buildAst', () => {
 
     it('uses uppercase HTTP method per RFC 9110', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       for (const op of root.operations) {
         expect(op.method).toBe(op.method?.toUpperCase())
       }
@@ -272,7 +272,7 @@ describe('buildAst', () => {
 
     it('converts query parameters', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const listPets = root.operations.find((op) => op.operationId === 'listPets')
       const limit = listPets?.parameters.find((p) => p.name === 'limit')
 
@@ -283,7 +283,7 @@ describe('buildAst', () => {
 
     it('converts path parameters', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const getPet = root.operations.find((op) => op.operationId === 'getPetById')
       const petId = getPet?.parameters.find((p) => p.name === 'petId')
 
@@ -321,7 +321,7 @@ describe('buildAst', () => {
           },
         },
       })
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const op = root.operations.find((o) => o.operationId === 'getPetById')
       const petId = op?.parameters.find((p) => p.name === 'petId')
 
@@ -346,7 +346,7 @@ describe('buildAst', () => {
           },
         },
       })
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const op = root.operations.find((o) => o.operationId === 'listPetsByIds')
       const ids = op?.parameters.find((p) => p.name === 'ids')
       const tags = op?.parameters.find((p) => p.name === 'tags')
@@ -359,7 +359,7 @@ describe('buildAst', () => {
 
     it('leaves style and explode undefined when the spec omits them', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const getPet = root.operations.find((op) => op.operationId === 'getPetById')
       const petId = getPet?.parameters.find((p) => p.name === 'petId')
 
@@ -369,7 +369,7 @@ describe('buildAst', () => {
 
     it('converts requestBody', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const createPet = root.operations.find((op) => op.operationId === 'createPet')
 
       expect(createPet?.requestBody).toBeDefined()
@@ -378,7 +378,7 @@ describe('buildAst', () => {
 
     it('captures requestBody description', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const createPet = root.operations.find((op) => op.operationId === 'createPet')
 
       expect(createPet?.requestBody?.description).toBe('New pet to create')
@@ -386,7 +386,7 @@ describe('buildAst', () => {
 
     it('sets requestBody.required to true when spec has required: true', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const createPet = root.operations.find((op) => op.operationId === 'createPet')
 
       expect(createPet?.requestBody?.required).toBe(true)
@@ -395,7 +395,7 @@ describe('buildAst', () => {
 
     it('leaves requestBody.required undefined when spec omits required', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const patchPet = root.operations.find((op) => op.operationId === 'patchPet')
 
       expect(patchPet?.requestBody).toBeDefined()
@@ -405,7 +405,7 @@ describe('buildAst', () => {
 
     it('converts responses with statusCode and schema', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const listPets = root.operations.find((op) => op.operationId === 'listPets')
       const ok = listPets?.responses.find((r) => r.statusCode === '200')
 
@@ -415,7 +415,7 @@ describe('buildAst', () => {
 
     it('converts responses without a body schema', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const getPet = root.operations.find((op) => op.operationId === 'getPetById')
       const notFound = getPet?.responses.find((r) => r.statusCode === '404')
 
@@ -424,7 +424,7 @@ describe('buildAst', () => {
 
     it('sets mediaType on responses', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const listPets = root.operations.find((op) => op.operationId === 'listPets')
       const ok = listPets?.responses.find((r) => r.statusCode === '200')
 
@@ -433,7 +433,7 @@ describe('buildAst', () => {
 
     it('populates requestBody.content with a single entry when operation has one content type', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const createPet = root.operations.find((op) => op.operationId === 'createPet')
 
       expect(createPet?.requestBody?.content).toHaveLength(1)
@@ -465,7 +465,7 @@ describe('buildAst', () => {
           },
         },
       })
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const upload = root.operations.find((op) => op.operationId === 'upload')
 
       expect(upload?.requestBody?.content).toHaveLength(2)
@@ -497,7 +497,7 @@ describe('buildAst', () => {
           },
         },
       })
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const upload = root.operations.find((op) => op.operationId === 'upload')
 
       expect(upload?.requestBody?.content?.[0]?.contentType).toBe('application/json')
@@ -528,7 +528,7 @@ describe('buildAst', () => {
           },
         },
       })
-      const root = parseOas(oas, { contentType: 'multipart/form-data' }).root
+      const root = parseOas(oas, { contentType: 'multipart/form-data' })
       const upload = root.operations.find((op) => op.operationId === 'upload')
 
       expect(upload?.requestBody?.content).toHaveLength(1)
@@ -556,7 +556,7 @@ describe('buildAst', () => {
           },
         },
       })
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const uploadFile = root.operations.find((op) => op.operationId === 'uploadFile')
 
       expect(uploadFile?.requestBody?.content).toHaveLength(1)
@@ -566,7 +566,7 @@ describe('buildAst', () => {
 
     it('populates response.content with a single entry when the response has one content type', async () => {
       const oas = await buildMinimalOas()
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const listPets = root.operations.find((op) => op.operationId === 'listPets')
       const ok = listPets?.responses.find((r) => r.statusCode === '200')
 
@@ -599,7 +599,7 @@ describe('buildAst', () => {
           },
         },
       })
-      const root = parseOas(oas).root
+      const root = parseOas(oas)
       const getPetById = root.operations.find((op) => op.operationId === 'getPetById')
       const ok = getPetById?.responses.find((r) => r.statusCode === '200')
 
@@ -633,7 +633,7 @@ describe('buildAst', () => {
           },
         },
       })
-      const root = parseOas(oas, { contentType: 'application/xml' }).root
+      const root = parseOas(oas, { contentType: 'application/xml' })
       const getPetById = root.operations.find((op) => op.operationId === 'getPetById')
       const ok = getPetById?.responses.find((r) => r.statusCode === '200')
 
@@ -1419,7 +1419,7 @@ describe('parseSchema readOnly / writeOnly', () => {
 
   it('populates node.schema with the resolved ref schema when the document contains the definition', async () => {
     const oas = await buildMinimalOas()
-    const root = parseOas(oas).root
+    const root = parseOas(oas)
     const petList = ast.narrowSchema(
       root.schemas.find((s) => s.name === 'PetList'),
       'array',
@@ -1434,7 +1434,7 @@ describe('parseSchema readOnly / writeOnly', () => {
 
   it('syncSchemaRef merges usage-site sibling fields over the resolved schema', async () => {
     const oas = await buildMinimalOas()
-    const { root } = parseOas(oas)
+    const root = parseOas(oas)
     const petList = ast.narrowSchema(
       root.schemas.find((s) => s.name === 'PetList'),
       'array',
@@ -3124,7 +3124,7 @@ describe('parseSchema array', () => {
         },
       },
     })
-    const root = parseOas(oas).root
+    const root = parseOas(oas)
 
     const collectEnumNames = (node: ast.SchemaNode | null | undefined): Array<string> =>
       node
@@ -3889,7 +3889,7 @@ describe('parseSchema discriminator on union without sibling properties', () => 
       },
     })
 
-    const pet = parseOas(oas).root.schemas.find((s) => s.name === 'Pet')
+    const pet = parseOas(oas).schemas.find((s) => s.name === 'Pet')
     const { members } = ast.narrowSchema(pet, 'union')!
 
     const discriminantOf = (member: ast.SchemaNode) => {
@@ -3920,7 +3920,7 @@ describe('parseSchema discriminator on union without sibling properties', () => 
       },
     })
 
-    const notification = parseOas(oas).root.schemas.find((s) => s.name === 'Notification')
+    const notification = parseOas(oas).schemas.find((s) => s.name === 'Notification')
     const { members } = ast.narrowSchema(notification, 'union')!
 
     // Each variant already carries its own `kind` literal, so folding the schema name would
@@ -3960,7 +3960,7 @@ describe('parseSchema circular allOf discriminator detection', () => {
       },
     })
 
-    const root = parseOas(oas).root
+    const root = parseOas(oas)
     const cat = root.schemas.find((s) => s.name === 'Cat')
 
     expect(cat).toBeDefined()
@@ -4000,7 +4000,7 @@ describe('parseSchema circular allOf discriminator detection', () => {
       },
     })
 
-    const root = parseOas(oas).root
+    const root = parseOas(oas)
 
     const cat = root.schemas.find((s) => s.name === 'Cat')
     expect(cat?.type).toBe('intersection')
@@ -4025,7 +4025,7 @@ describe('parseSchema circular allOf discriminator detection', () => {
 
 describe('buildAst', async () => {
   const oas = await buildMinimalOas()
-  const root = parseOas(oas).root
+  const root = parseOas(oas)
 
   it('produces an InputNode with expected schema and operation counts', () => {
     expect(root.kind).toBe('Input')
@@ -4136,7 +4136,7 @@ describe('buildAst – header and cookie parameters', async () => {
     },
   })
 
-  const root = parseOas(oas).root
+  const root = parseOas(oas)
   const getItems = root.operations.find((o) => o.operationId === 'getItems')
 
   it('parses operation description', () => {
@@ -4202,7 +4202,7 @@ describe('buildAst – parameter description propagation', async () => {
     },
   })
 
-  const root = parseOas(oas).root
+  const root = parseOas(oas)
   const listPets = root.operations.find((o) => o.operationId === 'listPets')
 
   it('propagates parameter-level description to schema.description for query params', () => {
@@ -4239,7 +4239,7 @@ describe('buildAst – parameter description propagation', async () => {
         },
       },
     })
-    const root2 = parseOas(oasWithBoth).root
+    const root2 = parseOas(oasWithBoth)
     const getItems = root2.operations.find((o) => o.operationId === 'getItems')
     const q = getItems?.parameters.find((p) => p.name === 'q')
 
@@ -4321,7 +4321,7 @@ describe('parameter enum naming', () => {
         },
       },
     })
-    const root = parseOas(oas).root
+    const root = parseOas(oas)
     const op = root.operations.find((o) => o.operationId === 'listPets')
     const statusParam = op?.parameters.find((p) => p.name === 'status')
     const enumNode = ast.narrowSchema(statusParam?.schema, 'enum')

--- a/packages/adapter-oas/src/parser.ts
+++ b/packages/adapter-oas/src/parser.ts
@@ -17,6 +17,12 @@ import type { ContentType, Document, Operation, SchemaObject } from './types.ts'
 export type OasParserContext = {
   document: Document
   contentType?: ContentType
+  /**
+   * Collision renames from `getSchemas`, keyed by the original component pointer. `convertRef`
+   * stamps `targetName` from it at ref creation, so refs to renamed schemas resolve to the
+   * emitted name without a post-parse pass.
+   */
+  renames?: ReadonlyMap<string, string>
 }
 
 /**
@@ -137,6 +143,7 @@ export function createSchemaParser(ctx: OasParserContext) {
       document,
       resolveRefNode,
       refExists,
+      renames: ctx.renames,
     }
 
     for (const rule of schemaRules) {

--- a/packages/adapter-oas/src/resolvers.test.ts
+++ b/packages/adapter-oas/src/resolvers.test.ts
@@ -425,9 +425,9 @@ describe('getSchemas', () => {
   } as Document
 
   it('returns empty schemas when components is absent', () => {
-    const { schemas, nameMapping } = getSchemas(base, {})
+    const { schemas, renames } = getSchemas(base, {})
     expect(schemas).toStrictEqual({})
-    expect(nameMapping.size).toBe(0)
+    expect(renames.size).toBe(0)
   })
 
   it('returns component schemas', () => {
@@ -440,14 +440,14 @@ describe('getSchemas', () => {
       },
     }
 
-    const { schemas, nameMapping } = getSchemas(document, {})
+    const { schemas, renames } = getSchemas(document, {})
     expect(schemas).toMatchObject({
       Pet: {
         type: 'object',
         properties: { name: { type: 'string' } },
       },
     })
-    expect(nameMapping.get('#/components/schemas/Pet')).toBe('Pet')
+    expect(renames.has('#/components/schemas/Pet')).toBe(false)
   })
 
   it('includes response schemas', () => {
@@ -470,14 +470,14 @@ describe('getSchemas', () => {
       },
     }
 
-    const { schemas, nameMapping } = getSchemas(document, {})
+    const { schemas, renames } = getSchemas(document, {})
     expect(schemas).toMatchObject({
       PetResponse: {
         type: 'object',
         properties: { id: { type: 'integer' } },
       },
     })
-    expect(nameMapping.get('#/components/responses/PetResponse')).toBe('PetResponse')
+    expect(renames.has('#/components/responses/PetResponse')).toBe(false)
   })
 
   it('includes requestBody schemas', () => {
@@ -499,14 +499,14 @@ describe('getSchemas', () => {
       },
     }
 
-    const { schemas, nameMapping } = getSchemas(document, {})
+    const { schemas, renames } = getSchemas(document, {})
     expect(schemas).toMatchObject({
       CreatePet: {
         type: 'object',
         properties: { name: { type: 'string' } },
       },
     })
-    expect(nameMapping.get('#/components/requestBodies/CreatePet')).toBe('CreatePet')
+    expect(renames.has('#/components/requestBodies/CreatePet')).toBe(false)
   })
 
   it('resolves same-source collisions with numeric suffixes', () => {
@@ -520,12 +520,12 @@ describe('getSchemas', () => {
       },
     }
 
-    const { schemas, nameMapping } = getSchemas(document, {})
+    const { schemas, renames } = getSchemas(document, {})
 
     // first entry keeps original name, second gets numeric suffix
     expect(Object.keys(schemas).sort()).toStrictEqual(['Pet2', 'pet'])
-    expect(nameMapping.get('#/components/schemas/pet')).toBe('pet')
-    expect(nameMapping.get('#/components/schemas/Pet')).toBe('Pet2')
+    expect(renames.has('#/components/schemas/pet')).toBe(false)
+    expect(renames.get('#/components/schemas/Pet')).toBe('Pet2')
   })
 
   it('resolves name collisions across sources with semantic suffixes (Schema, Response)', () => {
@@ -551,11 +551,11 @@ describe('getSchemas', () => {
       },
     }
 
-    const { schemas, nameMapping } = getSchemas(document, {})
+    const { schemas, renames } = getSchemas(document, {})
 
     expect(Object.keys(schemas).sort()).toStrictEqual(['PetResponse', 'PetSchema'])
-    expect(nameMapping.get('#/components/schemas/Pet')).toBe('PetSchema')
-    expect(nameMapping.get('#/components/responses/Pet')).toBe('PetResponse')
+    expect(renames.get('#/components/schemas/Pet')).toBe('PetSchema')
+    expect(renames.get('#/components/responses/Pet')).toBe('PetResponse')
   })
 
   it('resolves three-way collision across all sources with semantic suffixes', () => {
@@ -593,12 +593,12 @@ describe('getSchemas', () => {
       },
     }
 
-    const { schemas, nameMapping } = getSchemas(document, {})
+    const { schemas, renames } = getSchemas(document, {})
 
     expect(Object.keys(schemas).sort()).toStrictEqual(['PetRequest', 'PetResponse', 'PetSchema'])
-    expect(nameMapping.get('#/components/schemas/Pet')).toBe('PetSchema')
-    expect(nameMapping.get('#/components/responses/Pet')).toBe('PetResponse')
-    expect(nameMapping.get('#/components/requestBodies/Pet')).toBe('PetRequest')
+    expect(renames.get('#/components/schemas/Pet')).toBe('PetSchema')
+    expect(renames.get('#/components/responses/Pet')).toBe('PetResponse')
+    expect(renames.get('#/components/requestBodies/Pet')).toBe('PetRequest')
   })
 
   it('detects collisions from different casing that normalizes to the same PascalCase', () => {
@@ -624,11 +624,11 @@ describe('getSchemas', () => {
       },
     }
 
-    const { nameMapping } = getSchemas(document, {})
+    const { renames } = getSchemas(document, {})
 
     // both normalize to PetList → semantic suffixes applied
-    expect(nameMapping.get('#/components/schemas/pet_list')).toBe('pet_listSchema')
-    expect(nameMapping.get('#/components/responses/PetList')).toBe('PetListResponse')
+    expect(renames.get('#/components/schemas/pet_list')).toBe('pet_listSchema')
+    expect(renames.get('#/components/responses/PetList')).toBe('PetListResponse')
   })
 
   it('collects enum schemas correctly', () => {
@@ -641,8 +641,8 @@ describe('getSchemas', () => {
       },
     }
 
-    const { nameMapping } = getSchemas(document, {})
-    expect(nameMapping.get('#/components/schemas/Status')).toBe('Status')
+    const { renames } = getSchemas(document, {})
+    expect(renames.has('#/components/schemas/Status')).toBe(false)
   })
 
   it('resolves collision between enum schema and response with semantic suffixes', () => {
@@ -668,9 +668,9 @@ describe('getSchemas', () => {
       },
     }
 
-    const { nameMapping } = getSchemas(document, {})
-    expect(nameMapping.get('#/components/schemas/Status')).toBe('StatusSchema')
-    expect(nameMapping.get('#/components/responses/Status')).toBe('StatusResponse')
+    const { renames } = getSchemas(document, {})
+    expect(renames.get('#/components/schemas/Status')).toBe('StatusSchema')
+    expect(renames.get('#/components/responses/Status')).toBe('StatusResponse')
   })
 
   it('sorts schemas by $ref dependency (referenced schema appears first)', () => {

--- a/packages/adapter-oas/src/resolvers.ts
+++ b/packages/adapter-oas/src/resolvers.ts
@@ -250,10 +250,12 @@ export type GetSchemasOptions = {
 export type GetSchemasResult = {
   schemas: Record<string, SchemaObject>
   /**
-   * Maps each original component pointer (`#/components/<source>/<name>`) to the
-   * collision-resolved unique name used as the key in `schemas`.
+   * Maps a renamed component pointer (`#/components/<source>/<name>`) to the
+   * collision-resolved unique name used as the key in `schemas`. Components that keep
+   * their original name are not recorded, so the map stays empty for documents
+   * without collisions.
    */
-  nameMapping: Map<string, string>
+  renames: Map<string, string>
 }
 
 /**
@@ -423,7 +425,7 @@ function resolveSchemaRef(document: Document, schema: SchemaObject): SchemaObjec
  *
  * @example
  * ```ts
- * const { schemas, nameMapping } = getSchemas(document, { contentType: 'application/json' })
+ * const { schemas, renames } = getSchemas(document, { contentType: 'application/json' })
  * ```
  */
 export function getSchemas(document: Document, { contentType }: GetSchemasOptions): GetSchemasResult {
@@ -460,7 +462,7 @@ export function getSchemas(document: Document, { contentType }: GetSchemasOption
   }
 
   const schemas: Record<string, SchemaObject> = {}
-  const nameMapping = new Map<string, string>()
+  const renames = new Map<string, string>()
 
   for (const [, items] of normalizedNames) {
     const isSingle = items.length === 1
@@ -479,11 +481,11 @@ export function getSchemas(document: Document, { contentType }: GetSchemasOption
       const suffix = isSingle ? '' : hasMultipleSources ? semanticSuffixes[item.source] : index === 0 ? '' : String(index + 1)
       const uniqueName = item.originalName + suffix
       schemas[uniqueName] = item.schema
-      nameMapping.set(`#/components/${item.source}/${item.originalName}`, uniqueName)
+      if (suffix) renames.set(`#/components/${item.source}/${item.originalName}`, uniqueName)
     })
   }
 
-  return { schemas: sortSchemas(schemas), nameMapping }
+  return { schemas: sortSchemas(schemas), renames }
 }
 
 /**

--- a/packages/adapter-oas/src/types.ts
+++ b/packages/adapter-oas/src/types.ts
@@ -207,7 +207,7 @@ export type AdapterOasOptions = {
 } & Partial<ast.ParserOptions>
 
 /**
- * Adapter options after defaults have been applied and schema name collisions resolved.
+ * Adapter options after defaults have been applied.
  */
 export type AdapterOasResolvedOptions = {
   validate: boolean
@@ -220,17 +220,6 @@ export type AdapterOasResolvedOptions = {
   unknownType: NonNullable<AdapterOasOptions['unknownType']>
   emptySchemaType: NonNullable<AdapterOasOptions['emptySchemaType']>
   enumSuffix: AdapterOasOptions['enumSuffix']
-  /**
-   * Map from original `$ref` paths to their collision-resolved schema names.
-   * Populated once the adapter resolves a spec's schemas, on the first `parse()`.
-   *
-   * @example
-   * ```ts
-   * nameMapping.get('#/components/schemas/Order') // 'Order'
-   * nameMapping.get('#/components/responses/Order') // 'OrderResponse'
-   * ```
-   */
-  nameMapping: Map<string, string>
 }
 
 /**

--- a/packages/ast/src/macros/index.ts
+++ b/packages/ast/src/macros/index.ts
@@ -1,3 +1,4 @@
 export { macroDiscriminatorEnum } from './macroDiscriminatorEnum.ts'
 export { macroEnumName } from './macroEnumName.ts'
+export { macroRenameSchema } from './macroRenameSchema.ts'
 export { macroSimplifyUnion } from './macroSimplifyUnion.ts'

--- a/packages/ast/src/macros/macroRenameSchema.test.ts
+++ b/packages/ast/src/macros/macroRenameSchema.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { applyMacros } from '../defineMacro.ts'
+import { createProperty } from '../nodes/property.ts'
+import { createSchema, type RefSchemaNode, type SchemaNode } from '../nodes/schema.ts'
+import { narrowSchema } from '../guards.ts'
+import { resolveRefName } from '../utils/refs.ts'
+import { macroRenameSchema } from './macroRenameSchema.ts'
+
+function apply(node: SchemaNode, macro: Parameters<typeof applyMacros>[1][number]): SchemaNode {
+  return applyMacros(node, [macro])
+}
+
+describe('macroRenameSchema', () => {
+  it('renames the declaration name', () => {
+    const node = createSchema({ type: 'object', name: 'Order', properties: [] })
+    const result = apply(node, macroRenameSchema({ from: 'Order', to: 'StoreOrder' }))
+
+    expect(result.name).toBe('StoreOrder')
+  })
+
+  it('retargets refs pointing at the renamed schema', () => {
+    const node = createSchema({
+      type: 'object',
+      name: 'Cart',
+      properties: [createProperty({ name: 'order', schema: createSchema({ type: 'ref', ref: '#/components/schemas/Order', name: 'Order' }) })],
+    })
+
+    const result = apply(node, macroRenameSchema({ from: 'Order', to: 'StoreOrder' }))
+    const ref = narrowSchema(result, 'object')?.properties[0]?.schema
+
+    expect(resolveRefName(ref)).toBe('StoreOrder')
+    expect(narrowSchema(ref!, 'ref')?.ref).toBe('#/components/schemas/Order')
+  })
+
+  it('keeps a flatten alias declaration and its target independent', () => {
+    // `ClientDisconnectedProblem: { allOf: [$ref Problem] }` flattens to one ref node whose `name`
+    // is the declaring component and whose pointer is the target. Renaming `Problem` must retarget
+    // the pointer side without touching the declaration name.
+    const node: RefSchemaNode = { kind: 'Schema', type: 'ref', name: 'ClientDisconnectedProblem', ref: '#/components/schemas/Problem' }
+
+    const result = apply(node, macroRenameSchema({ from: 'Problem', to: 'ApiProblem' }))
+
+    expect(result.name).toBe('ClientDisconnectedProblem')
+    expect(resolveRefName(result)).toBe('ApiProblem')
+  })
+
+  it('passes through unrelated nodes unchanged', () => {
+    const node = createSchema({ type: 'object', name: 'Pet', properties: [] })
+
+    expect(apply(node, macroRenameSchema({ from: 'Order', to: 'StoreOrder' }))).toBe(node)
+  })
+})

--- a/packages/ast/src/macros/macroRenameSchema.test.ts
+++ b/packages/ast/src/macros/macroRenameSchema.test.ts
@@ -43,10 +43,4 @@ describe('macroRenameSchema', () => {
     expect(result.name).toBe('ClientDisconnectedProblem')
     expect(resolveRefName(result)).toBe('ApiProblem')
   })
-
-  it('passes through unrelated nodes unchanged', () => {
-    const node = createSchema({ type: 'object', name: 'Pet', properties: [] })
-
-    expect(apply(node, macroRenameSchema({ from: 'Order', to: 'StoreOrder' }))).toBe(node)
-  })
 })

--- a/packages/ast/src/macros/macroRenameSchema.ts
+++ b/packages/ast/src/macros/macroRenameSchema.ts
@@ -1,0 +1,41 @@
+import { defineMacro } from '../defineMacro.ts'
+import { narrowSchema } from '../guards.ts'
+import { resolveRefName } from '../utils/refs.ts'
+
+type Props = {
+  from: string
+  to: string
+}
+
+/**
+ * Builds a macro that renames a schema consistently: the declaration (`name`) and every ref
+ * pointing at it (`targetName`) change together, so imports and printed references stay in
+ * sync. Renaming only one side by hand produces imports for files that are never generated.
+ *
+ * @example
+ * ```ts
+ * const macro = macroRenameSchema({ from: 'Order', to: 'StoreOrder' })
+ * ```
+ */
+export function macroRenameSchema({ from, to }: Props) {
+  return defineMacro({
+    name: 'rename-schema',
+    schema(node) {
+      const refNode = narrowSchema(node, 'ref')
+
+      if (!refNode) {
+        return node.name === from ? { ...node, name: to } : undefined
+      }
+
+      const renamesDeclaration = refNode.name === from
+      const renamesTarget = resolveRefName(refNode) === from
+      if (!renamesDeclaration && !renamesTarget) return undefined
+
+      return {
+        ...refNode,
+        ...(renamesDeclaration ? { name: to } : {}),
+        ...(renamesTarget ? { targetName: to } : {}),
+      }
+    },
+  })
+}

--- a/packages/ast/src/macros/macroRenameSchema.ts
+++ b/packages/ast/src/macros/macroRenameSchema.ts
@@ -13,9 +13,7 @@ type Props = {
  * sync. Renaming only one side by hand produces imports for files that are never generated.
  *
  * @example
- * ```ts
- * const macro = macroRenameSchema({ from: 'Order', to: 'StoreOrder' })
- * ```
+ * `const macro = macroRenameSchema({ from: 'Order', to: 'StoreOrder' })`
  */
 export function macroRenameSchema({ from, to }: Props) {
   return defineMacro({

--- a/packages/ast/src/nodes/input.ts
+++ b/packages/ast/src/nodes/input.ts
@@ -61,11 +61,12 @@ export type InputMeta = {
    */
   enumNames: ReadonlyArray<string>
   /**
-   * Maps each original component pointer (e.g. `#/components/schemas/Order`) to the
+   * Maps a renamed component pointer (e.g. `#/components/schemas/Order`) to the
    * collision-corrected schema name the adapter emits (e.g. `OrderSchema`).
    * Populated by the adapter during parsing, so `resolver.imports` can resolve a raw
-   * `$ref` to the name of the file that is actually generated. Absent when the
-   * adapter performs no renaming.
+   * `$ref` to the name of the file that is actually generated. Refs that keep their
+   * pointer's last segment as their name are not recorded, so the record stays empty
+   * (or absent) for documents without renames.
    */
   nameMapping?: Readonly<Record<string, string>>
 }

--- a/packages/ast/src/nodes/input.ts
+++ b/packages/ast/src/nodes/input.ts
@@ -60,15 +60,6 @@ export type InputMeta = {
    * `const isEnum = enums.has(schemaName)`
    */
   enumNames: ReadonlyArray<string>
-  /**
-   * Maps a renamed component pointer (e.g. `#/components/schemas/Order`) to the
-   * collision-corrected schema name the adapter emits (e.g. `OrderSchema`).
-   * Populated by the adapter during parsing, so `resolver.imports` can resolve a raw
-   * `$ref` to the name of the file that is actually generated. Refs that keep their
-   * pointer's last segment as their name are not recorded, so the record stays empty
-   * (or absent) for documents without renames.
-   */
-  nameMapping?: Readonly<Record<string, string>>
 }
 
 /**

--- a/packages/ast/src/nodes/input.ts
+++ b/packages/ast/src/nodes/input.ts
@@ -60,6 +60,14 @@ export type InputMeta = {
    * `const isEnum = enums.has(schemaName)`
    */
   enumNames: ReadonlyArray<string>
+  /**
+   * Maps each original component pointer (e.g. `#/components/schemas/Order`) to the
+   * collision-corrected schema name the adapter emits (e.g. `OrderSchema`).
+   * Populated by the adapter during parsing, so `resolver.imports` can resolve a raw
+   * `$ref` to the name of the file that is actually generated. Absent when the
+   * adapter performs no renaming.
+   */
+  nameMapping?: Readonly<Record<string, string>>
 }
 
 /**

--- a/packages/ast/src/nodes/schema.ts
+++ b/packages/ast/src/nodes/schema.ts
@@ -388,6 +388,13 @@ export type RefSchemaNode = SchemaNodeBase & {
    */
   ref?: string
   /**
+   * Emitted name of the referenced schema when it differs from the pointer's last segment,
+   * for example after a collision rename (`Order` becomes `OrderSchema`) or a macro rename.
+   * Resolve display and import names through `resolveRefName`, which prefers this field and
+   * falls back to the pointer segment, then `name`.
+   */
+  targetName?: string
+  /**
    * Pattern copied from a sibling `pattern` field.
    */
   pattern?: string

--- a/packages/ast/src/utils/index.ts
+++ b/packages/ast/src/utils/index.ts
@@ -1,6 +1,6 @@
 export { combineExports, combineImports, combineSources } from './combineFileMembers.ts'
 export { extractStringsFromNodes } from './extractStringsFromNodes.ts'
 export { mergeAdjacentObjectsLazy } from './mergeAdjacentSchemas.ts'
-export { childName, enumPropName, extractRefName, isStringType, syncSchemaRef } from './refs.ts'
+export { childName, enumPropName, extractRefName, isStringType, resolveRefName, syncSchemaRef } from './refs.ts'
 export { collectUsedSchemaNames, containsCircularRef, findCircularSchemas } from './schemaGraph.ts'
 export { mapSchemaItems, mapSchemaMembers, mapSchemaProperties } from './schemaTraversal.ts'

--- a/packages/ast/src/utils/refs.test.ts
+++ b/packages/ast/src/utils/refs.test.ts
@@ -23,6 +23,12 @@ describe('resolveRefName', () => {
     expect(resolveRefName(ref)).toBe('Pet')
   })
 
+  it('prefers targetName over the pointer segment', () => {
+    const ref = createSchema({ type: 'ref', name: 'Order', ref: '#/components/schemas/Order', targetName: 'OrderSchema' })
+
+    expect(resolveRefName(ref)).toBe('OrderSchema')
+  })
+
   it('falls back to node.name when ref is missing', () => {
     const ref = createSchema({ type: 'ref', name: 'Pet' })
 

--- a/packages/ast/src/utils/refs.ts
+++ b/packages/ast/src/utils/refs.ts
@@ -16,16 +16,21 @@ export function extractRefName(ref: string): string {
 }
 
 /**
- * Resolves the schema name of a ref node. Uses the last segment of `ref` when set, otherwise falls
- * back to `name` then nested `schema.name`.
+ * Resolves the emitted name of the schema a ref node points at. Prefers `targetName` (set when
+ * the referenced schema was renamed, e.g. to break a collision), then the last segment of `ref`,
+ * then `name`, then the nested `schema.name`.
  *
  * Returns `null` for non-ref nodes or when no name resolves.
  *
  * @example
  * `resolveRefName({ kind: 'Schema', type: 'ref', ref: '#/components/schemas/Pet' }) // 'Pet'`
+ *
+ * @example Collision-renamed target
+ * `resolveRefName({ kind: 'Schema', type: 'ref', ref: '#/components/schemas/Order', targetName: 'OrderSchema' }) // 'OrderSchema'`
  */
-export function resolveRefName(node: SchemaNode | undefined): string | null {
+export function resolveRefName(node: SchemaNode | null | undefined): string | null {
   if (!node || node.type !== 'ref') return null
+  if (node.targetName) return node.targetName
   if (node.ref) return extractRefName(node.ref)
 
   return node.name ?? node.schema?.name ?? null

--- a/packages/ast/src/utils/schemaGraph.ts
+++ b/packages/ast/src/utils/schemaGraph.ts
@@ -45,13 +45,6 @@ export function collectReferencedSchemaNames(node: SchemaNode | undefined, out: 
   return out
 }
 
-/**
- * Memoized two-level cache keyed first on the operations array, then on the schemas array.
- */
-const collectUsedSchemaNamesMemo = memoize(new WeakMap<ReadonlyArray<OperationNode>, (schemas: ReadonlyArray<SchemaNode>) => Set<string>>(), (ops) =>
-  memoize(new WeakMap<ReadonlyArray<SchemaNode>, Set<string>>(), (schemas) => computeUsedSchemaNames(ops, schemas)),
-)
-
 function computeUsedSchemaNames(operations: ReadonlyArray<OperationNode>, schemas: ReadonlyArray<SchemaNode>): Set<string> {
   const schemaMap = new Map<string, SchemaNode>()
   for (const schema of schemas) {
@@ -101,7 +94,7 @@ function computeUsedSchemaNames(operations: ReadonlyArray<OperationNode>, schema
  * ```
  */
 export function collectUsedSchemaNames(operations: ReadonlyArray<OperationNode>, schemas: ReadonlyArray<SchemaNode>): Set<string> {
-  return collectUsedSchemaNamesMemo(operations)(schemas)
+  return computeUsedSchemaNames(operations, schemas)
 }
 
 const EMPTY_CIRCULAR_SET = new Set<string>()

--- a/packages/core/src/Resolver.ts
+++ b/packages/core/src/Resolver.ts
@@ -381,23 +381,25 @@ export class Resolver {
   }
 
   /**
-   * Builds one `ImportNode` per `$ref` occurrence in the schema tree. Each ref's target
-   * resolves through `resolveRefName`, so collision- or macro-renamed schemas (`targetName`)
-   * import the emitted name. Names and paths go through the top-level `name` and `file`, so
-   * import entries follow the plugin's conventions, and a per-call `name` override wins over
-   * both.
+   * Builds one `ImportNode` per unique schema referenced in the tree, in first-occurrence
+   * order. Each ref's target resolves through `resolveRefName`, so collision- or macro-renamed
+   * schemas (`targetName`) import the emitted name. Names and paths go through the top-level
+   * `name` and `file`, so import entries follow the plugin's conventions, and a per-call
+   * `name` override wins over both.
    */
   imports(options: ResolveImportsOptions): Array<ImportNode> {
     const { node, root, output, group, extname = '.ts', name } = options
     const resolveName = name ?? ((schemaName: string) => this.name(schemaName))
 
+    const seen = new Set<string>()
     return collect(node, {
       schema: (schemaNode) => {
         const schemaRef = narrowSchema(schemaNode, 'ref')
         if (!schemaRef?.ref) return null
 
         const schemaName = resolveRefName(schemaRef)
-        if (!schemaName) return null
+        if (!schemaName || seen.has(schemaName)) return null
+        seen.add(schemaName)
 
         return ast.factory.createImport({
           name: [resolveName(schemaName)],

--- a/packages/core/src/Resolver.ts
+++ b/packages/core/src/Resolver.ts
@@ -3,9 +3,9 @@ import { camelCase, toFilePath } from '@internals/utils'
 import {
   ast,
   collect,
-  extractRefName,
   narrowSchema,
   operationDef,
+  resolveRefName,
   schemaDef,
   type FileNode,
   type ImportNode,
@@ -123,14 +123,13 @@ export type ResolveFileOptions = ResolverFileParams & {
 }
 
 /**
- * Options for `resolver.imports`: the schema tree to scan (`node`), the document metadata
- * carrying the adapter's `nameMapping` (`meta`), and where the generated files live (`root`,
- * `output`, `group`). Pass `name` to override how a referenced schema name becomes the
- * imported identifier; it defaults to the resolver's top-level `name`.
+ * Options for `resolver.imports`: the schema tree to scan (`node`) and where the generated
+ * files live (`root`, `output`, `group`). Pass `name` to override how a referenced schema
+ * name becomes the imported identifier; it defaults to the resolver's top-level `name`.
  *
  * @example
  * ```ts
- * resolver.imports({ node, meta: ctx.meta, root, output, group })
+ * resolver.imports({ node, root, output, group })
  * // → [{ kind: 'Import', name: ['pet'], path: '/src/types/pet.ts' }]
  * ```
  */
@@ -139,12 +138,6 @@ export type ResolveImportsOptions = {
    * Schema tree scanned for `$ref` occurrences. Each ref contributes one import entry.
    */
   node: SchemaNode
-  /**
-   * Document metadata from `ctx.meta`. Its `nameMapping` resolves a raw `$ref` to the
-   * collision-corrected schema name, so imports stay in sync with the files the adapter
-   * actually names.
-   */
-  meta: Pick<InputMeta, 'nameMapping'>
   root: string
   output: Output
   group?: Group
@@ -388,13 +381,14 @@ export class Resolver {
   }
 
   /**
-   * Builds one `ImportNode` per `$ref` occurrence in the schema tree. The raw `$ref` resolves
-   * through `meta.nameMapping` (collision-renamed schemas) and falls back to the last pointer
-   * segment. Names and paths go through the top-level `name` and `file`, so import entries
-   * follow the plugin's conventions, and a per-call `name` override wins over both.
+   * Builds one `ImportNode` per `$ref` occurrence in the schema tree. Each ref's target
+   * resolves through `resolveRefName`, so collision- or macro-renamed schemas (`targetName`)
+   * import the emitted name. Names and paths go through the top-level `name` and `file`, so
+   * import entries follow the plugin's conventions, and a per-call `name` override wins over
+   * both.
    */
   imports(options: ResolveImportsOptions): Array<ImportNode> {
-    const { node, meta, root, output, group, extname = '.ts', name } = options
+    const { node, root, output, group, extname = '.ts', name } = options
     const resolveName = name ?? ((schemaName: string) => this.name(schemaName))
 
     return collect(node, {
@@ -402,7 +396,8 @@ export class Resolver {
         const schemaRef = narrowSchema(schemaNode, 'ref')
         if (!schemaRef?.ref) return null
 
-        const schemaName = meta.nameMapping?.[schemaRef.ref] ?? extractRefName(schemaRef.ref)
+        const schemaName = resolveRefName(schemaRef)
+        if (!schemaName) return null
 
         return ast.factory.createImport({
           name: [resolveName(schemaName)],

--- a/packages/core/src/Resolver.ts
+++ b/packages/core/src/Resolver.ts
@@ -1,6 +1,19 @@
 import path from 'node:path'
 import { camelCase, toFilePath } from '@internals/utils'
-import { ast, operationDef, schemaDef, type FileNode, type InputMeta, type Node, type OperationNode, type SchemaNode } from '@kubb/ast'
+import {
+  ast,
+  collect,
+  extractRefName,
+  narrowSchema,
+  operationDef,
+  schemaDef,
+  type FileNode,
+  type ImportNode,
+  type InputMeta,
+  type Node,
+  type OperationNode,
+  type SchemaNode,
+} from '@kubb/ast'
 import { Diagnostics } from './Diagnostics.ts'
 import { getInputKind } from './input.ts'
 import type { Filter, Override } from './definePlugin.ts'
@@ -107,6 +120,45 @@ export type ResolveFileOptions = ResolverFileParams & {
   root: string
   output: Output
   group?: Group
+}
+
+/**
+ * Options for `resolver.imports`: the schema tree to scan (`node`), the document metadata
+ * carrying the adapter's `nameMapping` (`meta`), and where the generated files live (`root`,
+ * `output`, `group`). Pass `name` to override how a referenced schema name becomes the
+ * imported identifier; it defaults to the resolver's top-level `name`.
+ *
+ * @example
+ * ```ts
+ * resolver.imports({ node, meta: ctx.meta, root, output, group })
+ * // → [{ kind: 'Import', name: ['pet'], path: '/src/types/pet.ts' }]
+ * ```
+ */
+export type ResolveImportsOptions = {
+  /**
+   * Schema tree scanned for `$ref` occurrences. Each ref contributes one import entry.
+   */
+  node: SchemaNode
+  /**
+   * Document metadata from `ctx.meta`. Its `nameMapping` resolves a raw `$ref` to the
+   * collision-corrected schema name, so imports stay in sync with the files the adapter
+   * actually names.
+   */
+  meta: Pick<InputMeta, 'nameMapping'>
+  root: string
+  output: Output
+  group?: Group
+  /**
+   * Extension of the generated files the imports point at.
+   *
+   * @default '.ts'
+   */
+  extname?: FileNode['extname']
+  /**
+   * Overrides how a referenced schema name becomes the imported identifier, for example to
+   * point enum refs at a suffixed type name. Defaults to the resolver's top-level `name`.
+   */
+  name?: (schemaName: string) => string
 }
 
 /**
@@ -264,9 +316,9 @@ function toBaseName({ name, extname }: Pick<ResolverFileParams, 'name' | 'extnam
 /**
  * Base constraint for all plugin resolver objects.
  *
- * The built-in machinery lives under `default`. Generators call the top-level `name` and
- * `file`, and a plugin overrides them to set its conventions. Extend with top-level helpers
- * (`typeName`, …) and/or grouped namespaces (`query`, `schema`, …).
+ * The built-in machinery lives under `default`. Generators call the top-level `name`, `file`,
+ * and `imports`, and a plugin overrides `name` and `file` to set its conventions. Extend with
+ * top-level helpers (`typeName`, …) and/or grouped namespaces (`query`, `schema`, …).
  *
  * @example Top-level helper
  * ```ts
@@ -333,6 +385,31 @@ export class Resolver {
 
   file(options: ResolveFileOptions): FileNode {
     return this.#resolveFile(options)
+  }
+
+  /**
+   * Builds one `ImportNode` per `$ref` occurrence in the schema tree. The raw `$ref` resolves
+   * through `meta.nameMapping` (collision-renamed schemas) and falls back to the last pointer
+   * segment. Names and paths go through the top-level `name` and `file`, so import entries
+   * follow the plugin's conventions, and a per-call `name` override wins over both.
+   */
+  imports(options: ResolveImportsOptions): Array<ImportNode> {
+    const { node, meta, root, output, group, extname = '.ts', name } = options
+    const resolveName = name ?? ((schemaName: string) => this.name(schemaName))
+
+    return collect(node, {
+      schema: (schemaNode) => {
+        const schemaRef = narrowSchema(schemaNode, 'ref')
+        if (!schemaRef?.ref) return null
+
+        const schemaName = meta.nameMapping?.[schemaRef.ref] ?? extractRefName(schemaRef.ref)
+
+        return ast.factory.createImport({
+          name: [resolveName(schemaName)],
+          path: this.file({ name: schemaName, extname, root, output, group }).path,
+        })
+      },
+    })
   }
 
   /**

--- a/packages/core/src/createAdapter.ts
+++ b/packages/core/src/createAdapter.ts
@@ -1,5 +1,5 @@
 import type { PossiblePromise } from '@internals/utils'
-import type { ImportNode, InputNode, SchemaNode } from '@kubb/ast'
+import type { InputNode } from '@kubb/ast'
 
 /**
  * Source data handed to an adapter's `parse` function. Mirrors the config
@@ -66,16 +66,12 @@ export type Adapter<TOptions extends AdapterFactoryOptions = AdapterFactoryOptio
   document: TOptions['document'] | null
   /**
    * Parse the source into a universal `InputNode`.
+   *
+   * An adapter that renames schemas (e.g. collision handling) must record each raw ref
+   * pointer to renamed-name entry in `meta.nameMapping`, so `resolver.imports` resolves
+   * a `$ref` to the file that is actually generated.
    */
   parse: (source: AdapterSource) => PossiblePromise<InputNode>
-  /**
-   * Extract `ImportNode` entries for a schema tree.
-   * Returns an empty array before the first `parse()` call.
-   *
-   * The `resolve` callback receives the collision-corrected schema name and must
-   * return `{ name, path }` for the import, or `undefined` to skip it.
-   */
-  getImports: (node: SchemaNode, resolve: (schemaName: string) => { name: string; path: string }) => Array<ImportNode>
   /**
    * Validate the document at the given path or URL.
    */
@@ -107,7 +103,6 @@ type AdapterBuilder<T extends AdapterFactoryOptions> = (options: T['options']) =
  *     // Convert the source (path or inline data) into an InputNode.
  *     return ast.factory.createInput()
  *   },
- *   getImports: () => [],
  *   async validate() {
  *     // Throw here when the spec is invalid.
  *   },

--- a/packages/core/src/createAdapter.ts
+++ b/packages/core/src/createAdapter.ts
@@ -67,10 +67,10 @@ export type Adapter<TOptions extends AdapterFactoryOptions = AdapterFactoryOptio
   /**
    * Parse the source into a universal `InputNode`.
    *
-   * An adapter that renames schemas (e.g. collision handling) must record each renamed
-   * ref pointer and its emitted name in `meta.nameMapping`, so `resolver.imports`
-   * resolves a `$ref` to the file that is actually generated. Refs that keep their
-   * pointer's last segment need no entry.
+   * An adapter that renames schemas (e.g. collision handling) must stamp `targetName` on
+   * every ref node pointing at a renamed schema, so `resolveRefName` and `resolver.imports`
+   * resolve a `$ref` to the file that is actually generated. Refs that keep their pointer's
+   * last segment need no stamp.
    */
   parse: (source: AdapterSource) => PossiblePromise<InputNode>
   /**

--- a/packages/core/src/createAdapter.ts
+++ b/packages/core/src/createAdapter.ts
@@ -67,9 +67,10 @@ export type Adapter<TOptions extends AdapterFactoryOptions = AdapterFactoryOptio
   /**
    * Parse the source into a universal `InputNode`.
    *
-   * An adapter that renames schemas (e.g. collision handling) must record each raw ref
-   * pointer to renamed-name entry in `meta.nameMapping`, so `resolver.imports` resolves
-   * a `$ref` to the file that is actually generated.
+   * An adapter that renames schemas (e.g. collision handling) must record each renamed
+   * ref pointer and its emitted name in `meta.nameMapping`, so `resolver.imports`
+   * resolves a `$ref` to the file that is actually generated. Refs that keep their
+   * pointer's last segment need no entry.
    */
   parse: (source: AdapterSource) => PossiblePromise<InputNode>
   /**

--- a/packages/core/src/createResolver.test.ts
+++ b/packages/core/src/createResolver.test.ts
@@ -486,6 +486,76 @@ describe('default.file', () => {
   })
 })
 
+describe('resolver.imports', () => {
+  const refNode = ast.factory.createSchema({
+    type: 'object',
+    properties: [
+      ast.factory.createProperty({ name: 'pet', schema: ast.factory.createSchema({ type: 'ref', ref: '#/components/schemas/Pet', name: 'Pet' }) }),
+      ast.factory.createProperty({ name: 'order', schema: ast.factory.createSchema({ type: 'ref', ref: '#/components/schemas/Order', name: 'Order' }) }),
+    ],
+  })
+
+  it('builds one import per ref with the resolver name and file path', () => {
+    const imports = baseResolver.imports({ node: refNode, meta: {}, ...context })
+
+    expect(imports).toMatchObject([
+      { kind: 'Import', name: ['pet'], path: '/root/types/pet.ts' },
+      { kind: 'Import', name: ['order'], path: '/root/types/order.ts' },
+    ])
+  })
+
+  it('resolves a collision-renamed ref through meta.nameMapping', () => {
+    const meta = { nameMapping: { '#/components/schemas/Order': 'OrderSchema' } }
+
+    const imports = baseResolver.imports({ node: refNode, meta, ...context })
+
+    expect(imports).toMatchObject([
+      { kind: 'Import', name: ['pet'], path: '/root/types/pet.ts' },
+      { kind: 'Import', name: ['orderSchema'], path: '/root/types/orderSchema.ts' },
+    ])
+  })
+
+  it('a per-call name override wins over the resolver name', () => {
+    const imports = baseResolver.imports({
+      node: refNode,
+      meta: {},
+      ...context,
+      name: (schemaName) => `${schemaName}Type`,
+    })
+
+    expect(imports.map((imp) => imp.name)).toStrictEqual([['PetType'], ['OrderType']])
+  })
+
+  it('uses the plugin name and file conventions for the import entries', () => {
+    const resolver = createResolver<TestPluginFactory>({
+      pluginName: 'test',
+      name(name) {
+        return `${this.default.name(name)}Schema`
+      },
+      file: {
+        baseName({ name, extname }) {
+          return `${this.name(name)}.gen${extname}`
+        },
+      },
+      greet: (name: string) => name,
+      farewell: (name: string) => name,
+    })
+
+    const imports = resolver.imports({ node: refNode, meta: {}, ...context })
+
+    expect(imports).toMatchObject([
+      { name: ['petSchema'], path: '/root/types/petSchema.gen.ts' },
+      { name: ['orderSchema'], path: '/root/types/orderSchema.gen.ts' },
+    ])
+  })
+
+  it('returns an empty array for a schema without refs', () => {
+    const node = ast.factory.createSchema({ type: 'string' })
+
+    expect(baseResolver.imports({ node, meta: {}, ...context })).toStrictEqual([])
+  })
+})
+
 const mockConfig = {
   input: 'petStore.yaml',
   output: { path: 'src/generated', defaultBanner: true },

--- a/packages/core/src/createResolver.test.ts
+++ b/packages/core/src/createResolver.test.ts
@@ -496,7 +496,7 @@ describe('resolver.imports', () => {
   })
 
   it('builds one import per ref with the resolver name and file path', () => {
-    const imports = baseResolver.imports({ node: refNode, meta: {}, ...context })
+    const imports = baseResolver.imports({ node: refNode, ...context })
 
     expect(imports).toMatchObject([
       { kind: 'Import', name: ['pet'], path: '/root/types/pet.ts' },
@@ -504,21 +504,25 @@ describe('resolver.imports', () => {
     ])
   })
 
-  it('resolves a collision-renamed ref through meta.nameMapping', () => {
-    const meta = { nameMapping: { '#/components/schemas/Order': 'OrderSchema' } }
+  it('resolves a collision-renamed ref through targetName', () => {
+    const node = ast.factory.createSchema({
+      type: 'object',
+      properties: [
+        ast.factory.createProperty({
+          name: 'order',
+          schema: ast.factory.createSchema({ type: 'ref', ref: '#/components/schemas/Order', name: 'Order', targetName: 'OrderSchema' }),
+        }),
+      ],
+    })
 
-    const imports = baseResolver.imports({ node: refNode, meta, ...context })
+    const imports = baseResolver.imports({ node, ...context })
 
-    expect(imports).toMatchObject([
-      { kind: 'Import', name: ['pet'], path: '/root/types/pet.ts' },
-      { kind: 'Import', name: ['orderSchema'], path: '/root/types/orderSchema.ts' },
-    ])
+    expect(imports).toMatchObject([{ kind: 'Import', name: ['orderSchema'], path: '/root/types/orderSchema.ts' }])
   })
 
   it('a per-call name override wins over the resolver name', () => {
     const imports = baseResolver.imports({
       node: refNode,
-      meta: {},
       ...context,
       name: (schemaName) => `${schemaName}Type`,
     })
@@ -541,7 +545,7 @@ describe('resolver.imports', () => {
       farewell: (name: string) => name,
     })
 
-    const imports = resolver.imports({ node: refNode, meta: {}, ...context })
+    const imports = resolver.imports({ node: refNode, ...context })
 
     expect(imports).toMatchObject([
       { name: ['petSchema'], path: '/root/types/petSchema.gen.ts' },
@@ -552,7 +556,7 @@ describe('resolver.imports', () => {
   it('returns an empty array for a schema without refs', () => {
     const node = ast.factory.createSchema({ type: 'string' })
 
-    expect(baseResolver.imports({ node, meta: {}, ...context })).toStrictEqual([])
+    expect(baseResolver.imports({ node, ...context })).toStrictEqual([])
   })
 })
 

--- a/packages/core/src/createResolver.test.ts
+++ b/packages/core/src/createResolver.test.ts
@@ -530,35 +530,6 @@ describe('resolver.imports', () => {
     expect(imports.map((imp) => imp.name)).toStrictEqual([['PetType'], ['OrderType']])
   })
 
-  it('uses the plugin name and file conventions for the import entries', () => {
-    const resolver = createResolver<TestPluginFactory>({
-      pluginName: 'test',
-      name(name) {
-        return `${this.default.name(name)}Schema`
-      },
-      file: {
-        baseName({ name, extname }) {
-          return `${this.name(name)}.gen${extname}`
-        },
-      },
-      greet: (name: string) => name,
-      farewell: (name: string) => name,
-    })
-
-    const imports = resolver.imports({ node: refNode, ...context })
-
-    expect(imports).toMatchObject([
-      { name: ['petSchema'], path: '/root/types/petSchema.gen.ts' },
-      { name: ['orderSchema'], path: '/root/types/orderSchema.gen.ts' },
-    ])
-  })
-
-  it('returns an empty array for a schema without refs', () => {
-    const node = ast.factory.createSchema({ type: 'string' })
-
-    expect(baseResolver.imports({ node, ...context })).toStrictEqual([])
-  })
-
   it('emits one import per unique target when a schema is referenced repeatedly', () => {
     const petRef = () => ast.factory.createSchema({ type: 'ref', ref: '#/components/schemas/Pet', name: 'Pet' })
     const node = ast.factory.createSchema({

--- a/packages/core/src/createResolver.test.ts
+++ b/packages/core/src/createResolver.test.ts
@@ -558,6 +558,16 @@ describe('resolver.imports', () => {
 
     expect(baseResolver.imports({ node, ...context })).toStrictEqual([])
   })
+
+  it('emits one import per unique target when a schema is referenced repeatedly', () => {
+    const petRef = () => ast.factory.createSchema({ type: 'ref', ref: '#/components/schemas/Pet', name: 'Pet' })
+    const node = ast.factory.createSchema({
+      type: 'object',
+      properties: [ast.factory.createProperty({ name: 'first', schema: petRef() }), ast.factory.createProperty({ name: 'second', schema: petRef() })],
+    })
+
+    expect(baseResolver.imports({ node, ...context })).toMatchObject([{ name: ['pet'], path: '/root/types/pet.ts' }])
+  })
 })
 
 const mockConfig = {

--- a/packages/core/src/mocks.ts
+++ b/packages/core/src/mocks.ts
@@ -57,14 +57,12 @@ export function createMockedPluginDriver(options: { name?: string; plugin?: Norm
 /**
  * Creates a minimal `Adapter` mock for unit tests.
  * `parse` returns an empty `InputNode` by default. Override via `options.parse`.
- * `getImports` returns `[]` by default.
  */
 export function createMockedAdapter<TOptions extends AdapterFactoryOptions = AdapterFactoryOptions>(
   options: {
     name?: TOptions['name']
     resolvedOptions?: TOptions['resolvedOptions']
     parse?: Adapter<TOptions>['parse']
-    getImports?: Adapter<TOptions>['getImports']
   } = {},
 ): Adapter<TOptions> {
   const adapter: Adapter<TOptions> = {
@@ -72,7 +70,6 @@ export function createMockedAdapter<TOptions extends AdapterFactoryOptions = Ada
     options: (options.resolvedOptions ?? {}) as TOptions['resolvedOptions'],
     document: null,
     parse: options.parse ?? (async () => ast.factory.createInput()),
-    getImports: options.getImports ?? ((_node: SchemaNode, _resolve: (schemaName: string) => { name: string; path: string }) => []),
     validate: async () => {},
   }
   return adapter

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -778,6 +778,7 @@ export type {
   ResolveBannerContext,
   ResolveBannerFile,
   ResolveFileOptions,
+  ResolveImportsOptions,
   ResolveOptionsContext,
   ResolvePathOptions,
   Resolver,

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -34,6 +34,7 @@ export type {
   Renderer,
   RendererFactory,
   ResolveFileOptions,
+  ResolveImportsOptions,
   ResolvePathOptions,
   ResolverFile,
   ResolverFileParams,

--- a/packages/kubb/package.json
+++ b/packages/kubb/package.json
@@ -136,7 +136,7 @@
     "@nuxt/kit": "^4.4.8",
     "@nuxt/schema": "^4.4.8",
     "esbuild": "^0.28.1",
-    "rolldown": "^1.1.4",
+    "rolldown": "^1.1.5",
     "rollup": "^4.62.2",
     "typescript": "catalog:",
     "vite": "^8.1.3",

--- a/packages/unplugin-kubb/package.json
+++ b/packages/unplugin-kubb/package.json
@@ -120,7 +120,7 @@
     "@nuxt/kit": "^4.4.8",
     "@nuxt/schema": "^4.4.8",
     "esbuild": "^0.28.1",
-    "rolldown": "^1.1.4",
+    "rolldown": "^1.1.5",
     "rollup": "^4.62.2",
     "vite": "^8.1.3",
     "webpack": "^5.108.4"

--- a/packages/unplugin-kubb/src/webpack.ts
+++ b/packages/unplugin-kubb/src/webpack.ts
@@ -1,7 +1,4 @@
-import type { UnpluginFactoryOutput } from 'unplugin'
 import { createWebpackPlugin } from 'unplugin'
-import type { WebpackPluginInstance } from 'webpack'
-import type { Options } from './types.ts'
 import { unpluginFactory } from './unpluginFactory.ts'
 
-export default createWebpackPlugin(unpluginFactory) as unknown as UnpluginFactoryOutput<Options, WebpackPluginInstance>
+export default createWebpackPlugin(unpluginFactory)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ catalogs:
       specifier: ^1.2.4
       version: 1.2.4
     tsdown:
-      specifier: ^0.22.3
-      version: 0.22.3
+      specifier: ^0.22.4
+      version: 0.22.4
     typescript:
       specifier: ^6.0.3
       version: 6.0.3
@@ -70,7 +70,7 @@ importers:
         version: 19.14.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.3(typescript@6.0.3)
+        version: 0.22.4(typescript@6.0.3)
       turbo:
         specifier: ^2.10.4
         version: 2.10.4
@@ -248,8 +248,8 @@ importers:
         specifier: ^0.28.1
         version: 0.28.1
       rolldown:
-        specifier: ^1.1.4
-        version: 1.1.4
+        specifier: ^1.1.5
+        version: 1.1.5
       rollup:
         specifier: ^4.62.2
         version: 4.62.2
@@ -360,7 +360,7 @@ importers:
         version: link:../plugin-barrel
       unplugin:
         specifier: ^3.3.0
-        version: 3.3.0(@farmfe/core@1.7.11(@types/node@26.0.1))(esbuild@0.28.1)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1))
+        version: 3.3.0(@farmfe/core@1.7.11(@types/node@26.0.1))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.3(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1))
     devDependencies:
       '@farmfe/core':
         specifier: ^1.7.11
@@ -378,8 +378,8 @@ importers:
         specifier: ^0.28.1
         version: 0.28.1
       rolldown:
-        specifier: ^1.1.4
-        version: 1.1.4
+        specifier: ^1.1.5
+        version: 1.1.5
       rollup:
         specifier: ^4.62.2
         version: 4.62.2
@@ -407,34 +407,17 @@ packages:
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@8.0.0':
-    resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/helper-string-parser@8.0.0':
-    resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
-    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@8.0.2':
-    resolution: {integrity: sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-
   '@babel/parser@7.29.7':
     resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
-    hasBin: true
-
-  '@babel/parser@8.0.0':
-    resolution: {integrity: sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==}
-    engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
 
   '@babel/runtime@7.29.7':
@@ -444,10 +427,6 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
-
-  '@babel/types@8.0.0':
-    resolution: {integrity: sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==}
-    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
@@ -839,6 +818,9 @@ packages:
   '@oxc-project/types@0.138.0':
     resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
 
+  '@oxc-project/types@0.139.0':
+    resolution: {integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==}
+
   '@oxfmt/binding-android-arm-eabi@0.58.0':
     resolution: {integrity: sha512-Uz62sHduGGPftXtILGyxdSW4PX82rUg+rfdNqhsgxe881g4rIoXlIqmZQ6HVKcF4f+F8qMhdD03Bx5u7gmeTdg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1111,8 +1093,20 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@rolldown/binding-android-arm64@1.1.5':
+    resolution: {integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
   '@rolldown/binding-darwin-arm64@1.1.4':
     resolution: {integrity: sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
+    resolution: {integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
@@ -1123,8 +1117,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@rolldown/binding-darwin-x64@1.1.5':
+    resolution: {integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
   '@rolldown/binding-freebsd-x64@1.1.4':
     resolution: {integrity: sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
+    resolution: {integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
@@ -1135,8 +1141,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    resolution: {integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@rolldown/binding-linux-arm64-gnu@1.1.4':
     resolution: {integrity: sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
+    resolution: {integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -1149,8 +1168,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    resolution: {integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-linux-ppc64-gnu@1.1.4':
     resolution: {integrity: sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
+    resolution: {integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -1163,8 +1196,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    resolution: {integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@rolldown/binding-linux-x64-gnu@1.1.4':
     resolution: {integrity: sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
+    resolution: {integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -1177,8 +1224,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    resolution: {integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@rolldown/binding-openharmony-arm64@1.1.4':
     resolution: {integrity: sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
+    resolution: {integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -1188,14 +1248,31 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    resolution: {integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
   '@rolldown/binding-win32-arm64-msvc@1.1.4':
     resolution: {integrity: sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    resolution: {integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
   '@rolldown/binding-win32-x64-msvc@1.1.4':
     resolution: {integrity: sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
+    resolution: {integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1411,9 +1488,6 @@ packages:
   '@types/http-proxy@1.17.17':
     resolution: {integrity: sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==}
 
-  '@types/jsesc@2.5.1':
-    resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
-
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -1537,6 +1611,131 @@ packages:
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
 
+  '@yuku-codegen/binding-darwin-arm64@0.5.44':
+    resolution: {integrity: sha512-mpZc7hrjl/qxcbEMS6vVLE0lO4DjiXCvrp3gYbZ58bbmsSxSGCTlOCA0lpeLXAKOZxe0ZrVoqKteaewFF2Vbuw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@yuku-codegen/binding-darwin-x64@0.5.44':
+    resolution: {integrity: sha512-PCt776PnGtnQYimxk18IyvPf/BQ6CNU95W+6eaoQfeME8ra+7v3pNNoTAmLfSveUC9KZPaoajR9NqkKfEVjA2Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@yuku-codegen/binding-freebsd-x64@0.5.44':
+    resolution: {integrity: sha512-5MNu1R4ysytPLMdl1UlGyjgAbUdT8fguW/QRo+pyEymbuWRN5n8JEHCFpm4AsWdP61fStagSpPDJcwN+mwC9Lg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@yuku-codegen/binding-linux-arm-gnu@0.5.44':
+    resolution: {integrity: sha512-xbP2qQ7/h6ZZKeckCiI2osB5SE5PBfLb4uzIfO1BSTX+9rlBKTqomxDaCib7aPf2X1CXMiIq+i7AK1EhBa5a7A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-codegen/binding-linux-arm-musl@0.5.44':
+    resolution: {integrity: sha512-gmXKMCpgkUm5PllGMKBMoBmqgbTQkx+S85eE46LctuwTSKS/K7u65NE6t4zk6cLDvZpV67enycKXBORWn6q7xA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-codegen/binding-linux-arm64-gnu@0.5.44':
+    resolution: {integrity: sha512-eOoejNUtnHs1/TMn4wryOAG/TarvlOqSZtRPeS56liBKp/GVQSirqTM9AITSGPLSdK1u7fZWMdj5IOEoJp3ruw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-codegen/binding-linux-arm64-musl@0.5.44':
+    resolution: {integrity: sha512-xTzrhEMy1mdv5+SbJPPlwqlMrhXGPntE2f12TLi+dNPXhif4iXCGJpoh8pV9nwZFE/cq1ITuTnjIfTFj/PifzA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-codegen/binding-linux-x64-gnu@0.5.44':
+    resolution: {integrity: sha512-2bvgIU4P+f4q18grdHoGnt9L6XlAciq/8GWpM06fmwj8qqruS8qwwwZXBk3/0U2+IHGv9pXRR8GtSXzl5n/blg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-codegen/binding-linux-x64-musl@0.5.44':
+    resolution: {integrity: sha512-EzX5hWK0MmU4fbqY9coc5PJ0y0LYjrBdAF7mjSyetdK/yWRGBfHi9nh0dUJ0lqb47653hxB8/r9byfYgg6ecbA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-codegen/binding-win32-arm64@0.5.44':
+    resolution: {integrity: sha512-/ajGFWcOLGtmVUdxWKXDW6Ixtez68xxtmd2l95xNg8Lzs4aqbV2cy0Ns2Bzg9vjHsgDIooQlLXHpWh6HsHcy6w==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@yuku-codegen/binding-win32-x64@0.5.44':
+    resolution: {integrity: sha512-geuJQ7FKI8YUtBgW8w72ChMfMvYy3gSytACxB4HOkylsoutrhH6lUNYHk1ny/p8u8t47NGxktpnzVJzI8IzJkA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@yuku-parser/binding-darwin-arm64@0.5.44':
+    resolution: {integrity: sha512-EXSW5w1YOIMyxu53MFxP43gTDeHlQueOjk8AEI9tuLF5976bDq3MXuIgzQvZKPVAirxGZu8+ANVXH1WcAH1G6A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@yuku-parser/binding-darwin-x64@0.5.44':
+    resolution: {integrity: sha512-pJBHsKxqR/nPwwaXgkkYTVo3G9dJ/AXhWsYyKyadU1zLg9gGfVwVTMehqwwutMCONDsLqOmEv/UqItmhpVsQJw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@yuku-parser/binding-freebsd-x64@0.5.44':
+    resolution: {integrity: sha512-fOqYX5BQML94uj9hd3a+LlBNz54OoDm6l+wgUIZ8UUkOBfPV+w2lux1jj9FKXT85wwjDOFhgZ/XQYSEDK/N9mA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@yuku-parser/binding-linux-arm-gnu@0.5.44':
+    resolution: {integrity: sha512-kA2jRNh2cbbHDbhBN9IR8CnYI4UZHNQg0OVz6+V16Ph5VlLYpfv/6GdCmvQQoTGAnhFlbQiRoQys03ey91FTew==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-parser/binding-linux-arm-musl@0.5.44':
+    resolution: {integrity: sha512-TQ82L8c5Lxl3HBOmw0uGfCcsyw0mp7DVGwCuW24OdDWak6BKaumvB8/Ep1llPOvhk5xgSFB7fsqgh6sIwkNRew==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-parser/binding-linux-arm64-gnu@0.5.44':
+    resolution: {integrity: sha512-o6up+m/MsoMEtq6h4JTzmzKOvH9o3o41vK8oiok0LOZoPOFOqOSqC+N5V2ArD1O54m5LUq6ErghAbGWiPsMsqg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-parser/binding-linux-arm64-musl@0.5.44':
+    resolution: {integrity: sha512-3XZoiHhtrjWKgk7CJC/sGzk1TE57SDPYzOFXUg6CZrigRZ+c0Q5ItzJpyAvhzlxv5ruNRYiuGvFbaRSIDnp2BA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-parser/binding-linux-x64-gnu@0.5.44':
+    resolution: {integrity: sha512-7KYCySZI6cjsdeiiIwvviDfJFd4Xj5gjNBzm9akUpwxRXNwaHHuEq2yGkVdGqj3BT6dJsiNhJIhtS6k7/HJdFA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@yuku-parser/binding-linux-x64-musl@0.5.44':
+    resolution: {integrity: sha512-SLU/nXwOjET2XlOiO984sAzCloiWw0+JdcWpGzXLz3JQWbdiblxWC9cIvB0fCtKdDhX1mIutKNEH+RRRJADYcQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@yuku-parser/binding-win32-arm64@0.5.44':
+    resolution: {integrity: sha512-LGmaJtB2mVqPD7Gu/RKAu9aIVxlaKPOgKB8RPHeFFD5Tf/apCiWZix1tkBjdOAo9cVEAoR9qnVHE6zJ+OG0drQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@yuku-parser/binding-win32-x64@0.5.44':
+    resolution: {integrity: sha512-2i0FTklLuhBIgILvtEQ3IN3J4qaTMKlxptseWNrz4F5mimL9UpQFUniVju9OOInwP2O1vgLdZn8EBjEXGNCHmg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@yuku-toolchain/types@0.5.43':
+    resolution: {integrity: sha512-kSpvPntnXw5+lYjO71ffBEnQ5ycQ74KGIYknh0TS4xeyCuBkOqxyJumxZkMhLBBUCLjDAbx2+Icnr3Zh4ftjpQ==}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -1610,10 +1809,6 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-kit@3.0.0:
-    resolution: {integrity: sha512-8OG92q3R35qjC/4i6BLBMg8IB+fClWu/1PEwg2Z9Rn+BuNaiEgJzpzn+pxWOdHJWDCAwu2JP0wCDTozAM4QirQ==}
-    engines: {node: ^22.18.0 || >=24.11.0}
-
   ast-v8-to-istanbul@1.0.4:
     resolution: {integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==}
 
@@ -1633,9 +1828,6 @@ packages:
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
-
-  birpc@4.0.0:
-    resolution: {integrity: sha512-LShSxJP0KTmd101b6DRyGBj57LZxSDYWKitQNW/mi8GRMvZb078Uf9+pveax1DrVL89vm7mWe+TovdI/UDOuPw==}
 
   bplist-parser@0.2.0:
     resolution: {integrity: sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==}
@@ -2334,11 +2526,6 @@ packages:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
-  jsesc@3.1.0:
-    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
-    engines: {node: '>=6'}
-    hasBin: true
-
   json-crawl@0.4.2:
     resolution: {integrity: sha512-MOKk9cjtpMrP4H1DmG+PtS7aFWg9OuSqxc/wpFcOE++yVnD5Bi5iKoXD6oqs+kltRwJRgZBYMozRNpQpxD/TJw==}
     engines: {node: '>=14.0.0'}
@@ -2785,6 +2972,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
@@ -2857,8 +3048,8 @@ packages:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
 
-  rolldown-plugin-dts@0.26.0:
-    resolution: {integrity: sha512-e+kEPtUiDES0htk5iqkSeF4EzAV7R+vugGB44iPDuw1Kw9E+WyL1VG7PaV0IIjGHLiacztMBcMTyrr8ON9CT1Q==}
+  rolldown-plugin-dts@0.27.1:
+    resolution: {integrity: sha512-s1HLtZfsXcLsBrcqW6nmIcTqkBZd7Y9srgL9SMS2hNvl37US5jFl193d5ki2w9Ei5myP7ERLVlQX2o6ZTL/AQQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
     peerDependencies:
       '@ts-macro/tsc': ^0.3.6
@@ -2878,6 +3069,11 @@ packages:
 
   rolldown@1.1.4:
     resolution: {integrity: sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  rolldown@1.1.5:
+    resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -3070,14 +3266,14 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
-  tsdown@0.22.3:
-    resolution: {integrity: sha512-louqbfA8Qf//B9jTTL0FPtXTNpjCWv1VPkbcmQMph2pTpzs+LnB1tbe4tDDRVpo2BjF5SgUXaTZe45SxB8pWHg==}
+  tsdown@0.22.4:
+    resolution: {integrity: sha512-3a5FsNL2fH2jw3ozvFUuPMBgS0xXjX9wpZShHyB4klXelVhyaNw5Q5WA9TPCNeoGYpRZEc4OZdMx5wT4Fkma3A==}
     engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
     peerDependencies:
       '@arethetypeswrong/core': ^0.18.1
-      '@tsdown/css': 0.22.3
-      '@tsdown/exe': 0.22.3
+      '@tsdown/css': 0.22.4
+      '@tsdown/exe': 0.22.4
       '@vitejs/devtools': '*'
       publint: ^0.3.8
       tsx: '*'
@@ -3362,6 +3558,15 @@ packages:
     resolution: {integrity: sha512-2OQsPNEmBCvXuFlIni/a+Rn+R2pHW9INm0BxXJ4hVDA8TirqMj+J/Rp9ItLatT/5pZqWwefVrTQcHpixsxnVlA==}
     engines: {node: '>= 4.0.0'}
 
+  yuku-ast@0.1.7:
+    resolution: {integrity: sha512-2RiMEWv500TixY5rJy6OZd4fSy9WYZKWh6gGbIJ7y7vAGcuCugWOWwOLGaQcRZrXcPUfqtLtvpaJ3SdXtWlhKA==}
+
+  yuku-codegen@0.5.44:
+    resolution: {integrity: sha512-0rhtgWGz+bR3Pe7xqJ5E4VqxI1vqNtkeJRkeXM0Qd3tgldYClQipxa9bRZyuNOOfk0Ri02scrjnkoAHM16/f2g==}
+
+  yuku-parser@0.5.44:
+    resolution: {integrity: sha512-mAhpQZ/bXjxZmKiGUqEWskC9mZTcTBv6/fdzVdzdjM6XuD1DP3IavdLVWdM39L9ewK9vS9OtJmaKNeWgRzpy0w==}
+
   zod-validation-error@1.5.0:
     resolution: {integrity: sha512-/7eFkAI4qV0tcxMBB/3+d2c1P6jzzZYdYSlBuAklzMuCrJu5bzJfHS0yVAS87dRHVlhftd6RFJDIvv03JgkSbw==}
     engines: {node: '>=16.0.0'}
@@ -3391,30 +3596,13 @@ snapshots:
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
-  '@babel/generator@8.0.0':
-    dependencies:
-      '@babel/parser': 8.0.0
-      '@babel/types': 8.0.0
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-      '@types/jsesc': 2.5.1
-      jsesc: 3.1.0
-
   '@babel/helper-string-parser@7.29.7': {}
 
-  '@babel/helper-string-parser@8.0.0': {}
-
   '@babel/helper-validator-identifier@7.29.7': {}
-
-  '@babel/helper-validator-identifier@8.0.2': {}
 
   '@babel/parser@7.29.7':
     dependencies:
       '@babel/types': 7.29.7
-
-  '@babel/parser@8.0.0':
-    dependencies:
-      '@babel/types': 8.0.0
 
   '@babel/runtime@7.29.7': {}
 
@@ -3422,11 +3610,6 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-
-  '@babel/types@8.0.0':
-    dependencies:
-      '@babel/helper-string-parser': 8.0.0
-      '@babel/helper-validator-identifier': 8.0.2
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -3931,6 +4114,8 @@ snapshots:
 
   '@oxc-project/types@0.138.0': {}
 
+  '@oxc-project/types@0.139.0': {}
+
   '@oxfmt/binding-android-arm-eabi@0.58.0':
     optional: true
 
@@ -4078,37 +4263,73 @@ snapshots:
   '@rolldown/binding-android-arm64@1.1.4':
     optional: true
 
+  '@rolldown/binding-android-arm64@1.1.5':
+    optional: true
+
   '@rolldown/binding-darwin-arm64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.1.5':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.1.4':
     optional: true
 
+  '@rolldown/binding-darwin-x64@1.1.5':
+    optional: true
+
   '@rolldown/binding-freebsd-x64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.1.5':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
     optional: true
 
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.5':
+    optional: true
+
   '@rolldown/binding-linux-arm64-gnu@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.1.5':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.1.4':
     optional: true
 
+  '@rolldown/binding-linux-arm64-musl@1.1.5':
+    optional: true
+
   '@rolldown/binding-linux-ppc64-gnu@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.1.5':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.1.4':
     optional: true
 
+  '@rolldown/binding-linux-s390x-gnu@1.1.5':
+    optional: true
+
   '@rolldown/binding-linux-x64-gnu@1.1.4':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.1.5':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.1.4':
     optional: true
 
+  '@rolldown/binding-linux-x64-musl@1.1.5':
+    optional: true
+
   '@rolldown/binding-openharmony-arm64@1.1.4':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.1.5':
     optional: true
 
   '@rolldown/binding-wasm32-wasi@1.1.4':
@@ -4118,10 +4339,23 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
+  '@rolldown/binding-wasm32-wasi@1.1.5':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
   '@rolldown/binding-win32-arm64-msvc@1.1.4':
     optional: true
 
+  '@rolldown/binding-win32-arm64-msvc@1.1.5':
+    optional: true
+
   '@rolldown/binding-win32-x64-msvc@1.1.4':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.1.5':
     optional: true
 
   '@rolldown/pluginutils@1.0.1': {}
@@ -4259,8 +4493,6 @@ snapshots:
   '@types/http-proxy@1.17.17':
     dependencies:
       '@types/node': 26.0.1
-
-  '@types/jsesc@2.5.1': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -4432,6 +4664,74 @@ snapshots:
 
   '@xtuc/long@4.2.2': {}
 
+  '@yuku-codegen/binding-darwin-arm64@0.5.44':
+    optional: true
+
+  '@yuku-codegen/binding-darwin-x64@0.5.44':
+    optional: true
+
+  '@yuku-codegen/binding-freebsd-x64@0.5.44':
+    optional: true
+
+  '@yuku-codegen/binding-linux-arm-gnu@0.5.44':
+    optional: true
+
+  '@yuku-codegen/binding-linux-arm-musl@0.5.44':
+    optional: true
+
+  '@yuku-codegen/binding-linux-arm64-gnu@0.5.44':
+    optional: true
+
+  '@yuku-codegen/binding-linux-arm64-musl@0.5.44':
+    optional: true
+
+  '@yuku-codegen/binding-linux-x64-gnu@0.5.44':
+    optional: true
+
+  '@yuku-codegen/binding-linux-x64-musl@0.5.44':
+    optional: true
+
+  '@yuku-codegen/binding-win32-arm64@0.5.44':
+    optional: true
+
+  '@yuku-codegen/binding-win32-x64@0.5.44':
+    optional: true
+
+  '@yuku-parser/binding-darwin-arm64@0.5.44':
+    optional: true
+
+  '@yuku-parser/binding-darwin-x64@0.5.44':
+    optional: true
+
+  '@yuku-parser/binding-freebsd-x64@0.5.44':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm-gnu@0.5.44':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm-musl@0.5.44':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm64-gnu@0.5.44':
+    optional: true
+
+  '@yuku-parser/binding-linux-arm64-musl@0.5.44':
+    optional: true
+
+  '@yuku-parser/binding-linux-x64-gnu@0.5.44':
+    optional: true
+
+  '@yuku-parser/binding-linux-x64-musl@0.5.44':
+    optional: true
+
+  '@yuku-parser/binding-win32-arm64@0.5.44':
+    optional: true
+
+  '@yuku-parser/binding-win32-x64@0.5.44':
+    optional: true
+
+  '@yuku-toolchain/types@0.5.43': {}
+
   accepts@1.3.8:
     dependencies:
       mime-types: 2.1.35
@@ -4488,12 +4788,6 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  ast-kit@3.0.0:
-    dependencies:
-      '@babel/parser': 8.0.0
-      estree-walker: 3.0.3
-      pathe: 2.0.3
-
   ast-v8-to-istanbul@1.0.4:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
@@ -4509,8 +4803,6 @@ snapshots:
   big-integer@1.6.52: {}
 
   binary-extensions@2.3.0: {}
-
-  birpc@4.0.0: {}
 
   bplist-parser@0.2.0:
     dependencies:
@@ -5172,8 +5464,6 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  jsesc@3.1.0: {}
-
   json-crawl@0.4.2: {}
 
   json-rpc-2.0@1.7.1: {}
@@ -5546,6 +5836,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  picomatch@4.0.5: {}
+
   pify@4.0.1: {}
 
   pkg-types@1.3.1:
@@ -5616,17 +5908,15 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.26.0(rolldown@1.1.4)(typescript@6.0.3):
+  rolldown-plugin-dts@0.27.1(rolldown@1.1.4)(typescript@6.0.3):
     dependencies:
-      '@babel/generator': 8.0.0
-      '@babel/helper-validator-identifier': 8.0.2
-      '@babel/parser': 8.0.0
-      ast-kit: 3.0.0
-      birpc: 4.0.0
       dts-resolver: 3.0.0
       get-tsconfig: 5.0.0-beta.5
       obug: 2.1.3
       rolldown: 1.1.4
+      yuku-ast: 0.1.7
+      yuku-codegen: 0.5.44
+      yuku-parser: 0.5.44
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -5652,6 +5942,27 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.1.4
       '@rolldown/binding-win32-arm64-msvc': 1.1.4
       '@rolldown/binding-win32-x64-msvc': 1.1.4
+
+  rolldown@1.1.5:
+    dependencies:
+      '@oxc-project/types': 0.139.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.1.5
+      '@rolldown/binding-darwin-arm64': 1.1.5
+      '@rolldown/binding-darwin-x64': 1.1.5
+      '@rolldown/binding-freebsd-x64': 1.1.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.5
+      '@rolldown/binding-linux-arm64-gnu': 1.1.5
+      '@rolldown/binding-linux-arm64-musl': 1.1.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.5
+      '@rolldown/binding-linux-s390x-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-gnu': 1.1.5
+      '@rolldown/binding-linux-x64-musl': 1.1.5
+      '@rolldown/binding-openharmony-arm64': 1.1.5
+      '@rolldown/binding-wasm32-wasi': 1.1.5
+      '@rolldown/binding-win32-arm64-msvc': 1.1.5
+      '@rolldown/binding-win32-x64-msvc': 1.1.5
 
   rollup@4.62.2:
     dependencies:
@@ -5846,7 +6157,7 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  tsdown@0.22.3(typescript@6.0.3):
+  tsdown@0.22.4(typescript@6.0.3):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -5855,9 +6166,9 @@ snapshots:
       hookable: 6.1.1
       import-without-cache: 0.4.0
       obug: 2.1.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       rolldown: 1.1.4
-      rolldown-plugin-dts: 0.26.0(rolldown@1.1.4)(typescript@6.0.3)
+      rolldown-plugin-dts: 0.27.1(rolldown@1.1.4)(typescript@6.0.3)
       semver: 7.8.5
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
@@ -5930,7 +6241,7 @@ snapshots:
       picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
-  unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@26.0.1))(esbuild@0.28.1)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)):
+  unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@26.0.1))(esbuild@0.28.1)(rolldown@1.1.5)(rollup@4.62.2)(vite@8.1.3(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.4
@@ -5938,7 +6249,7 @@ snapshots:
     optionalDependencies:
       '@farmfe/core': 1.7.11(@types/node@26.0.1)
       esbuild: 0.28.1
-      rolldown: 1.1.4
+      rolldown: 1.1.5
       rollup: 4.62.2
       vite: 8.1.3(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0)
       webpack: 5.108.4(esbuild@0.28.1)
@@ -6093,6 +6404,42 @@ snapshots:
   yaml@2.9.0: {}
 
   ylru@1.4.0: {}
+
+  yuku-ast@0.1.7:
+    dependencies:
+      '@yuku-toolchain/types': 0.5.43
+
+  yuku-codegen@0.5.44:
+    dependencies:
+      '@yuku-toolchain/types': 0.5.43
+    optionalDependencies:
+      '@yuku-codegen/binding-darwin-arm64': 0.5.44
+      '@yuku-codegen/binding-darwin-x64': 0.5.44
+      '@yuku-codegen/binding-freebsd-x64': 0.5.44
+      '@yuku-codegen/binding-linux-arm-gnu': 0.5.44
+      '@yuku-codegen/binding-linux-arm-musl': 0.5.44
+      '@yuku-codegen/binding-linux-arm64-gnu': 0.5.44
+      '@yuku-codegen/binding-linux-arm64-musl': 0.5.44
+      '@yuku-codegen/binding-linux-x64-gnu': 0.5.44
+      '@yuku-codegen/binding-linux-x64-musl': 0.5.44
+      '@yuku-codegen/binding-win32-arm64': 0.5.44
+      '@yuku-codegen/binding-win32-x64': 0.5.44
+
+  yuku-parser@0.5.44:
+    dependencies:
+      '@yuku-toolchain/types': 0.5.43
+    optionalDependencies:
+      '@yuku-parser/binding-darwin-arm64': 0.5.44
+      '@yuku-parser/binding-darwin-x64': 0.5.44
+      '@yuku-parser/binding-freebsd-x64': 0.5.44
+      '@yuku-parser/binding-linux-arm-gnu': 0.5.44
+      '@yuku-parser/binding-linux-arm-musl': 0.5.44
+      '@yuku-parser/binding-linux-arm64-gnu': 0.5.44
+      '@yuku-parser/binding-linux-arm64-musl': 0.5.44
+      '@yuku-parser/binding-linux-x64-gnu': 0.5.44
+      '@yuku-parser/binding-linux-x64-musl': 0.5.44
+      '@yuku-parser/binding-win32-arm64': 0.5.44
+      '@yuku-parser/binding-win32-x64': 0.5.44
 
   zod-validation-error@1.5.0(zod@3.25.76):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ catalog:
   oxfmt: ^0.58.0
   oxlint: ^1.73.0
   "tinyexec": ^1.2.4
-  tsdown: ^0.22.3
+  tsdown: ^0.22.4
   typescript: ^6.0.3
   vitest: ^4.1.10
   yaml: ^2.9.0


### PR DESCRIPTION
## 🎯 Changes

### Why

Import resolution used to be an adapter concern. Every generator called `adapter.getImports(node, resolve)` and passed a callback that rebuilt the resolver's naming and file conventions inline. On top of that, collision renames (two components emitting the same name) traveled through a `nameMapping` side channel that lived in three places: `adapter.options.nameMapping`, `meta.nameMapping`, and a printer option. Every consumer had to remember to thread the map through, and forgetting produced imports pointing at the pre-rename name.

This PR makes the resolver own import resolution and makes ref nodes self-describing, so the side channel disappears entirely.

### `resolver.imports` (@kubb/core)

`Resolver` gains an `imports` method that walks a schema tree and builds one import entry per unique `$ref`, routing names and paths through the resolver's own `name` and `file` conventions:

```ts
// before: every generator rebuilt naming and paths in a callback
const imports = adapter.getImports(node, (schemaName) => ({
  name: resolver.name(schemaName),
  path: resolver.file({ name: schemaName, extname: '.ts', root, output, group }).path,
}))

// after: the resolver already knows its own conventions
const imports = resolver.imports({ node, root, output, group })
```

A per-call `name` callback overrides the imported identifier when a plugin emits a different symbol for some schemas, for example enum key types in plugin-ts or codec input variants in plugin-zod:

```ts
resolver.imports({
  node,
  root,
  output,
  name: (schemaName) => (enumSchemaNames.has(schemaName) ? resolver.enum.keyName({ name: schemaName }, typeSuffix) : resolver.name(schemaName)),
})
```

`getImports` is removed from the `Adapter` contract and from `createMockedAdapter`. Custom adapters now implement only `parse` and `validate`.

### `targetName` on ref nodes (@kubb/ast, @kubb/adapter-oas)

When `getSchemas` renames a colliding component (for example `#/components/schemas/Order` emitted as `OrderSchema`), the parser now stamps the rename on every ref node pointing at it, at ref creation time:

```ts
{ type: 'ref', name: 'Order', ref: '#/components/schemas/Order', targetName: 'OrderSchema' }
```

`resolveRefName` prefers `targetName`, so printers, imports, and circular-ref detection all resolve the emitted name through one helper instead of the copy-pasted `nameMapping.get(ref) ?? extractRefName(ref) ?? name` chain. Refs that keep their pointer name carry no stamp. `ref.name` stays untouched because it is the declaration identity: a single-member `allOf` flatten emits a file named after `name` while printing the referenced type, so the two must stay separate.

Because stamping happens during parsing rather than in a post-parse walk, the schema graph (circular detection) sees corrected edges for free, and `getSchemas` now returns only the non-identity renames instead of a full name map.

### `macroRenameSchema` (@kubb/ast)

Macros can rename schemas, which used to desync refs from their declarations. The new `macroRenameSchema({ from, to })` renames the declaration and retargets every ref to it in one visitor, so imports stay consistent after a macro rename.

### Validation

Validated against the plugins repo using the workspace `link:` overrides: build, typecheck, lint, and all 1227 plugin tests pass, all 14 examples regenerate byte-identical, and the e2e project generates and typechecks. Performance is unchanged: interleaved main-vs-branch benchmark runs show wall-time parity, and the heap stays flat over 50 consecutive builds.

Companion PRs: kubb-labs/plugins#669 (generator migration) and kubb-labs/docs#125 (documentation).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGYyHAJz2SsziJErwZ53cX