### PR TITLE
fix(core): write files through a bounded pool, keep generation order

### DIFF
--- a/.changeset/core-file-processing-generation-order.md
+++ b/.changeset/core-file-processing-generation-order.md
@@ -2,6 +2,6 @@
 '@kubb/core': patch
 ---
 
-Stream file-processing progress events in a stable order.
+Cap file writing to a bounded pool and stream progress in generation order.
 
-The `kubb:files:processing:update` rows were ordered by whichever file finished writing first, so the list shuffled between runs. They now follow the order files were generated, numbered `1..N`, which keeps the CLI counter and Kubb Studio's events panel consistent.
+`FileManager.write` parsed every file at once, so large specs held every source in memory and the `kubb:files:processing:update` rows arrived in whichever order files finished. It now caps in-flight files at 50, which keeps memory flat on large specs while small specs still write fully in parallel. Each row carries its file's position, so the CLI counter and Kubb Studio's events panel show a stable `1..N` list.

--- a/.changeset/core-file-processing-generation-order.md
+++ b/.changeset/core-file-processing-generation-order.md
@@ -1,0 +1,7 @@
+---
+'@kubb/core': patch
+---
+
+Stream `kubb:files:processing:update` rows in generation order with a sequential counter.
+
+The write pass runs files through `Promise.all`, so the buffered update rows landed in I/O-completion order, which varied from run to run and left the streamed file list nondeterministic. The buffer is now sorted into generation order and renumbered, so a consumer (the CLI counter, Kubb Studio's events panel) renders a stable `1..N` sequence over the generated files. The batch is emitted at once after every file is written, so the counter was never live progress and nothing is lost.

--- a/.changeset/core-file-processing-generation-order.md
+++ b/.changeset/core-file-processing-generation-order.md
@@ -2,6 +2,6 @@
 '@kubb/core': patch
 ---
 
-Stream `kubb:files:processing:update` rows in generation order with a sequential counter.
+Stream file-processing progress events in a stable order.
 
-The write pass runs files through `Promise.all`, so the buffered update rows landed in I/O-completion order, which varied from run to run and left the streamed file list nondeterministic. The buffer is now sorted into generation order and renumbered, so a consumer (the CLI counter, Kubb Studio's events panel) renders a stable `1..N` sequence over the generated files. The batch is emitted at once after every file is written, so the counter was never live progress and nothing is lost.
+The `kubb:files:processing:update` rows were ordered by whichever file finished writing first, so the list shuffled between runs. They now follow the order files were generated, numbered `1..N`, which keeps the CLI counter and Kubb Studio's events panel consistent.

--- a/packages/core/src/FileManager.test.ts
+++ b/packages/core/src/FileManager.test.ts
@@ -336,6 +336,27 @@ describe('FileManager', () => {
       await writing
     })
 
+    it('bounds how many files are in flight for a large spec', async () => {
+      // Blocks every write for the duration of the test so the in-flight count can be observed.
+      const block = new Promise<void>(() => {})
+      const storage = memoryStorage()
+      const started: Array<string> = []
+      storage.setItem = async (itemPath: string) => {
+        started.push(itemPath)
+        await block
+      }
+      const manager = new FileManager()
+      const files = Array.from({ length: 200 }, (_, index) => makeFileWithSources(`f${index}.ts`, [`/* ${index} */`]))
+
+      manager.write(files, { storage }).catch(() => {})
+      await new Promise((resolve) => setTimeout(resolve, 20))
+
+      // Unbounded `Promise.all(files.map(...))` would have started all 200 writes. The pool keeps
+      // at most WRITE_CONCURRENCY (50) parsed sources in flight at once.
+      expect(started.length).toBeLessThan(files.length)
+      expect(started.length).toBe(50)
+    })
+
     it('waits for every write to finish before resolving', async () => {
       const { promise: blocker, resolve: unblock } = Promise.withResolvers<void>()
       const storage = memoryStorage()

--- a/packages/core/src/FileManager.ts
+++ b/packages/core/src/FileManager.ts
@@ -21,6 +21,12 @@ type WriteOptions = ParseOptions & {
   storage: Storage
 }
 
+// Cap how many files are parsed and written at once. A small spec runs all its files in parallel;
+// a spec with thousands of files keeps at most this many parsed sources in memory instead of every
+// source at once, while each file's write still overlaps the next file's parse. Disk writes are
+// throttled separately inside `fsStorage`.
+const WRITE_CONCURRENCY = 50
+
 function joinSources(file: FileNode): string {
   return file.sources
     .map((source) => extractStringsFromNodes(source.nodes as Array<CodeNode>))
@@ -175,8 +181,11 @@ export class FileManager {
   }
 
   /**
-   * Converts and writes every file at once, letting `storage.setItem` decide how much of
-   * that runs concurrently.
+   * Parses and writes every file through a bounded pool of workers. A small spec runs all its files
+   * at once; a spec with thousands of files keeps at most `WRITE_CONCURRENCY` parsed sources in
+   * memory rather than holding every source, while still overlapping each file's write with the
+   * next file's parse. Each `update` carries the file's input position, so a consumer can present
+   * the files in generation order even though they finish in whatever order they parse.
    */
   async write(files: Array<FileNode>, { storage, parsers }: WriteOptions): Promise<void> {
     if (files.length === 0) return
@@ -184,15 +193,18 @@ export class FileManager {
     await this.hooks.callHook('start', files)
 
     const total = files.length
-    let processed = 0
-    await Promise.all(
-      files.map(async (file) => {
+    // Workers share one iterator, so each `next()` hands the next file to whichever worker is free.
+    const entries = files.entries()
+
+    const worker = async (): Promise<void> => {
+      for (const [index, file] of entries) {
         const source = await this.parse(file, { parsers })
-        processed++
-        await this.hooks.callHook('update', { file, source, processed, total, percentage: (processed / total) * 100 })
+        await this.hooks.callHook('update', { file, source, processed: index + 1, total, percentage: ((index + 1) / total) * 100 })
         if (source) await storage.setItem(file.path, source)
-      }),
-    )
+      }
+    }
+
+    await Promise.all(Array.from({ length: Math.min(WRITE_CONCURRENCY, total) }, () => worker()))
 
     await this.hooks.callHook('end', files)
   }

--- a/packages/core/src/KubbDriver.ts
+++ b/packages/core/src/KubbDriver.ts
@@ -295,8 +295,15 @@ export class KubbDriver {
         updateBuffer.push(item)
       },
       end: async (files: Array<FileNode>) => {
+        // The write pass runs files through `Promise.all`, so `updateBuffer` fills in
+        // I/O-completion order, which differs from run to run. Re-sort into generation order and
+        // renumber so the streamed rows read as a stable `1..N` sequence for a human.
+        const orderByPath = new Map(files.map((file, index) => [file.path, index]))
+        updateBuffer.sort((a, b) => (orderByPath.get(a.file.path) ?? 0) - (orderByPath.get(b.file.path) ?? 0))
+
+        const total = files.length
         await hooks.callHook('kubb:files:processing:update', {
-          files: updateBuffer.map((item) => ({ ...item, config })),
+          files: updateBuffer.map((item, index) => ({ ...item, processed: index + 1, total, percentage: ((index + 1) / total) * 100, config })),
         })
         updateBuffer.length = 0
         await hooks.callHook('kubb:files:processing:end', { files })

--- a/packages/core/src/KubbDriver.ts
+++ b/packages/core/src/KubbDriver.ts
@@ -295,15 +295,12 @@ export class KubbDriver {
         updateBuffer.push(item)
       },
       end: async (files: Array<FileNode>) => {
-        // The write pass runs files through `Promise.all`, so `updateBuffer` fills in
-        // I/O-completion order, which differs from run to run. Re-sort into generation order and
-        // renumber so the streamed rows read as a stable `1..N` sequence for a human.
-        const orderByPath = new Map(files.map((file, index) => [file.path, index]))
-        updateBuffer.sort((a, b) => (orderByPath.get(a.file.path) ?? 0) - (orderByPath.get(b.file.path) ?? 0))
+        // Files parse concurrently, so the buffer arrives in completion order. `processed` is each
+        // file's input position, so sorting by it restores generation order for the streamed rows.
+        updateBuffer.sort((a, b) => a.processed - b.processed)
 
-        const total = files.length
         await hooks.callHook('kubb:files:processing:update', {
-          files: updateBuffer.map((item, index) => ({ ...item, processed: index + 1, total, percentage: ((index + 1) / total) * 100, config })),
+          files: updateBuffer.map((item) => ({ ...item, config })),
         })
         updateBuffer.length = 0
         await hooks.callHook('kubb:files:processing:end', { files })

--- a/packages/core/src/createKubb.test.ts
+++ b/packages/core/src/createKubb.test.ts
@@ -317,6 +317,67 @@ describe('createKubb', () => {
     expect(files.map((file) => file.path)).toStrictEqual(['/workspace/src/gen/one.ts', '/workspace/src/gen/two.ts'])
   })
 
+  it('streams file-processing updates in generation order with a sequential counter', async () => {
+    const hooks = new Hookable<KubbHooks>()
+    const updateRows: Array<{ path: string; processed: number; total: number }> = []
+    hooks.hook('kubb:files:processing:update', ({ files }) => {
+      for (const row of files) {
+        updateRows.push({ path: row.file.path, processed: row.processed, total: row.total })
+      }
+    })
+
+    const makePlugin = (name: string, filePath: string) =>
+      definePlugin(() => ({
+        name,
+        hooks: {
+          'kubb:plugin:setup'(ctx) {
+            ctx.addGenerator({
+              name: `${name}-generator`,
+              schema() {
+                return [
+                  ast.factory.createFile({
+                    path: filePath,
+                    baseName: filePath.split('/').pop() as `${string}.${string}`,
+                    sources: [ast.factory.createSource({ nodes: [ast.factory.createText(`export const ${name.replaceAll('-', '_')} = null`)] })],
+                    imports: [],
+                    exports: [],
+                  }),
+                ]
+              },
+            })
+          },
+        },
+      }))()
+
+    const streamingConfig = {
+      ...config,
+      storage: memoryStorage(),
+      adapter: createMockedAdapter({
+        parse: async () => ({
+          kind: 'Input' as const,
+          meta: { circularNames: [] as Array<string>, enumNames: [] as Array<string> },
+          schemas: [ast.factory.createSchema({ name: 'Pet', type: 'string' })],
+          operations: [],
+        }),
+      }),
+      plugins: [
+        makePlugin('plugin-one', '/workspace/src/gen/one.ts'),
+        makePlugin('plugin-two', '/workspace/src/gen/two.ts'),
+        makePlugin('plugin-three', '/workspace/src/gen/three.ts'),
+      ] as unknown as Array<Plugin>,
+    } satisfies Config
+
+    await createKubb(streamingConfig, { hooks }).build()
+
+    // Order matches the generated files, and the counter is a clean 1..N, regardless of the
+    // order the concurrent write pass finished each file in.
+    expect(updateRows).toStrictEqual([
+      { path: '/workspace/src/gen/one.ts', processed: 1, total: 3 },
+      { path: '/workspace/src/gen/two.ts', processed: 2, total: 3 },
+      { path: '/workspace/src/gen/three.ts', processed: 3, total: 3 },
+    ])
+  })
+
   it('cleans up hook-style plugin listeners between builds on shared hooks', async () => {
     const hooks = new Hookable<KubbHooks>()
     const hookPlugin = definePlugin(() => ({


### PR DESCRIPTION
## 🎯 Changes

`FileManager.write` fanned every file out through `Promise.all`, which had two downsides: a large spec parsed and held **every** source in memory at once, and the `kubb:files:processing:update` rows arrived in write-completion order, so the streamed file list shuffled between runs.

The writes now run through a small pool of workers that share one iterator, capped at 50 in-flight files:

- **Small specs** still write fully in parallel — the pool is `min(50, fileCount)` wide, so a handful of files all run at once, same as before.
- **Large specs** keep memory flat instead of scaling with the file count, while each file's write still overlaps the next file's parse, so throughput holds.
- Each `update` carries the file's **input position**, so the driver just sorts the buffer by it to restore generation order. That dropped the earlier path-map and renumber in `KubbDriver`.

A consumer (the CLI counter, Kubb Studio's events panel) now renders a stable `1..N` sequence over the generated files, regardless of the order the concurrent writes finish.

This is the follow-up to the event-ordering work in `kubb-labs/platform` (Studio's transport already reorders events by an emission `seq`). The core emits every lifecycle hook serially and awaited, so this concurrent write pass was the one remaining source of nondeterministic ordering. Plugin `start`/`end` emission is intentionally left as-is, since it mirrors the real two-phase execution and reordering it would change when plugin code runs.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

`FileManager` (including a new bounded-pool test), `KubbDriver`, and `createKubb` suites pass (79 tests); `@kubb/core` builds cleanly; `oxlint` and `oxfmt` are clean.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SrLvdqG63uFbYazhg62BH