### PR TITLE
refactor: fold in-file clones flagged by Fallow into shared helpers

### DIFF
--- a/.changeset/tidy-clones-fold.md
+++ b/.changeset/tidy-clones-fold.md
@@ -1,0 +1,7 @@
+---
+'@kubb/ast': patch
+'@kubb/renderer-jsx': patch
+'@kubb/cli': patch
+---
+
+Fold duplicated code paths into shared helpers: the import and export merge loops in `@kubb/ast` now run through one generic `mergeMembers` helper, the JSX runtime walkers in `@kubb/renderer-jsx` share one `resolveElement` classifier, and the clack and plain loggers in `@kubb/cli` share one message and step helper. No behavior changes.

--- a/packages/ast/src/utils/combineFileMembers.ts
+++ b/packages/ast/src/utils/combineFileMembers.ts
@@ -53,12 +53,87 @@ export function combineSources(sources: Array<SourceNode>): Array<SourceNode> {
 /**
  * Merges `incoming` names into `existing`, preserving order and dropping duplicates.
  *
- * Shared by `combineExports` and `combineImports` for the same-path name-merge case.
+ * Used by `mergeMembers` for the same-path name-merge case.
  */
 function mergeNameArrays<TName>(existing: Array<TName>, incoming: Array<TName>): Array<TName> {
   const merged = new Set(existing)
   for (const name of incoming) merged.add(name)
   return [...merged]
+}
+
+type MergeMembersOptions<TNode, TName> = {
+  /**
+   * Drops a member before any merging.
+   */
+  skip?: (node: TNode) => boolean
+  /**
+   * Deduplicates and filters an array name before merging. An empty result drops the member.
+   */
+  normalizeNames: (names: Array<TName>) => Array<TName>
+  /**
+   * Builds the member stored for a new `path:isTypeOnly` group, carrying the normalized names.
+   */
+  create: (node: TNode, names: Array<TName>) => TNode
+  /**
+   * Drops a member whose name is not an array. Receives the non-array name.
+   */
+  skipSingle?: (node: TNode, name: string | null | undefined) => boolean
+  /**
+   * Exact-identity key deduplicating members whose name is not an array.
+   */
+  identityKey: (node: TNode, name: string | null | undefined) => string
+}
+
+/**
+ * Shared merge loop behind `combineExports` and `combineImports`: sorts by `sortKey`, merges
+ * array-named members with the same `path:isTypeOnly` key into one member, and deduplicates the
+ * rest by `identityKey`.
+ */
+function mergeMembers<TNode extends { path: string; isTypeOnly?: boolean | null; name?: string | Array<TName> | null }, TName>(
+  nodes: Array<TNode>,
+  { skip, normalizeNames, create, skipSingle, identityKey }: MergeMembersOptions<TNode, TName>,
+): Array<TNode> {
+  const result: Array<TNode> = []
+  // Accumulates array-named members keyed by `path:isTypeOnly` for name-merging
+  const namedByPath = new Map<string, TNode>()
+  // Deduplicates non-array members by their exact identity
+  const seen = new Set<string>()
+
+  // Precompute sort keys once, avoids recomputing per comparison.
+  const keyed = nodes.map((node) => ({ node, key: sortKey(node) }))
+  keyed.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0))
+
+  for (const { node: curr } of keyed) {
+    if (skip?.(curr)) continue
+
+    const { name, path, isTypeOnly } = curr
+
+    if (Array.isArray(name)) {
+      const names = normalizeNames(name)
+      if (!names.length) continue
+
+      const key = pathTypeKey(path, isTypeOnly)
+      const existing = namedByPath.get(key)
+
+      if (existing && Array.isArray(existing.name)) {
+        existing.name = mergeNameArrays(existing.name, names)
+      } else {
+        const newItem = create(curr, names)
+        result.push(newItem)
+        namedByPath.set(key, newItem)
+      }
+    } else {
+      if (skipSingle?.(curr, name)) continue
+
+      const key = identityKey(curr, name)
+      if (!seen.has(key)) {
+        result.push(curr)
+        seen.add(key)
+      }
+    }
+  }
+
+  return result
 }
 
 /**
@@ -68,42 +143,11 @@ function mergeNameArrays<TName>(existing: Array<TName>, incoming: Array<TName>):
  * Non-array exports are deduplicated by exact identity. Returns a sorted, deduplicated array.
  */
 export function combineExports(exports: Array<ExportNode>): Array<ExportNode> {
-  const result: Array<ExportNode> = []
-  // Accumulates array-named exports keyed by `path:isTypeOnly` for name-merging
-  const namedByPath = new Map<string, ExportNode>()
-  // Deduplicates non-array exports by their exact identity
-  const seen = new Set<string>()
-
-  // Precompute sort keys once, avoids recomputing per comparison.
-  const keyed = exports.map((node) => ({ node, key: sortKey(node) }))
-  keyed.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0))
-
-  for (const { node: curr } of keyed) {
-    const { name, path, isTypeOnly, asAlias } = curr
-
-    if (Array.isArray(name)) {
-      if (!name.length) continue
-
-      const key = pathTypeKey(path, isTypeOnly)
-      const existing = namedByPath.get(key)
-
-      if (existing && Array.isArray(existing.name)) {
-        existing.name = mergeNameArrays(existing.name, name)
-      } else {
-        const newItem: ExportNode = { ...curr, name: [...new Set(name)] }
-        result.push(newItem)
-        namedByPath.set(key, newItem)
-      }
-    } else {
-      const key = exportKey(path, name, isTypeOnly, asAlias)
-      if (!seen.has(key)) {
-        result.push(curr)
-        seen.add(key)
-      }
-    }
-  }
-
-  return result
+  return mergeMembers<ExportNode, string>(exports, {
+    normalizeNames: (names) => [...new Set(names)],
+    create: (node, names) => ({ ...node, name: names }),
+    identityKey: (node, name) => exportKey(node.path, name, node.isTypeOnly, node.asAlias),
+  })
 }
 
 /**
@@ -138,46 +182,12 @@ export function combineImports(imports: Array<ImportNode>, exports: Array<Export
     }
   }
 
-  const result: Array<ImportNode> = []
-  // Accumulates array-named imports keyed by `path:isTypeOnly` for name-merging
-  const namedByPath = new Map<string, ImportNode>()
-  // Deduplicates non-array imports by their exact identity
-  const seen = new Set<string>()
-
-  // Precompute sort keys once, avoids recomputing per comparison.
-  const keyed = imports.map((node) => ({ node, key: sortKey(node) }))
-  keyed.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0))
-
-  for (const { node: curr } of keyed) {
-    if (curr.path === curr.root) continue
-
-    const { path, isTypeOnly } = curr
-    let { name } = curr
-
-    if (Array.isArray(name)) {
-      name = [...new Set(name.map(canonicalizeName))].filter((item) => (typeof item === 'string' ? isUsed(item) : isUsed(item.name ?? item.propertyName)))
-      if (!name.length) continue
-
-      const key = pathTypeKey(path, isTypeOnly)
-      const existing = namedByPath.get(key)
-
-      if (existing && Array.isArray(existing.name)) {
-        existing.name = mergeNameArrays(existing.name, name)
-      } else {
-        const newItem: ImportNode = { ...curr, name }
-        result.push(newItem)
-        namedByPath.set(key, newItem)
-      }
-    } else {
-      if (name && !isUsed(name) && !pathsWithUsedNamedImport.has(path)) continue
-
-      const key = importKey(path, name, isTypeOnly)
-      if (!seen.has(key)) {
-        result.push(curr)
-        seen.add(key)
-      }
-    }
-  }
-
-  return result
+  return mergeMembers<ImportNode, string | { propertyName: string; name?: string }>(imports, {
+    skip: (node) => node.path === node.root,
+    normalizeNames: (names) =>
+      [...new Set(names.map(canonicalizeName))].filter((item) => (typeof item === 'string' ? isUsed(item) : isUsed(item.name ?? item.propertyName))),
+    create: (node, names) => ({ ...node, name: names }),
+    skipSingle: (node, name) => !!name && !isUsed(name) && !pathsWithUsedNamedImport.has(node.path),
+    identityKey: (node, name) => importKey(node.path, name, node.isTypeOnly),
+  })
 }

--- a/packages/cli/src/loggers/clackLogger.ts
+++ b/packages/cli/src/loggers/clackLogger.ts
@@ -3,14 +3,14 @@ import process from 'node:process'
 import { styleText } from 'node:util'
 import * as clack from '@clack/prompts'
 import { formatMsWithColor, getElapsedMs, getIntro } from '@internals/utils'
-import { Diagnostics, type KubbHooks, logLevel as logLevelMap } from '@kubb/core'
+import { Diagnostics, logLevel as logLevelMap } from '@kubb/core'
 import type { Logger } from './defineLogger.ts'
 import {
   buildProgressLine,
+  createLogHelpers,
   createProgressCounters,
   formatCommandWithArgs,
   formatErrorFrames,
-  formatMessage,
   recordPluginResult,
   resetProgressCounters,
 } from './utils.ts'
@@ -22,6 +22,7 @@ export const clackLogger = {
   name: 'clack',
   install(context, options) {
     const logLevel = options?.logLevel ?? logLevelMap.info
+    const { getMessage, onStep } = createLogHelpers({ context, logLevel, print: (text) => clack.log.step(text) })
     const state = {
       ...createProgressCounters(),
       spinner: clack.spinner(),
@@ -67,20 +68,6 @@ export const clackLogger = {
       if (line) {
         clack.log.step(getMessage(line))
       }
-    }
-
-    function getMessage(message: string): string {
-      return formatMessage(message, logLevel)
-    }
-
-    // Registers a handler that prints a fixed step message, skipped at silent level.
-    function onStep<E extends keyof KubbHooks>(hook: E, message: string): void {
-      context.hook(hook, () => {
-        if (logLevel <= logLevelMap.silent) {
-          return
-        }
-        clack.log.step(getMessage(message))
-      })
     }
 
     function stopSpinner(text?: string) {

--- a/packages/cli/src/loggers/plainLogger.ts
+++ b/packages/cli/src/loggers/plainLogger.ts
@@ -1,8 +1,8 @@
 import { relative } from 'node:path'
 import { formatMs } from '@internals/utils'
-import { Diagnostics, type KubbHooks, logLevel as logLevelMap } from '@kubb/core'
+import { Diagnostics, logLevel as logLevelMap } from '@kubb/core'
 import type { Logger } from './defineLogger.ts'
-import { createHookTimer, formatCommandWithArgs, formatErrorFrames, formatMessage } from './utils.ts'
+import { createHookTimer, createLogHelpers, formatCommandWithArgs, formatErrorFrames } from './utils.ts'
 
 /**
  * Plain console adapter for non-TTY environments, built on `console.log`.
@@ -12,20 +12,7 @@ export const plainLogger = {
   install(context, options) {
     const logLevel = options?.logLevel ?? logLevelMap.info
     const hookTimer = createHookTimer()
-
-    function getMessage(message: string): string {
-      return formatMessage(message, logLevel)
-    }
-
-    // Registers a handler that logs a fixed message, skipped at silent level.
-    function onStep<E extends keyof KubbHooks>(hook: E, message: string): void {
-      context.hook(hook, () => {
-        if (logLevel <= logLevelMap.silent) {
-          return
-        }
-        console.log(getMessage(message))
-      })
-    }
+    const { getMessage, onStep } = createLogHelpers({ context, logLevel, print: (text) => console.log(text) })
 
     context.hook('kubb:info', ({ message, info }) => {
       if (logLevel <= logLevelMap.silent) {

--- a/packages/cli/src/loggers/utils.ts
+++ b/packages/cli/src/loggers/utils.ts
@@ -1,7 +1,7 @@
 import process from 'node:process'
 import { styleText } from 'node:util'
 import { canUseTTY, formatMs, getElapsedMs, toCause } from '@internals/utils'
-import type { Reporter, ReporterContext } from '@kubb/core'
+import type { KubbHooks, Reporter, ReporterContext } from '@kubb/core'
 import { logLevel as logLevelMap } from '@kubb/core'
 import type { LoggerContext, LoggerOptions } from './defineLogger.ts'
 import { clackLogger } from './clackLogger.ts'
@@ -22,6 +22,38 @@ export function formatMessage(message: string, logLevel: number): string {
     return `${styleText('dim', `[${timestamp}]`)} ${message}`
   }
   return message
+}
+
+type LogHelpers = {
+  /**
+   * Applies {@link formatMessage} with the adapter's log level.
+   */
+  getMessage: (message: string) => string
+  /**
+   * Registers a handler that prints a fixed step message through `print`, skipped at silent level.
+   */
+  onStep: <E extends keyof KubbHooks>(hook: E, message: string) => void
+}
+
+/**
+ * Creates the `getMessage` and `onStep` helpers shared by the logger adapters. `print` is the
+ * adapter's line output, `clack.log.step` for the clack logger and `console.log` for the plain one.
+ */
+export function createLogHelpers({ context, logLevel, print }: { context: LoggerContext; logLevel: number; print: (text: string) => void }): LogHelpers {
+  function getMessage(message: string): string {
+    return formatMessage(message, logLevel)
+  }
+
+  function onStep<E extends keyof KubbHooks>(hook: E, message: string): void {
+    context.hook(hook, () => {
+      if (logLevel <= logLevelMap.silent) {
+        return
+      }
+      print(getMessage(message))
+    })
+  }
+
+  return { getMessage, onStep }
 }
 
 /**

--- a/packages/renderer-jsx/src/Runtime.tsx
+++ b/packages/renderer-jsx/src/Runtime.tsx
@@ -16,23 +16,27 @@ import type { KubbReactElement } from './types.ts'
 type OnText = (text: string) => void
 type OnHost = (type: string, props: Record<string, unknown>) => void
 
+type ResolvedElement =
+  | { kind: 'none' }
+  | { kind: 'text'; value: string }
+  | { kind: 'children'; children: Array<unknown> }
+  | { kind: 'host'; type: string; props: Record<string, unknown> }
+
 /**
- * Walks `element`, resolving arrays, Fragments, and function components, then
- * calls `onText` for primitive values and `onHost` for each host element.
- * Function components are called synchronously. Hooks and class components are
- * not supported.
+ * Classifies one element for the tree walkers: primitives become text, arrays, Fragments, and
+ * function components become children to recurse into, and string-typed elements become host
+ * elements. Anything else (null, booleans, unknown objects) resolves to `none`. Function
+ * components are called synchronously.
  */
-function walkElement(element: unknown, onText: OnText, onHost: OnHost): void {
-  if (element == null || typeof element === 'boolean') return
+function resolveElement(element: unknown): ResolvedElement {
+  if (element == null || typeof element === 'boolean') return { kind: 'none' }
 
   if (typeof element === 'string' || typeof element === 'number' || typeof element === 'bigint') {
-    onText(String(element))
-    return
+    return { kind: 'text', value: String(element) }
   }
 
   if (Array.isArray(element)) {
-    for (const child of element) walkElement(child, onText, onHost)
-    return
+    return { kind: 'children', children: element }
   }
 
   if (typeof element === 'object' && '$$typeof' in element) {
@@ -41,16 +45,38 @@ function walkElement(element: unknown, onText: OnText, onHost: OnHost): void {
     const props = el.props as Record<string, unknown>
 
     if (type === Fragment) {
-      walkElement(props['children'], onText, onHost)
-      return
+      return { kind: 'children', children: [props['children']] }
     }
     if (typeof type === 'function') {
-      walkElement((type as (p: unknown) => unknown)(props), onText, onHost)
-      return
+      return { kind: 'children', children: [(type as (p: unknown) => unknown)(props)] }
     }
     if (typeof type === 'string') {
-      onHost(type, props)
+      return { kind: 'host', type, props }
     }
+  }
+
+  return { kind: 'none' }
+}
+
+/**
+ * Walks `element`, resolving arrays, Fragments, and function components, then
+ * calls `onText` for primitive values and `onHost` for each host element.
+ * Function components are called synchronously. Hooks and class components are
+ * not supported.
+ */
+function walkElement(element: unknown, onText: OnText, onHost: OnHost): void {
+  const resolved = resolveElement(element)
+
+  if (resolved.kind === 'text') {
+    onText(resolved.value)
+    return
+  }
+  if (resolved.kind === 'children') {
+    for (const child of resolved.children) walkElement(child, onText, onHost)
+    return
+  }
+  if (resolved.kind === 'host') {
+    onHost(resolved.type, resolved.props)
   }
 }
 
@@ -216,54 +242,37 @@ function collectFileChildren(element: unknown): FileChildren {
 }
 
 function* walkFiles(element: unknown): Generator<FileNode> {
-  if (element == null || typeof element === 'boolean') return
+  const resolved = resolveElement(element)
 
-  if (typeof element === 'string' || typeof element === 'number' || typeof element === 'bigint') return
-
-  if (Array.isArray(element)) {
-    for (const child of element) yield* walkFiles(child)
-
+  if (resolved.kind === 'children') {
+    for (const child of resolved.children) yield* walkFiles(child)
     return
   }
 
-  if (typeof element === 'object' && '$$typeof' in element) {
-    const el = element as unknown as KubbReactElement
-    const { type } = el
-    const props = el.props as Record<string, unknown>
+  if (resolved.kind !== 'host') return
 
-    if (type === Fragment) {
-      yield* walkFiles(props['children'])
-      return
-    }
+  const { type, props } = resolved
 
-    if (typeof type === 'function') {
-      yield* walkFiles((type as (p: unknown) => unknown)(props))
-      return
+  if (type === KUBB_FILE && props['baseName'] !== undefined && props['path'] !== undefined) {
+    const { sources, exports, imports } = collectFileChildren(props['children'])
+    // `walkFiles` yields the `<kubb-file>` props as-is; `id`, `name`, `extname`, and `kind`,
+    // plus unused-import pruning, are only computed once the file reaches `FileManager` (via
+    // `ast.factory.createFile`) — calling it here would prune imports before `FileManager`
+    // merges same-path fragments from separate `render()` calls into their final source text.
+    const file: UserFileNode = {
+      baseName: props['baseName'] as FileNode['baseName'],
+      path: props['path'] as string,
+      meta: (props['meta'] as FileNode['meta']) || {},
+      footer: props['footer'] as FileNode['footer'],
+      banner: props['banner'] as FileNode['banner'],
+      copy: props['copy'] as FileNode['copy'],
+      sources,
+      exports,
+      imports,
     }
-
-    if (typeof type === 'string') {
-      if (type === KUBB_FILE && props['baseName'] !== undefined && props['path'] !== undefined) {
-        const { sources, exports, imports } = collectFileChildren(props['children'])
-        // `walkFiles` yields the `<kubb-file>` props as-is; `id`, `name`, `extname`, and `kind`,
-        // plus unused-import pruning, are only computed once the file reaches `FileManager` (via
-        // `ast.factory.createFile`) — calling it here would prune imports before `FileManager`
-        // merges same-path fragments from separate `render()` calls into their final source text.
-        const file: UserFileNode = {
-          baseName: props['baseName'] as FileNode['baseName'],
-          path: props['path'] as string,
-          meta: (props['meta'] as FileNode['meta']) || {},
-          footer: props['footer'] as FileNode['footer'],
-          banner: props['banner'] as FileNode['banner'],
-          copy: props['copy'] as FileNode['copy'],
-          sources,
-          exports,
-          imports,
-        }
-        yield file as unknown as FileNode
-      } else {
-        yield* walkFiles(props['children'])
-      }
-    }
+    yield file as unknown as FileNode
+  } else {
+    yield* walkFiles(props['children'])
   }
 }
 


### PR DESCRIPTION
## 🎯 Changes

Collapses the three hand-written clones from the `fallow dupes --mode mild` scan (closes #3771, follow-up to #3769):

- `@kubb/ast` (`combineFileMembers.ts`): the structurally identical merge loops in `combineExports` and `combineImports` now run through one generic `mergeMembers` helper, parameterized by `skip`/`normalizeNames`/`create`/`skipSingle`/`identityKey` callbacks so the import-specific filtering (unused-import pruning, name canonicalization) stays at the call site.
- `@kubb/renderer-jsx` (`Runtime.tsx`): the repeated child-flattening/normalization block in `walkElement` and `walkFiles` is hoisted into a `resolveElement` classifier that maps an element to `text`, `children`, `host`, or `none`, and both walkers consume it.
- `@kubb/cli` (loggers): the duplicated `getMessage`/`onStep` pair in `clackLogger` and `plainLogger` moves into a shared `createLogHelpers` factory in `loggers/utils.ts`, parameterized by each adapter's line output (`clack.log.step` vs `console.log`).

Behavior is unchanged: each helper reproduces the original control flow exactly, and the two call sites can no longer drift apart.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test` (`@kubb/ast` 237, `@kubb/renderer-jsx` 22, `@kubb/cli` 58 tests pass, plus `pnpm lint`, `pnpm typecheck`, and builds).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFeuumSZAGiGGFwSBuwePB

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFeuumSZAGiGGFwSBuwePB)_