### PR TITLE
perf(adapter-oas): fold schema diagnostics and circular detection into one convert walk

### DIFF
--- a/.changeset/adapter-oas-single-convert-scan.md
+++ b/.changeset/adapter-oas-single-convert-scan.md
@@ -5,6 +5,6 @@
 
 Fold schema diagnostics and circular detection into a single convert walk.
 
-The adapter used to sweep every freshly parsed schema three times: once to report the advisory diagnostics (`KUBB_UNSUPPORTED_FORMAT`, `KUBB_DEPRECATED`), again to collect referenced names for `findCircularSchemas`, and the graph build itself. The diagnostics walk now also collects each schema's outbound refs, so circular detection reads the collected graph instead of walking the same nodes again.
+The adapter walked every freshly parsed schema twice: once to report the advisory diagnostics (`KUBB_UNSUPPORTED_FORMAT`, `KUBB_DEPRECATED`), then again inside `findCircularSchemas` to collect the names each schema references. The diagnostics walk now gathers those names in the same pass, and circular detection reads that graph instead of sweeping the nodes again.
 
-Add `findCircularSchemasFromGraph` to `@kubb/ast`, which runs cycle detection over a pre-built name-to-refs graph. `findCircularSchemas` now builds the graph and delegates to it, so both share one implementation. Generated output is unchanged.
+`@kubb/ast` gains `findCircularSchemasFromGraph`, which runs cycle detection over a pre-built name-to-refs graph. `findCircularSchemas` builds the graph and hands off to it, so both share one implementation. Generated output does not change.

--- a/.changeset/adapter-oas-single-convert-scan.md
+++ b/.changeset/adapter-oas-single-convert-scan.md
@@ -1,0 +1,10 @@
+---
+'@kubb/adapter-oas': patch
+'@kubb/ast': minor
+---
+
+Fold schema diagnostics and circular detection into a single convert walk.
+
+The adapter used to sweep every freshly parsed schema three times: once to report the advisory diagnostics (`KUBB_UNSUPPORTED_FORMAT`, `KUBB_DEPRECATED`), again to collect referenced names for `findCircularSchemas`, and the graph build itself. The diagnostics walk now also collects each schema's outbound refs, so circular detection reads the collected graph instead of walking the same nodes again.
+
+Add `findCircularSchemasFromGraph` to `@kubb/ast`, which runs cycle detection over a pre-built name-to-refs graph. `findCircularSchemas` now builds the graph and delegates to it, so both share one implementation. Generated output is unchanged.

--- a/packages/adapter-oas/src/adapter.bench.ts
+++ b/packages/adapter-oas/src/adapter.bench.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import { findCircularSchemasFromGraph } from '@kubb/ast'
 import { bench, describe } from 'vitest'
 import { DEFAULT_PARSER_OPTIONS } from './constants.ts'
 import { parseDocument } from './load/normalize.ts'
@@ -6,6 +7,7 @@ import { getSchemas } from './model/components.ts'
 import { getOperations } from './operation.ts'
 import { createSchemaParser } from './parser.ts'
 import { createRefs } from './refs.ts'
+import { scanSchema } from './schemaDiagnostics.ts'
 import type { Document } from './types.ts'
 
 const petStorePath = path.resolve(import.meta.dirname, '../mocks/petStore.yaml')
@@ -19,12 +21,21 @@ async function getPetStoreDocument(): Promise<Document> {
   return petStoreDoc
 }
 
+// Mirrors the adapter's convert pass: parse each schema, then in the same walk report diagnostics
+// and collect its outbound refs, so circular detection reads the collected graph instead of sweeping
+// the nodes a second time.
 function parseOas(document: Document): void {
   const refs = createRefs(document)
   const { schemas: schemaObjects } = getSchemas(document, {}, refs)
   const { parseSchema, parseOperation } = createSchemaParser({ document, refs })
 
-  for (const [name, schema] of Object.entries(schemaObjects)) parseSchema({ schema, name }, DEFAULT_PARSER_OPTIONS)
+  const graph = new Map<string, Set<string>>()
+  for (const [name, schema] of Object.entries(schemaObjects)) {
+    const node = parseSchema({ schema, name }, DEFAULT_PARSER_OPTIONS)
+    if (node.name) graph.set(node.name, scanSchema({ node, name }))
+  }
+  findCircularSchemasFromGraph(graph)
+
   for (const operation of getOperations(document, refs)) parseOperation(DEFAULT_PARSER_OPTIONS, operation)
 }
 

--- a/packages/adapter-oas/src/adapter.ts
+++ b/packages/adapter-oas/src/adapter.ts
@@ -1,4 +1,4 @@
-import { ast, findCircularSchemas, narrowSchema } from '@kubb/ast'
+import { ast, findCircularSchemasFromGraph, narrowSchema } from '@kubb/ast'
 import { createAdapter } from '@kubb/core'
 import type { AdapterSource } from '@kubb/core'
 import { DEFAULT_PARSER_OPTIONS } from './constants.ts'
@@ -12,7 +12,7 @@ import { getOperations } from './operation.ts'
 import { createSchemaParser } from './parser.ts'
 import { collectInlineEnums, refPromotedEnums } from './promoteEnums.ts'
 import { createRefs } from './refs.ts'
-import { reportSchemaDiagnostics } from './schemaDiagnostics.ts'
+import { scanSchema } from './schemaDiagnostics.ts'
 import type { AdapterOas, Document, SchemaObject } from './types.ts'
 
 /**
@@ -97,11 +97,15 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
     const refAliasMap = new Map<string, ast.SchemaNode>()
     const enumNames: Array<string> = []
     const discriminatorParentNodes: Array<ast.SchemaNode> = []
+    // Built from the same walk that reports diagnostics: each schema maps to the names it references,
+    // so circular detection reads this graph instead of sweeping the nodes again.
+    const refGraph = new Map<string, Set<string>>()
 
     for (const [name, schema] of Object.entries(schemas)) {
       const node = parseSchema({ schema, name }, parserOptions)
       parsedByName.set(name, node)
-      reportSchemaDiagnostics({ node, name })
+      const refs = scanSchema({ node, name })
+      if (node.name) refGraph.set(node.name, refs)
       if (node.type === 'ref' && node.name && node.name !== name) {
         refAliasMap.set(name, node)
       }
@@ -113,7 +117,7 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
       }
     }
 
-    const circularNames = [...findCircularSchemas([...parsedByName.values()])]
+    const circularNames = [...findCircularSchemasFromGraph(refGraph)]
     const discriminatorChildMap: Map<string, DiscriminatorTarget> | null =
       discriminatorParentNodes.length > 0 ? buildDiscriminatorChildMap(discriminatorParentNodes) : null
 

--- a/packages/adapter-oas/src/schemaDiagnostics.test.ts
+++ b/packages/adapter-oas/src/schemaDiagnostics.test.ts
@@ -1,7 +1,9 @@
+import { ast } from '@kubb/ast'
 import { type Diagnostic, Diagnostics } from '@kubb/core'
 import { describe, expect, it } from 'vitest'
 import { adapterOas } from './adapter.ts'
 import { formatMap, specialCasedFormats } from './constants.ts'
+import { scanSchema } from './schemaDiagnostics.ts'
 
 const spec = {
   openapi: '3.0.3',
@@ -116,5 +118,42 @@ describe('schema diagnostics during parse', () => {
     const diagnostics = await collect(allFormats)
 
     expect(diagnostics.filter((diagnostic) => diagnostic.code === 'KUBB_UNSUPPORTED_FORMAT')).toHaveLength(0)
+  })
+})
+
+describe('scanSchema referenced names', () => {
+  it('collects ref names nested in properties, arrays and unions in one walk', () => {
+    const node = ast.factory.createSchema({
+      type: 'object',
+      name: 'Pet',
+      properties: [
+        ast.factory.createProperty({
+          name: 'category',
+          required: false,
+          schema: ast.factory.createSchema({ type: 'ref', name: 'Category', ref: '#/components/schemas/Category' }),
+        }),
+        ast.factory.createProperty({
+          name: 'tags',
+          required: false,
+          schema: ast.factory.createSchema({ type: 'array', items: [ast.factory.createSchema({ type: 'ref', name: 'Tag', ref: '#/components/schemas/Tag' })] }),
+        }),
+        ast.factory.createProperty({
+          name: 'owner',
+          required: false,
+          schema: ast.factory.createSchema({
+            type: 'union',
+            members: [ast.factory.createSchema({ type: 'null' }), ast.factory.createSchema({ type: 'ref', name: 'User', ref: '#/components/schemas/User' })],
+          }),
+        }),
+      ],
+    })
+
+    expect(scanSchema({ node, name: 'Pet' })).toStrictEqual(new Set(['Category', 'Tag', 'User']))
+  })
+
+  it('returns an empty set for a schema without refs', () => {
+    const node = ast.factory.createSchema({ type: 'string' })
+
+    expect(scanSchema({ node, name: 'Name' })).toStrictEqual(new Set())
   })
 })

--- a/packages/adapter-oas/src/schemaDiagnostics.ts
+++ b/packages/adapter-oas/src/schemaDiagnostics.ts
@@ -1,17 +1,23 @@
+import { resolveRefName } from '@kubb/ast'
 import type { ast } from '@kubb/ast'
 import { Diagnostics } from '@kubb/core'
 import { isHandledFormat } from './emit/schemaShape.ts'
 
 /**
- * Reports the advisory diagnostics (`KUBB_UNSUPPORTED_FORMAT`, `KUBB_DEPRECATED`) for one
- * top-level schema. Walks the node the parser produced, threading the RFC 6901
- * pointer as it descends so a nested field reports against its full path
- * (`#/components/schemas/Pet/properties/owner/properties/name`). Refs are not followed, so the
- * resolved schema is reported under its own walk. Reports land in the active build run, are a
- * no-op outside one, and repeats are deduped by the build.
+ * Scans one freshly converted top-level schema in a single walk, so the post-convert pass never
+ * sweeps the same nodes twice. It reports the advisory diagnostics (`KUBB_UNSUPPORTED_FORMAT`,
+ * `KUBB_DEPRECATED`) and returns the names of every schema the node references, ready to feed the
+ * circular-dependency graph.
+ *
+ * Walks the node the parser produced, threading the RFC 6901 pointer as it descends so a nested
+ * field reports against its full path (`#/components/schemas/Pet/properties/owner/properties/name`).
+ * Refs are recorded by name and not followed, so the resolved schema is reported under its own walk.
+ * Reports land in the active build run, are a no-op outside one, and repeats are deduped by the build.
  */
-export function reportSchemaDiagnostics({ node, name }: { node: ast.SchemaNode; name: string }): void {
-  visit(node, `#/components/schemas/${escapePointerToken(name)}`)
+export function scanSchema({ node, name }: { node: ast.SchemaNode; name: string }): Set<string> {
+  const refs = new Set<string>()
+  visit(node, `#/components/schemas/${escapePointerToken(name)}`, refs)
+  return refs
 }
 
 /**
@@ -22,7 +28,12 @@ function escapePointerToken(token: string): string {
   return token.replace(/~/g, '~0').replace(/\//g, '~1')
 }
 
-function visit(node: ast.SchemaNode, pointer: string): void {
+function visit(node: ast.SchemaNode, pointer: string, refs: Set<string>): void {
+  if (node.type === 'ref') {
+    const refName = resolveRefName(node)
+    if (refName) refs.add(refName)
+  }
+
   if (node.deprecated) {
     Diagnostics.report({
       code: Diagnostics.code.deprecated,
@@ -44,17 +55,17 @@ function visit(node: ast.SchemaNode, pointer: string): void {
 
   if (node.type === 'object') {
     for (const property of node.properties) {
-      visit(property.schema, `${pointer}/properties/${escapePointerToken(property.name)}`)
+      visit(property.schema, `${pointer}/properties/${escapePointerToken(property.name)}`, refs)
     }
     if (node.additionalProperties && typeof node.additionalProperties === 'object') {
-      visit(node.additionalProperties, `${pointer}/additionalProperties`)
+      visit(node.additionalProperties, `${pointer}/additionalProperties`, refs)
     }
     return
   }
 
   if (node.type === 'array') {
     for (const item of node.items ?? []) {
-      visit(item, `${pointer}/items`)
+      visit(item, `${pointer}/items`, refs)
     }
     return
   }
@@ -63,14 +74,14 @@ function visit(node: ast.SchemaNode, pointer: string): void {
     // Each tuple position has its own pointer, so index them. A shared `/items` would collapse
     // distinct diagnostics in the dedupe.
     for (const [index, item] of (node.items ?? []).entries()) {
-      visit(item, `${pointer}/items/${index}`)
+      visit(item, `${pointer}/items/${index}`, refs)
     }
     return
   }
 
   if (node.type === 'union' || node.type === 'intersection') {
     for (const [index, member] of (node.members ?? []).entries()) {
-      visit(member, `${pointer}/members/${index}`)
+      visit(member, `${pointer}/members/${index}`, refs)
     }
   }
 }

--- a/packages/ast/src/utils/index.ts
+++ b/packages/ast/src/utils/index.ts
@@ -1,4 +1,4 @@
 export { combineExports, combineImports, combineSources } from './combineFileMembers.ts'
 export { extractStringsFromNodes } from './extractStringsFromNodes.ts'
 export { resolveRefName } from './refs.ts'
-export { collectUsedSchemaNames, findCircularSchemas } from './schemaGraph.ts'
+export { collectUsedSchemaNames, findCircularSchemas, findCircularSchemasFromGraph } from './schemaGraph.ts'

--- a/packages/ast/src/utils/schemaGraph.test.ts
+++ b/packages/ast/src/utils/schemaGraph.test.ts
@@ -5,7 +5,7 @@ import { createParameter } from '../nodes/parameter.ts'
 import { createProperty } from '../nodes/property.ts'
 import { createResponse } from '../nodes/response.ts'
 import { createSchema } from '../nodes/schema.ts'
-import { collectReferencedSchemaNames, collectUsedSchemaNames, findCircularSchemas } from './schemaGraph.ts'
+import { collectReferencedSchemaNames, collectUsedSchemaNames, findCircularSchemas, findCircularSchemasFromGraph } from './schemaGraph.ts'
 
 describe('findCircularSchemas', () => {
   it('returns empty set for acyclic schemas', () => {
@@ -94,6 +94,52 @@ describe('findCircularSchemas', () => {
   it('skips unnamed schemas', () => {
     const anon = createSchema({ type: 'object' })
     expect(findCircularSchemas([anon])).toStrictEqual(new Set())
+  })
+})
+
+describe('findCircularSchemasFromGraph', () => {
+  it('returns an empty set for an acyclic graph', () => {
+    const graph = new Map([
+      ['Pet', new Set(['Category'])],
+      ['Category', new Set<string>()],
+    ])
+
+    expect(findCircularSchemasFromGraph(graph)).toStrictEqual(new Set())
+  })
+
+  it('detects a direct self-loop', () => {
+    const graph = new Map([['TreeNode', new Set(['TreeNode'])]])
+
+    expect(findCircularSchemasFromGraph(graph)).toStrictEqual(new Set(['TreeNode']))
+  })
+
+  it('detects an indirect cycle and leaves non-participants out', () => {
+    const graph = new Map([
+      ['Pet', new Set(['Cat'])],
+      ['Cat', new Set(['Pet'])],
+      ['Owner', new Set(['Pet'])],
+    ])
+    const result = findCircularSchemasFromGraph(graph)
+
+    expect(result).toStrictEqual(new Set(['Pet', 'Cat']))
+    expect(result.has('Owner')).toBe(false)
+  })
+
+  it('matches findCircularSchemas when fed a graph collected from the same schemas', () => {
+    const A = createSchema({
+      type: 'object',
+      name: 'A',
+      properties: [createProperty({ name: 'self', required: false, schema: createSchema({ type: 'ref', name: 'A', ref: '#/components/schemas/A' }) })],
+    })
+    const B = createSchema({
+      type: 'object',
+      name: 'B',
+      properties: [createProperty({ name: 'a', required: false, schema: createSchema({ type: 'ref', name: 'A', ref: '#/components/schemas/A' }) })],
+    })
+
+    const graph = new Map([A, B].map((schema) => [schema.name!, collectReferencedSchemaNames(schema)] as const))
+
+    expect(findCircularSchemasFromGraph(graph)).toStrictEqual(findCircularSchemas([A, B]))
   })
 })
 

--- a/packages/ast/src/utils/schemaGraph.ts
+++ b/packages/ast/src/utils/schemaGraph.ts
@@ -99,14 +99,24 @@ export function collectUsedSchemaNames(operations: ReadonlyArray<OperationNode>,
 
 const EMPTY_CIRCULAR_SET = new Set<string>()
 
-const findCircularSchemasMemo = memoize(new WeakMap<ReadonlyArray<SchemaNode>, Set<string>>(), (schemas: ReadonlyArray<SchemaNode>): Set<string> => {
-  const graph = new Map<string, Set<string>>()
-
-  for (const schema of schemas) {
-    if (!schema.name) continue
-    graph.set(schema.name, collectReferencedSchemaNames(schema))
-  }
-
+/**
+ * Finds every schema that takes part in a circular dependency chain in a schema dependency graph
+ * that maps each schema name to the names it references directly.
+ *
+ * Use this when the graph was already collected during another pass (e.g. the adapter's convert
+ * walk), so the schema nodes are not swept a second time. `findCircularSchemas` builds the graph
+ * from schema nodes and delegates here.
+ *
+ * @example
+ * ```ts
+ * const graph = new Map([
+ *   ['Pet', new Set(['Category'])],
+ *   ['Category', new Set(['Pet'])],
+ * ])
+ * findCircularSchemasFromGraph(graph) // Set { 'Pet', 'Category' }
+ * ```
+ */
+export function findCircularSchemasFromGraph(graph: ReadonlyMap<string, ReadonlySet<string>>): Set<string> {
   const circular = new Set<string>()
   for (const start of graph.keys()) {
     const visited = new Set<string>()
@@ -126,6 +136,17 @@ const findCircularSchemasMemo = memoize(new WeakMap<ReadonlyArray<SchemaNode>, S
   }
 
   return circular
+}
+
+const findCircularSchemasMemo = memoize(new WeakMap<ReadonlyArray<SchemaNode>, Set<string>>(), (schemas: ReadonlyArray<SchemaNode>): Set<string> => {
+  const graph = new Map<string, Set<string>>()
+
+  for (const schema of schemas) {
+    if (!schema.name) continue
+    graph.set(schema.name, collectReferencedSchemaNames(schema))
+  }
+
+  return findCircularSchemasFromGraph(graph)
 })
 
 /**


### PR DESCRIPTION
## 🎯 Changes

Closes #3819.

The adapter walked every freshly parsed schema twice: once to report the advisory diagnostics (`KUBB_UNSUPPORTED_FORMAT`, `KUBB_DEPRECATED`), then again inside `findCircularSchemas` to collect the names each schema references.

This folds the two into one traversal. `reportSchemaDiagnostics` becomes `scanSchema`, which reports the same diagnostics and returns the names each schema references. The adapter assembles those into the circular-dependency graph during the same loop, so the nodes are never swept a second time.

`@kubb/ast` gains `findCircularSchemasFromGraph`, which runs cycle detection over a pre-built name-to-refs graph. `findCircularSchemas` now builds the graph from schema nodes and hands off to it, so both share one implementation. `validate` stays opt-out through `validate: false`, as before.

Generated output does not change. Parity of `circularNames` was checked against the previous `findCircularSchemas` path on the petStore spec and on a synthetic circular spec, and `adapter.bench.ts` now exercises the folded scan so the convert pass stays measurable.

### Files

- `packages/adapter-oas/src/schemaDiagnostics.ts`: `scanSchema` reports diagnostics and returns referenced names in one walk.
- `packages/adapter-oas/src/adapter.ts`: builds the ref graph in the convert loop and calls `findCircularSchemasFromGraph`.
- `packages/ast/src/utils/schemaGraph.ts`: adds `findCircularSchemasFromGraph`; `findCircularSchemas` hands off to it.
- `packages/adapter-oas/src/adapter.bench.ts`: benchmarks the full convert scan (parse, diagnostics, refs, circular).
- Tests for both new behaviors, plus a changeset.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012TngUoKD2cTxBkrK1Ct53V