### PR TITLE
feat(kit): re-export the Hookable class

### DIFF
--- a/.changeset/kit-core-type-reexports.md
+++ b/.changeset/kit-core-type-reexports.md
@@ -1,0 +1,5 @@
+---
+"@kubb/kit": minor
+---
+
+Re-export the `Hookable` class from `@kubb/kit` (and so from the `kubb/kit` subpath), alongside the `Diagnostics`, `fsStorage`, and `memoryStorage` values already there. Code building on the kit no longer has to reach into `@kubb/core` for the hook emitter.

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -8,6 +8,7 @@ export { defineParser } from '@kubb/core'
 export { definePlugin } from '@kubb/core'
 export { createResolver, Resolver } from '@kubb/core'
 export { Diagnostics } from '@kubb/core'
+export { Hookable } from '@kubb/core'
 export { fsStorage } from '@kubb/core'
 export { memoryStorage } from '@kubb/core'
 export type {


### PR DESCRIPTION
## What

`@kubb/kit` already re-exports the `Diagnostics`, `fsStorage`, and `memoryStorage` values from `@kubb/core`, but not the `Hookable` hook emitter. This adds it:

```ts
export { Hookable } from '@kubb/core'
```

It flows through the `kubb/kit` subpath too (`kubb` re-exports `@kubb/kit` via `packages/kubb/src/kit.ts`).

## Why

Tools building on the kit (e.g. the Kubb Studio agent) construct `new Hookable()` for the generation event bus. With this, the hook/diagnostic runtime resolves entirely through `kubb`/`kubb/kit`, so consumers don't need `@kubb/core` as a runtime dependency — they can keep it as a types-only devDependency.

`Hookable` is a custom class (wraps Node's `EventEmitter`), so it isn't available from the `hookable` npm package.

## Verification

- `@kubb/kit` builds; `dist/index.js` exports `Hookable` as a runtime value, `dist/index.d.ts` carries the type.
- oxfmt / oxlint clean.
- Changeset (`@kubb/kit` minor) included; the `fixed` group republishes `kubb`/`kubb/kit` with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ew4223tfK92qE2WKigE5aw