### PR TITLE
feat(cli): accept the validate spec as a positional argument

### DIFF
--- a/.changeset/cli-validate-positional-input.md
+++ b/.changeset/cli-validate-positional-input.md
@@ -1,0 +1,8 @@
+---
+'@kubb/cli': patch
+'kubb': patch
+---
+
+Accept the spec as a positional argument on `kubb validate`, matching `kubb generate`.
+
+`kubb validate` took the spec through the `--input`/`-i` flag, while `kubb generate` already read it as a positional argument. The two commands now share the same shape, so `kubb validate ./openapi.yaml` replaces `kubb validate --input ./openapi.yaml`. The argument stays required, and both local paths and URLs still work.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -141,23 +141,23 @@ npx kubb generate --reporter cli,json
 Parse and validate an OpenAPI/Swagger file for structural correctness. Reports schema errors, missing required fields, and malformed references. Use this before running `generate` to catch spec issues early.
 
 ```bash
-npx kubb validate --input <path-or-url>
+npx kubb validate <path-or-url>
 ```
 
-#### Options
+#### Arguments
 
-| Flag             | Short | Type   | Required | Description                                         |
-| ---------------- | ----- | ------ | -------- | --------------------------------------------------- |
-| `--input <path>` | `-i`  | string | ✅       | Path or URL to the OpenAPI/Swagger file to validate |
+| Argument  | Required | Description                                         |
+| --------- | -------- | --------------------------------------------------- |
+| `<input>` | ✅       | Path or URL to the OpenAPI/Swagger file to validate |
 
 #### Examples
 
 ```bash
 # Validate a local file
-npx kubb validate --input ./openapi.yaml
+npx kubb validate ./openapi.yaml
 
 # Validate a remote spec
-npx kubb validate --input https://petstore3.swagger.io/api/v3/openapi.json
+npx kubb validate https://petstore3.swagger.io/api/v3/openapi.json
 ```
 
 ---

--- a/packages/cli/src/commands/validate.test.ts
+++ b/packages/cli/src/commands/validate.test.ts
@@ -1,0 +1,39 @@
+import process from 'node:process'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { runValidate } = vi.hoisted(() => ({ runValidate: vi.fn(async () => undefined) }))
+
+vi.mock('../runners/validate/run.ts', () => ({ run: runValidate }))
+
+describe('validate command', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+    runValidate.mockClear()
+  })
+
+  it('forwards the positional input to the validate runner', async () => {
+    using _log = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    vi.stubEnv('KUBB_DISABLE_TELEMETRY', '1')
+
+    const { run } = await import('../index.ts')
+    await run(['/usr/bin/node', '/usr/local/bin/kubb', 'validate', './spec.yaml'])
+
+    expect(runValidate).toHaveBeenCalledWith(expect.objectContaining({ input: './spec.yaml' }))
+  })
+
+  it('exits with a non-zero code when the input is missing', async () => {
+    using _log = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+    using _error = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    using _exit = vi.spyOn(process, 'exit').mockImplementation((() => {
+      throw new Error('process.exit')
+    }) as never)
+    vi.stubEnv('KUBB_DISABLE_TELEMETRY', '1')
+
+    const { run } = await import('../index.ts')
+    await expect(run(['/usr/bin/node', '/usr/local/bin/kubb', 'validate'])).rejects.toThrow('process.exit')
+
+    expect(runValidate).not.toHaveBeenCalled()
+    expect(_exit).toHaveBeenCalledWith(1)
+  })
+})

--- a/packages/cli/src/commands/validate.ts
+++ b/packages/cli/src/commands/validate.ts
@@ -5,12 +5,11 @@ export const command = define({
   name: 'validate',
   description:
     'Parse and validate an OpenAPI/Swagger file for structural correctness. Reports schema errors, missing required fields, and malformed references. Use this before running generate to catch spec issues early.',
-  examples: ['kubb validate --input ./openapi.yaml', 'kubb validate --input https://petstore3.swagger.io/api/v3/openapi.json'].join('\n'),
+  examples: ['kubb validate ./openapi.yaml', 'kubb validate https://petstore3.swagger.io/api/v3/openapi.json'].join('\n'),
   args: {
     input: {
-      type: 'string',
+      type: 'positional',
       description: 'Path or URL to the OpenAPI/Swagger file to validate',
-      short: 'i',
       required: true,
     },
   },

--- a/tools/claude/agents/kubb-expert.md
+++ b/tools/claude/agents/kubb-expert.md
@@ -15,7 +15,7 @@ catalog.
 Approach:
 
 1. Find the spec (a local file or a URL) and the target output directory. Validate the spec with
-   `kubb validate --input <spec>` before doing anything destructive.
+   `kubb validate <spec>` before doing anything destructive.
 2. Decide which `@kubb/plugin-*` packages match what the user wants generated. Keep `plugin-ts`
    as the base, since the client, framework and MSW plugins need it. Add a client or framework
    plugin for data fetching (the framework plugins also pull in a client plugin like `plugin-axios` or `plugin-fetch`), `plugin-zod` for

--- a/tools/claude/commands/validate.md
+++ b/tools/claude/commands/validate.md
@@ -9,7 +9,7 @@ terminal (ask for the path or URL if empty).
 1. Run validation:
 
    ```shell
-   npx kubb validate --input <spec>
+   npx kubb validate <spec>
    ```
 
    The input accepts a local path or a URL.

--- a/tools/claude/skills/config/SKILL.md
+++ b/tools/claude/skills/config/SKILL.md
@@ -101,7 +101,7 @@ Common combinations:
 
 The commands wrap the `kubb` CLI, so the same steps work from a terminal.
 
-1. Validate the spec with `kubb validate --input <spec>` before anything else.
+1. Validate the spec with `kubb validate <spec>` before anything else.
 2. Scaffold and install with `kubb init`. Pass `--input`, `--output` and `--plugins` to skip the
    prompts, or write `kubb.config.ts` by hand using the shape above.
 3. Generate with `kubb generate`. Pass `--verbose` when diagnosing why a file is missing or


### PR DESCRIPTION
## 🎯 Changes

`kubb validate` took the spec through the `--input`/`-i` flag, while `kubb generate` already read it as a positional argument. This aligns the two commands so the input is a positional argument on `validate` too:

```bash
# before
kubb validate --input ./openapi.yaml

# after
kubb validate ./openapi.yaml
```

The argument stays required, and both local paths and URLs still work. Passing the old `--input` flag (or omitting the argument) now reports `Positional argument 'input' is required` and exits non-zero.

Details:
- `packages/cli/src/commands/validate.ts` switches `input` from a `string` flag to a required `positional`, and updates the command examples.
- `packages/cli/src/commands/validate.test.ts` adds a command-level test that drives the real CLI entry: the positional input reaches the runner, and a missing argument exits with a non-zero code.
- `packages/cli/README.md` documents the positional argument instead of the flag.
- Internal tooling copy under `tools/claude/` (validate command, kubb-expert agent, config skill) uses the new syntax.
- Adds a changeset (`@kubb/cli` and `kubb`, patch).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MjfJLz3uEZDnVwmbshX2PQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjfJLz3uEZDnVwmbshX2PQ)_