### PR TITLE
perf: walk a schema's $ref subtree once and share it across plugins

### DIFF
--- a/.changeset/share-imports-ref-scan.md
+++ b/.changeset/share-imports-ref-scan.md
@@ -1,0 +1,10 @@
+---
+'@kubb/ast': minor
+'@kubb/core': patch
+---
+
+Walk a schema's `$ref` subtree once and share it across plugins.
+
+`resolver.imports` scanned a node's whole subtree for `$ref`s on every call, so the ts, zod, and faker plugins each re-walked the same schema and operation. The scan now runs through a new `collectImportedRefNames` helper in `@kubb/ast` that memoizes the ordered ref set by node identity, so a schema shared across plugins is walked once and every plugin's resolver reads the same result.
+
+Import output is unchanged. Only refs carrying a `$ref` pointer are counted, in first-occurrence order and de-duplicated. `collectImportedRefNames` is the ordered, import-facing counterpart to `collectReferencedSchemaNames`, which stays the unordered set used for graph analysis.

--- a/packages/ast/src/utils/index.ts
+++ b/packages/ast/src/utils/index.ts
@@ -1,4 +1,4 @@
 export { combineExports, combineImports, combineSources } from './combineFileMembers.ts'
 export { extractStringsFromNodes } from './extractStringsFromNodes.ts'
 export { resolveRefName } from './refs.ts'
-export { collectUsedSchemaNames, findCircularSchemas } from './schemaGraph.ts'
+export { collectImportedRefNames, collectUsedSchemaNames, findCircularSchemas } from './schemaGraph.ts'

--- a/packages/ast/src/utils/schemaGraph.test.ts
+++ b/packages/ast/src/utils/schemaGraph.test.ts
@@ -5,7 +5,7 @@ import { createParameter } from '../nodes/parameter.ts'
 import { createProperty } from '../nodes/property.ts'
 import { createResponse } from '../nodes/response.ts'
 import { createSchema } from '../nodes/schema.ts'
-import { collectReferencedSchemaNames, collectUsedSchemaNames, findCircularSchemas } from './schemaGraph.ts'
+import { collectImportedRefNames, collectReferencedSchemaNames, collectUsedSchemaNames, findCircularSchemas } from './schemaGraph.ts'
 
 describe('findCircularSchemas', () => {
   it('returns empty set for acyclic schemas', () => {
@@ -125,6 +125,67 @@ describe('collectReferencedSchemaNames', () => {
 
   it('returns an empty set for schemas without refs', () => {
     expect(collectReferencedSchemaNames(createSchema({ type: 'string' }))).toStrictEqual(new Set())
+  })
+})
+
+describe('collectImportedRefNames', () => {
+  it('collects pointer-carrying ref names in first-occurrence order, de-duplicated', () => {
+    const schema = createSchema({
+      type: 'object',
+      name: 'Pet',
+      properties: [
+        createProperty({ name: 'category', required: false, schema: createSchema({ type: 'ref', name: 'Category', ref: '#/components/schemas/Category' }) }),
+        createProperty({
+          name: 'tags',
+          required: false,
+          schema: createSchema({ type: 'array', items: [createSchema({ type: 'ref', name: 'Tag', ref: '#/components/schemas/Tag' })] }),
+        }),
+        createProperty({ name: 'primary', required: false, schema: createSchema({ type: 'ref', name: 'Category', ref: '#/components/schemas/Category' }) }),
+      ],
+    })
+
+    expect(collectImportedRefNames(schema)).toStrictEqual(['Category', 'Tag'])
+  })
+
+  it('prefers targetName for collision-renamed refs', () => {
+    const schema = createSchema({
+      type: 'object',
+      name: 'Order',
+      properties: [
+        createProperty({
+          name: 'order',
+          required: false,
+          schema: createSchema({ type: 'ref', name: 'Order', ref: '#/components/schemas/Order', targetName: 'OrderSchema' }),
+        }),
+      ],
+    })
+
+    expect(collectImportedRefNames(schema)).toStrictEqual(['OrderSchema'])
+  })
+
+  it('skips refs without a $ref pointer, such as union members pointing at a sibling', () => {
+    const schema = createSchema({
+      type: 'union',
+      members: [createSchema({ type: 'ref', name: 'PetApplicationJson' }), createSchema({ type: 'ref', name: 'PetTextPlain' })],
+    })
+
+    expect(collectImportedRefNames(schema)).toStrictEqual([])
+  })
+
+  it('returns an empty array for schemas without refs', () => {
+    expect(collectImportedRefNames(createSchema({ type: 'string' }))).toStrictEqual([])
+  })
+
+  it('memoizes by node identity so the same node yields the same array reference', () => {
+    const schema = createSchema({
+      type: 'object',
+      name: 'Pet',
+      properties: [
+        createProperty({ name: 'category', required: false, schema: createSchema({ type: 'ref', name: 'Category', ref: '#/components/schemas/Category' }) }),
+      ],
+    })
+
+    expect(collectImportedRefNames(schema)).toBe(collectImportedRefNames(schema))
   })
 })
 

--- a/packages/ast/src/utils/schemaGraph.ts
+++ b/packages/ast/src/utils/schemaGraph.ts
@@ -45,6 +45,39 @@ export function collectReferencedSchemaNames(node: SchemaNode | undefined, out: 
   return out
 }
 
+/**
+ * Collects the de-duplicated target names of every pointer-carrying ref in a node's subtree, in
+ * first-occurrence order. The walk is memoized by node identity, so the subtree is scanned once and
+ * `resolver.imports` reads the same result across the ts, zod, and faker plugins instead of
+ * re-scanning the same schema per plugin.
+ *
+ * Only refs that carry a `$ref` pointer count, so a synthesized ref pointing at a sibling in the
+ * same file (a union member created by name) is left out. That leaves exactly the set
+ * `resolver.imports` emits. This is the ordered, import-facing counterpart to
+ * {@link collectReferencedSchemaNames}, which returns an unordered set for graph analysis.
+ *
+ * @example
+ * ```ts
+ * collectImportedRefNames(petSchema)
+ * // ['Category', 'Tag']
+ * ```
+ */
+export const collectImportedRefNames = memoize(new WeakMap<SchemaNode, ReadonlyArray<string>>(), (node: SchemaNode): ReadonlyArray<string> => {
+  const seen = new Set<string>()
+  const names: Array<string> = []
+  collectSync<void>(node, {
+    schema(child) {
+      if (child.type !== 'ref' || !child.ref) return
+      const name = resolveRefName(child)
+      if (name && !seen.has(name)) {
+        seen.add(name)
+        names.push(name)
+      }
+    },
+  })
+  return names
+})
+
 function computeUsedSchemaNames(operations: ReadonlyArray<OperationNode>, schemas: ReadonlyArray<SchemaNode>): Set<string> {
   const schemaMap = new Map<string, SchemaNode>()
   for (const schema of schemas) {

--- a/packages/core/src/Resolver.ts
+++ b/packages/core/src/Resolver.ts
@@ -2,10 +2,8 @@ import path from 'node:path'
 import { camelCase, toFilePath } from '@internals/utils'
 import {
   ast,
-  collectSync,
-  narrowSchema,
+  collectImportedRefNames,
   operationDef,
-  resolveRefName,
   schemaDef,
   type FileNode,
   type ImportNode,
@@ -386,27 +384,21 @@ export class Resolver {
    * schemas (`targetName`) import the emitted name. Names and paths go through the top-level
    * `name` and `file`, so import entries follow the plugin's conventions, and a per-call
    * `name` override wins over both.
+   *
+   * The subtree scan runs through `collectImportedRefNames`, which memoizes by node identity, so a
+   * schema shared across the ts, zod, and faker plugins is walked once and every plugin's resolver
+   * reads the same ref set instead of re-scanning it per plugin.
    */
   imports(options: ResolveImportsOptions): Array<ImportNode> {
     const { node, root, output, group, extname = '.ts', name } = options
     const resolveName = name ?? ((schemaName: string) => this.name(schemaName))
 
-    const seen = new Set<string>()
-    return collectSync(node, {
-      schema: (schemaNode) => {
-        const schemaRef = narrowSchema(schemaNode, 'ref')
-        if (!schemaRef?.ref) return null
-
-        const schemaName = resolveRefName(schemaRef)
-        if (!schemaName || seen.has(schemaName)) return null
-        seen.add(schemaName)
-
-        return ast.factory.createImport({
-          name: [resolveName(schemaName)],
-          path: this.file({ name: schemaName, extname, root, output, group }).path,
-        })
-      },
-    })
+    return collectImportedRefNames(node).map((schemaName) =>
+      ast.factory.createImport({
+        name: [resolveName(schemaName)],
+        path: this.file({ name: schemaName, extname, root, output, group }).path,
+      }),
+    )
   }
 
   /**


### PR DESCRIPTION
## 🎯 Changes

Closes #3814.

`resolver.imports` walked a node's whole schema subtree for `$ref`s on every call. Ref resolution was already memoized, but the subtree scan itself was redone once per schema and per operation, independently in each plugin (ts, zod, faker), so the same `Pet` schema got re-scanned three times.

The scan now runs through a new `collectImportedRefNames` helper in `@kubb/ast` that memoizes the ordered ref set by node identity. It uses a module-level `WeakMap<SchemaNode, ReadonlyArray<string>>`, the same pattern `collectSchemaRefs` and `findCircularSchemas` already use. The adapter parses the spec into one shared `InputNode` that every plugin reads, so a schema node handed to `resolver.imports` is walked once total and every plugin's resolver reads the same cached result.

`@kubb/ast` gains `collectImportedRefNames(node)`, the ordered, import-facing counterpart to `collectReferencedSchemaNames` (which stays the unordered set used for graph analysis). In `@kubb/core`, `Resolver.imports` maps the memoized names onto `ImportNode`s instead of re-scanning per call.

Import output stays byte-identical. Only refs carrying a `$ref` pointer are counted (a synthesized union member pointing at a sibling in the same file is still skipped), in first-occurrence order and de-duplicated. The change lives entirely in `@kubb/ast` and `@kubb/core`, so plugins call `resolver.imports` transparently with no code changes.

### Design note

The issue proposed exposing the precomputed set on `InputMeta`. I used node-identity memoization instead. It keeps `InputMeta` JSON-serializable per its documented contract, matches the existing shared-cache pattern in `schemaGraph.ts`, and also covers shared sub-schema nodes rather than only named top-level schemas. The net effect is the same. The subtree is scanned once and shared across every plugin.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

Added `collectImportedRefNames` unit tests (order, dedup, `targetName`, pointer-less refs, memoization by identity), and the existing `resolver.imports` parity tests still pass. The `@kubb/ast` (209), `@kubb/core` (263), and `@kubb/adapter-oas` (486) suites are green, with `typecheck`, `lint`, and `oxfmt` clean across the touched packages.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)