### PR TITLE
refactor: make Fallow-flagged unused exports module-private

### DIFF
--- a/.changeset/fallow-remove-unused-exports.md
+++ b/.changeset/fallow-remove-unused-exports.md
@@ -1,0 +1,5 @@
+---
+"@kubb/adapter-oas": patch
+---
+
+Make the per-schema converter functions in `converters.ts` module-private. They were exported but only consumed inside the file through the `schemaRules` table, so nothing outside the module could see them anyway.

--- a/internals/changelog/index.mjs
+++ b/internals/changelog/index.mjs
@@ -105,7 +105,7 @@ function aggregate(entries) {
   return { byPackage, contributors: [...contributors].sort() }
 }
 
-export function flush() {
+function flush() {
   if (!pending.length) return
 
   const { rootChangelog, versionPackage, typeOrder, typeHeaders } = {

--- a/packages/adapter-oas/src/converters.ts
+++ b/packages/adapter-oas/src/converters.ts
@@ -135,7 +135,7 @@ function nameEnums(node: ast.SchemaNode, options: { parentName: string | null | 
  * Use `syncSchemaRef(node)` in printers to get a merged view of both.
  * Circular refs are detected in `resolveRefNode` and leave `schema` as `null`.
  */
-export function convertRef({ schema, name, nullable, defaultValue, rawOptions, document, resolveRefNode, refExists }: ConvertContext): ast.SchemaNode {
+function convertRef({ schema, name, nullable, defaultValue, rawOptions, document, resolveRefNode, refExists }: ConvertContext): ast.SchemaNode {
   const refPath = schema.$ref
   const resolvedSchema = refPath ? resolveRefNode(refPath, rawOptions) : null
 
@@ -163,7 +163,7 @@ export function convertRef({ schema, name, nullable, defaultValue, rawOptions, d
 /**
  * Converts an `allOf` schema into a flattened node or an `IntersectionSchemaNode`.
  */
-export function convertAllOf({ schema, name, nullable, defaultValue, rawOptions, parse, document }: ConvertContext): ast.SchemaNode {
+function convertAllOf({ schema, name, nullable, defaultValue, rawOptions, parse, document }: ConvertContext): ast.SchemaNode {
   if (
     schema.allOf!.length === 1 &&
     !schema.properties &&
@@ -269,7 +269,7 @@ export function convertAllOf({ schema, name, nullable, defaultValue, rawOptions,
 /**
  * Converts a `oneOf` / `anyOf` schema into a `UnionSchemaNode`.
  */
-export function convertUnion({ schema, name, nullable, defaultValue, rawOptions, parse, document }: ConvertContext): ast.SchemaNode {
+function convertUnion({ schema, name, nullable, defaultValue, rawOptions, parse, document }: ConvertContext): ast.SchemaNode {
   function pickDiscriminatorPropertyNode(node: ast.SchemaNode, propertyName: string): ast.SchemaNode | null {
     const objectNode = ast.narrowSchema(node, 'object')
     const discriminatorProperty = objectNode?.properties?.find((property) => property.name === propertyName)
@@ -399,7 +399,7 @@ export function convertUnion({ schema, name, nullable, defaultValue, rawOptions,
 /**
  * Converts an OAS 3.1 `const` schema into a null scalar or a single-value `EnumSchemaNode`.
  */
-export function convertConst({ schema, name, nullable, defaultValue }: ConvertContext): ast.SchemaNode {
+function convertConst({ schema, name, nullable, defaultValue }: ConvertContext): ast.SchemaNode {
   const constValue = schema.const
 
   if (constValue === null) {
@@ -419,7 +419,7 @@ export function convertConst({ schema, name, nullable, defaultValue }: ConvertCo
  * Converts a format-annotated schema into a special-type `SchemaNode`.
  * Returns `null` when the format should fall through to string handling (`dateType: false`).
  */
-export function convertFormat({ schema, name, nullable, defaultValue, options }: ConvertContext): ast.SchemaNode | null {
+function convertFormat({ schema, name, nullable, defaultValue, options }: ConvertContext): ast.SchemaNode | null {
   const base = buildSchemaNode(schema, name, nullable, defaultValue)
 
   if (schema.format === 'int64') {
@@ -472,7 +472,7 @@ export function convertFormat({ schema, name, nullable, defaultValue, options }:
 /**
  * Converts an `enum` schema into an `EnumSchemaNode`.
  */
-export function convertEnum({ schema, name, nullable, type, rawOptions, parse }: ConvertContext): ast.SchemaNode {
+function convertEnum({ schema, name, nullable, type, rawOptions, parse }: ConvertContext): ast.SchemaNode {
   if (type === 'array') {
     return parse({ schema: normalizeArrayEnum(schema), name }, rawOptions)
   }
@@ -536,7 +536,7 @@ export function convertEnum({ schema, name, nullable, type, rawOptions, parse }:
 /**
  * Converts an object-like schema into an `ObjectSchemaNode`.
  */
-export function convertObject({ schema, name, nullable, defaultValue, rawOptions, options, parse }: ConvertContext): ast.SchemaNode {
+function convertObject({ schema, name, nullable, defaultValue, rawOptions, options, parse }: ConvertContext): ast.SchemaNode {
   const properties: Array<ast.PropertyNode> = schema.properties
     ? Object.entries(schema.properties).map(([propName, propSchema]) => {
         const required = Array.isArray(schema.required) ? schema.required.includes(propName) : !!schema.required
@@ -608,7 +608,7 @@ export function convertObject({ schema, name, nullable, defaultValue, rawOptions
 /**
  * Converts an OAS 3.1 `prefixItems` tuple into a `TupleSchemaNode`.
  */
-export function convertTuple({ schema, name, nullable, defaultValue, rawOptions, parse }: ConvertContext): ast.SchemaNode {
+function convertTuple({ schema, name, nullable, defaultValue, rawOptions, parse }: ConvertContext): ast.SchemaNode {
   const tupleItems = (schema.prefixItems ?? []).map((item) => parse({ schema: item as SchemaObject }, rawOptions))
   // items: false closes the tuple; absent/true widens the tail to any.
   const rest =
@@ -632,7 +632,7 @@ export function convertTuple({ schema, name, nullable, defaultValue, rawOptions,
 /**
  * Converts a `type: 'array'` schema into an `ArraySchemaNode`.
  */
-export function convertArray({ schema, name, nullable, defaultValue, rawOptions, options, parse }: ConvertContext): ast.SchemaNode {
+function convertArray({ schema, name, nullable, defaultValue, rawOptions, options, parse }: ConvertContext): ast.SchemaNode {
   const rawItems = schema.items as SchemaObject | undefined
   const itemName = rawItems?.enum?.length && name ? enumPropName(null, name, options.enumSuffix) : name
   const items = rawItems ? [parse({ schema: rawItems, name: itemName }, rawOptions)] : []
@@ -651,7 +651,7 @@ export function convertArray({ schema, name, nullable, defaultValue, rawOptions,
 /**
  * Converts a `type: 'string'` schema into a `StringSchemaNode`.
  */
-export function convertString({ schema, name, nullable, defaultValue }: ConvertContext): ast.SchemaNode {
+function convertString({ schema, name, nullable, defaultValue }: ConvertContext): ast.SchemaNode {
   return ast.factory.createSchema({
     type: 'string',
     primitive: 'string',
@@ -665,7 +665,7 @@ export function convertString({ schema, name, nullable, defaultValue }: ConvertC
 /**
  * Converts a `type: 'number'` or `type: 'integer'` schema.
  */
-export function convertNumeric({ schema, name, nullable, defaultValue }: ConvertContext, type: 'number' | 'integer'): ast.SchemaNode {
+function convertNumeric({ schema, name, nullable, defaultValue }: ConvertContext, type: 'number' | 'integer'): ast.SchemaNode {
   return ast.factory.createSchema({
     type,
     primitive: type,
@@ -681,7 +681,7 @@ export function convertNumeric({ schema, name, nullable, defaultValue }: Convert
 /**
  * Converts a `type: 'boolean'` schema.
  */
-export function convertBoolean({ schema, name, nullable, defaultValue }: ConvertContext): ast.SchemaNode {
+function convertBoolean({ schema, name, nullable, defaultValue }: ConvertContext): ast.SchemaNode {
   return ast.factory.createSchema({
     type: 'boolean',
     primitive: 'boolean',
@@ -693,7 +693,7 @@ export function convertBoolean({ schema, name, nullable, defaultValue }: Convert
  * Converts a binary string schema (`type: 'string'`, `contentMediaType: 'application/octet-stream'`)
  * into a `blob` node.
  */
-export function convertBinary({ schema, name, nullable, defaultValue }: ConvertContext): ast.SchemaNode {
+function convertBinary({ schema, name, nullable, defaultValue }: ConvertContext): ast.SchemaNode {
   return ast.factory.createSchema({
     type: 'blob',
     primitive: 'string',
@@ -707,7 +707,7 @@ export function convertBinary({ schema, name, nullable, defaultValue }: ConvertC
  * Returns `null` when only one non-`null` type remains (e.g. `['string', 'null']`), so `parse`
  * falls through and handles it as that single type with nullability already folded in.
  */
-export function convertMultiType({ schema, name, nullable, defaultValue, rawOptions, parse }: ConvertContext): ast.SchemaNode | null {
+function convertMultiType({ schema, name, nullable, defaultValue, rawOptions, parse }: ConvertContext): ast.SchemaNode | null {
   const types = schema.type as Array<string>
   const nonNullTypes = types.filter((t) => t !== 'null')
   if (nonNullTypes.length <= 1) return null


### PR DESCRIPTION
## 🎯 Changes

Ran [Fallow](https://fallow.tools) (`fallow dead-code --format json --quiet --unused-exports` and `fallow dupes --mode mild`) over the repo and cleaned up the confirmed unused exports.

- `packages/adapter-oas/src/converters.ts`: the 14 per-schema converter functions (`convertRef`, `convertAllOf`, `convertUnion`, `convertConst`, `convertFormat`, `convertEnum`, `convertObject`, `convertTuple`, `convertArray`, `convertString`, `convertNumeric`, `convertBoolean`, `convertBinary`, `convertMultiType`) are now module-private. They are only consumed inside the file through the `schemaRules` table, and `parser.ts` imports only `schemaRules` and `ConvertContext`.
- `internals/changelog/index.mjs`: `flush` is now module-private. It is only referenced by the file's own `process.on('exit', flush)` hook.

Kept as deliberate false positives (verified before skipping):

- `getReleaseLine` / `getDependencyReleaseLine` in `internals/changelog/index.mjs` are the changesets changelog-module interface, loaded via `.changeset/config.json`.
- `parseStaged` in `scripts/release.mjs` is imported by `scripts/release.test.mjs`.
- Fallow also suggested dropping the `@farmfe/core` devDependencies, but those back the `unplugin-kubb/farm` and `kubb/farm` subpath builds, so they stay.

Duplication scan for reference: 2.1% duplicated lines, 7 clone groups, almost all of them near-identical `tsdown.config.ts` files across packages plus two small in-file clones. Nothing worth a shared-config refactor in this PR.

Verified with `pnpm turbo run typecheck --filter=@kubb/adapter-oas`, the adapter-oas test suite, `vitest run internals/changelog scripts/release.test.mjs`, `pnpm lint`, and `pnpm format`. A rerun of Fallow reports only the documented false positives.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014dHSbuoSN5pYaXowWwZj5B

---
_Generated by [Claude Code](https://claude.ai/code/session_014dHSbuoSN5pYaXowWwZj5B)_