### PR TITLE
feat(core)!: flip output.barrel default from { type: 'named' } to false

### DIFF
--- a/.changeset/barrel-default-off.md
+++ b/.changeset/barrel-default-off.md
@@ -1,0 +1,10 @@
+---
+'kubb': major
+'unplugin-kubb': major
+---
+
+Flip the default `output.barrel` from `{ type: 'named' }` to `false`. A config that omits `output.barrel` (root or per-plugin) no longer generates a barrel `index.ts` file.
+
+Set `output.barrel: { type: 'named' | 'all' }` explicitly to keep generating a barrel.
+
+**Breaking change:** any project relying on the implicit `{ type: 'named' }` default to get a barrel now needs `output.barrel` set explicitly, or imports that go through the barrel (`import { Pet } from './gen'`) stop resolving.

--- a/.changeset/plugin-barrel-default-off.md
+++ b/.changeset/plugin-barrel-default-off.md
@@ -1,0 +1,7 @@
+---
+'@kubb/plugin-barrel': major
+---
+
+Adjust for `output.barrel` defaulting to `false` instead of `{ type: 'named' }`. `pluginBarrel` still ships with `kubb` and `unplugin-kubb` by default, but now generates nothing until a barrel is configured on the root config, a plugin, or both.
+
+**Breaking change:** a config that never set `output.barrel` and relied on the implicit `{ type: 'named' }` default now needs it set explicitly to keep generating barrel files.

--- a/packages/kubb/src/defineConfig.test.ts
+++ b/packages/kubb/src/defineConfig.test.ts
@@ -104,7 +104,7 @@ describe('defineConfig', () => {
     expect(resolved.plugins?.some((p) => p.name === pluginBarrelName)).toBe(true)
   })
 
-  test("defaults output.barrel to { type: 'named' } when not set", () => {
+  test('defaults output.barrel to false when not set', () => {
     const config = defineConfig({
       root: '.',
       input: 'spec.yaml',
@@ -112,7 +112,7 @@ describe('defineConfig', () => {
     } as UserConfig)
     const resolved = config as UserConfig
 
-    expect(resolved.output.barrel).toStrictEqual({ type: 'named' })
+    expect(resolved.output.barrel).toBe(false)
   })
 
   test('preserves explicit output.barrel (including false)', () => {
@@ -155,7 +155,7 @@ describe('defineConfig', () => {
     const resolved = config as UserConfig
 
     expect(resolved.plugins?.some((p) => p.name === pluginBarrelName)).toBe(true)
-    expect(resolved.output.barrel).toStrictEqual({ type: 'named' })
+    expect(resolved.output.barrel).toBe(false)
   })
 
   test('preserves existing adapter', () => {

--- a/packages/kubb/src/defineConfig.ts
+++ b/packages/kubb/src/defineConfig.ts
@@ -23,7 +23,7 @@ type DefinedConfig<TConfig extends ConfigInput> = TConfig extends (cli: CLIOptio
  * - `parsers` defaults to `[parserTs(), parserTsx(), parserMd()]`
  * - `reporters` defaults to `[cliReporter, jsonReporter, fileReporter]`
  * - `plugins` gets `pluginBarrel()` appended when none is already present
- * - `output.barrel` defaults to `{ type: 'named' }` when not set (`pluginBarrel` is always present after the step above)
+ * - `output.barrel` defaults to `false` when not set (`pluginBarrel` is always present after the step above, but generates nothing until configured)
  * - `output.format` defaults to `false`
  * - `output.lint` defaults to `false`
  */
@@ -32,7 +32,7 @@ function applyDefaults<TInput>(config: UserConfig<TInput>): UserConfig<TInput> {
     defaultAdapter: adapterOas(),
     barrelPlugin: pluginBarrel(),
     barrelPluginName: pluginBarrelName,
-    defaultOutput: { barrel: { type: 'named' }, format: false, lint: false },
+    defaultOutput: { barrel: false, format: false, lint: false },
   })
 
   return {
@@ -62,7 +62,7 @@ function normalizeConfig<TInput>(config: UserConfig<TInput> | Array<UserConfig<T
  * - `parsers` → `[parserTs(), parserTsx(), parserMd()]`.
  * - `reporters` → `[cliReporter, jsonReporter, fileReporter]`.
  * - `plugins` → `pluginBarrel()` is appended when not already present.
- * - `output.barrel` → `{ type: 'named' }` when not set.
+ * - `output.barrel` → `false` when not set.
  * - `output.format` and `output.lint` → `false`.
  *
  * Accepts a config object, an array of configs, a Promise resolving to one,

--- a/packages/plugin-barrel/src/plugin.ts
+++ b/packages/plugin-barrel/src/plugin.ts
@@ -35,12 +35,13 @@ declare global {
       output: {
         /**
          * Barrel configuration for this plugin's output.
-         * Set to `false` to disable barrel generation for this plugin entirely. Doing so also
+         * Set to `{ type: 'named' | 'all' }` to opt this plugin into a barrel. Set to `false`
+         * (the default) to disable barrel generation for this plugin entirely, which also
          * excludes the plugin's files from the root barrel.
          *
          * Falls back to `config.output.barrel` when omitted.
          *
-         * @default { type: 'named' }
+         * @default false
          */
         barrel?: PluginBarrelConfig | false
       }
@@ -49,10 +50,10 @@ declare global {
       output: {
         /**
          * Barrel configuration for the root barrel file at `config.output.path/index.ts`.
-         * Set to `false` to disable root barrel generation. Individual plugins can override
-         * this via their own `output.barrel`.
+         * Set to `{ type: 'named' | 'all' }` to opt into a root barrel. Individual plugins can
+         * override this via their own `output.barrel`.
          *
-         * @default { type: 'named' }
+         * @default false
          */
         barrel?: BarrelConfig | false
       }
@@ -69,11 +70,14 @@ export const pluginBarrelName = 'plugin-barrel' satisfies Plugin['name']
 /**
  * Generates an `index.ts` for every plugin output directory and one root
  * barrel at `config.output.path/index.ts` after the build completes. Ships
- * with Kubb and is registered by default in `defineConfig`.
+ * with Kubb and is registered by default in `defineConfig`, but generates
+ * nothing until a barrel is configured.
  *
  * Each plugin inherits `output.barrel` from `config.output.barrel` (which
- * defaults to `{ type: 'named' }`). Set `barrel: false` on a plugin to skip
- * its barrel and also exclude its files from the root barrel.
+ * defaults to `false`, no barrel). Set `barrel: { type: 'named' | 'all' }` on
+ * the root config, a plugin, or both to opt in; a plugin-level `false`
+ * overrides an enabled root barrel and also excludes that plugin's files
+ * from the root barrel.
  *
  * A plugin with `output.mode: 'file'` gets no per-plugin barrel, since its output
  * is a single file. The root barrel re-exports that file directly.
@@ -109,13 +113,12 @@ export const pluginBarrel = definePlugin(() => {
 
         const pluginBarrelOpt = plugin.options.output?.barrel
         const configBarrel = config.output.barrel
-        const defaultBarrel = { type: 'named' } as const
 
         // Root config barrel doesn't have nested, so we add it
         const barrelConfig: PluginBarrelConfig | false = (() => {
           if (pluginBarrelOpt !== undefined) return pluginBarrelOpt
           if (configBarrel !== undefined) return configBarrel === false ? false : { ...configBarrel, nested: false }
-          return defaultBarrel
+          return false
         })()
 
         if (barrelConfig === false) {
@@ -143,7 +146,7 @@ export const pluginBarrel = definePlugin(() => {
         }
       },
       'kubb:plugins:end'({ files, config, upsertFile }) {
-        const barrelConfig = config.output.barrel ?? { type: 'named' }
+        const barrelConfig = config.output.barrel ?? false
 
         const filteredFiles = excludedPrefixes.size === 0 ? files : files.filter((f) => !isExcludedPath(f.path, excludedPrefixes))
         excludedPrefixes.clear()

--- a/packages/plugin-barrel/src/types.ts
+++ b/packages/plugin-barrel/src/types.ts
@@ -11,9 +11,9 @@ export type BarrelType = 'all' | 'named'
  *
  * @example
  * ```ts
- * barrel: { type: 'named' }  // default
+ * barrel: { type: 'named' }
  * barrel: { type: 'all' }
- * barrel: false  // disable barrel generation
+ * barrel: false  // no barrel generated (default)
  * ```
  */
 export type BarrelConfig = {
@@ -34,7 +34,7 @@ export type BarrelConfig = {
  * barrel: { type: 'named' }  // single barrel with named exports
  * barrel: { type: 'all', nested: true }  // hierarchical barrels with wildcard exports
  * barrel: { type: 'named', nested: true }  // hierarchical barrels with named exports
- * barrel: false  // disable barrel generation
+ * barrel: false  // no barrel generated (default)
  * ```
  */
 export type PluginBarrelConfig = {

--- a/packages/unplugin-kubb/src/unpluginFactory.ts
+++ b/packages/unplugin-kubb/src/unpluginFactory.ts
@@ -83,7 +83,7 @@ export const unpluginFactory: UnpluginFactory<Options | undefined> = (options, m
       defaultAdapter: adapterOas(),
       barrelPlugin: pluginBarrel(),
       barrelPluginName: pluginBarrelName,
-      defaultOutput: { barrel: { type: 'named' }, format: false, lint: false },
+      defaultOutput: { barrel: false, format: false, lint: false },
     })
 
     const config = {


### PR DESCRIPTION
## 🎯 Changes

Follow-up to the `output.mode` default flip (#3791), this time targeting `output.barrel`.

Today, `output.barrel` defaults to `{ type: 'named' }`, so every config gets a root barrel `index.ts` whether or not it's used. The `'named'` strategy enumerates every exported symbol, so its size scales with the spec, not the file count. On a benchmark against the GitHub REST API spec, the barrel alone came out to 1.2 MB, generated unconditionally even for projects that never import through it.

This flips the default to `false`. A config that omits `output.barrel` (root or per-plugin) now generates no barrel file at all. Projects that want one set `output.barrel: { type: 'named' | 'all' }` explicitly, same syntax as today.

Changes:
- `packages/plugin-barrel/src/plugin.ts`: both internal default fallbacks (`kubb:plugin:end` and `kubb:plugins:end` hooks) now resolve to `false` instead of `{ type: 'named' }` when nothing is configured. Updated JSDoc on `PluginOptionsRegistry`/`ConfigOptionsRegistry` and the `pluginBarrel` export.
- `packages/plugin-barrel/src/types.ts`: updated `@example` blocks on `BarrelConfig`/`PluginBarrelConfig`.
- `packages/kubb/src/defineConfig.ts`: `applyDefaults`'s `defaultOutput.barrel` changed from `{ type: 'named' }` to `false`.
- `packages/unplugin-kubb/src/unpluginFactory.ts`: same default change for the unplugin entry point.
- Test updates in `packages/kubb/src/defineConfig.test.ts` for the two tests asserting the old default.

`pluginBarrel` still ships by default via `kubb`/`unplugin-kubb`, it just generates nothing until a barrel is configured.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).


---
_Generated by [Claude Code](https://claude.ai/code/session_01GTm7pZ68FXo7x5YY2XjAWe)_