### PR TITLE
ci: pin kubb-labs/config actions to latest main

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@d2daeb58eb7dc8c19d595c926b4788b7f682fb51 # main
+        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/changeset-format.yml
+++ b/.github/workflows/changeset-format.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@d2daeb58eb7dc8c19d595c926b4788b7f682fb51 # main
+        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@d2daeb58eb7dc8c19d595c926b4788b7f682fb51 # main
+        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@d2daeb58eb7dc8c19d595c926b4788b7f682fb51 # main
+        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
         with:
           node-version: '22.22.3'
 
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@d2daeb58eb7dc8c19d595c926b4788b7f682fb51 # main
+        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
         with:
           node-version: '22.22.3'
 
@@ -72,7 +72,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@d2daeb58eb7dc8c19d595c926b4788b7f682fb51 # main
+        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
         with:
           node-version: '22.22.3'
 
@@ -102,7 +102,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@d2daeb58eb7dc8c19d595c926b4788b7f682fb51 # main
+        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
         with:
           node-version: '22.22.3'
 
@@ -127,7 +127,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@d2daeb58eb7dc8c19d595c926b4788b7f682fb51 # main
+        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
         with:
           node-version: '22.22.3'
 
@@ -152,7 +152,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@d2daeb58eb7dc8c19d595c926b4788b7f682fb51 # main
+        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
         with:
           node-version: '22.22.3'
 
@@ -199,7 +199,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@d2daeb58eb7dc8c19d595c926b4788b7f682fb51 # main
+        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
         with:
           node-version: '22.22.3'
 
@@ -225,7 +225,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@d2daeb58eb7dc8c19d595c926b4788b7f682fb51 # main
+        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@d2daeb58eb7dc8c19d595c926b4788b7f682fb51 # main
+        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
         with:
           node-version: '22.22.3'
           cache: 'false'
@@ -48,7 +48,7 @@ jobs:
 
       - name: Release
         id: release
-        uses: kubb-labs/config/.github/actions/release@6498246dc71ad3c27db69f9cc1f928a05e79d0c7 # main
+        uses: kubb-labs/config/.github/actions/release@b673ab918489eb77823cac38fc17d67f325177b8 # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -90,7 +90,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@d2daeb58eb7dc8c19d595c926b4788b7f682fb51 # main
+        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
         with:
           node-version: '22.22.3'
           cache: 'false'
@@ -104,7 +104,7 @@ jobs:
       # version independently.
       - name: Promote
         id: promote
-        uses: kubb-labs/config/.github/actions/promote@6498246dc71ad3c27db69f9cc1f928a05e79d0c7 # main
+        uses: kubb-labs/config/.github/actions/promote@b673ab918489eb77823cac38fc17d67f325177b8 # main
         with:
           staged-packages: ${{ needs.release.outputs.staged_packages }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 🎯 Changes

Update the pinned commit SHA for the shared [kubb-labs/config](https://github.com/kubb-labs/config) composite actions to the latest `main` commit [`b673ab9`](https://github.com/kubb-labs/config/commit/b673ab918489eb77823cac38fc17d67f325177b8).

Repointed across `.github/workflows/`:
- `.github/setup`
- `.github/actions/release`
- `.github/actions/promote`

Two different pinned hashes were in use before (`d2daeb5` for `setup`, `6498246` for `release`/`promote`); both now resolve to the single latest `main` commit.

Files touched: `autofix.yml`, `changeset-format.yml`, `copilot-setup-steps.yml`, `pr.yml`, `release.yml`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`. <!-- CI-config-only change, not covered by unit tests -->

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a changeset.
- [ ] This change is for the docs (no release).

CI-only change: only workflow action pins were updated, so no published package code changed and no changeset is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HgjSB6Ac8HQD6QFyNqUxu5)_