### PR TITLE
feat(core,ast): add a match predicate to Generator, aligned with Macro

### DIFF
--- a/.changeset/core-generator-match-predicate.md
+++ b/.changeset/core-generator-match-predicate.md
@@ -1,0 +1,7 @@
+---
+'@kubb/core': minor
+---
+
+Add an optional `match` predicate to `Generator` (`defineGenerator`). Return `false` from `match(node, ctx)` to skip a generator's `schema`/`operation` call for a given node entirely, with no context work beyond what the driver already builds per node and no render call, instead of the generator being invoked and returning early. Omit it to run for every node, the existing default behavior — this is purely additive.
+
+This lets a generator declare its own scope declaratively instead of always running. A plugin that registers several generators for the same node type (for example one hook generator per query variant) can now let each one opt in with `match` rather than hand-rolling a dispatcher that classifies the node once and manually renders the matching generator's output.

--- a/.changeset/core-generator-match-predicate.md
+++ b/.changeset/core-generator-match-predicate.md
@@ -2,6 +2,6 @@
 '@kubb/core': minor
 ---
 
-Add an optional `match` predicate to `Generator` (`defineGenerator`). Return `false` from `match(node, ctx)` to skip a generator's `schema`/`operation` call for a given node entirely, with no context work beyond what the driver already builds per node and no render call, instead of the generator being invoked and returning early. Omit it to run for every node, the existing default behavior — this is purely additive.
+Add an optional `match` predicate to `Generator`. When `match(node, ctx)` returns `false`, the driver skips that node's `schema`/`operation` call entirely, instead of invoking the generator and letting it return early itself. Omit `match` to keep running for every node, so this is purely additive.
 
-This lets a generator declare its own scope declaratively instead of always running. A plugin that registers several generators for the same node type (for example one hook generator per query variant) can now let each one opt in with `match` rather than hand-rolling a dispatcher that classifies the node once and manually renders the matching generator's output.
+This lets a generator declare its own scope instead of a plugin hand-rolling a dispatcher when several generators target the same node type but only one should run per node.

--- a/.changeset/macro-ast-transform-layer.md
+++ b/.changeset/macro-ast-transform-layer.md
@@ -6,7 +6,7 @@
 
 Add macros, a named and composable way to rewrite the AST, and make them the single transform layer.
 
-`defineMacro`, `composeMacros`, and `applyMacros` live on the `@kubb/ast` root and turn an anonymous transform into a named unit with an optional `enforce` order and a `when` gate. Macros follow the `macro<Name>` convention, mirroring plugins (`pluginTs`). The built-in presets live on the new `@kubb/ast/macros` subpath, one file per macro. Plugins register macros through the new `addMacro` and `setMacros` setup-context methods in `@kubb/core`, replacing the old `setTransformer`.
+`defineMacro`, `composeMacros`, and `applyMacros` live on the `@kubb/ast` root and turn an anonymous transform into a named unit with an optional `enforce` order and a `match` predicate. Macros follow the `macro<Name>` convention, mirroring plugins (`pluginTs`). The built-in presets live on the new `@kubb/ast/macros` subpath, one file per macro. Plugins register macros through the new `addMacro` and `setMacros` setup-context methods in `@kubb/core`, replacing the old `setTransformer`.
 
 The plugin `transformer?: Visitor` field is gone, and `createMockedPlugin` from `@kubb/core/mocks` takes `macros` instead of a `transformer` visitor.
 

--- a/packages/ast/src/defineMacro.test.ts
+++ b/packages/ast/src/defineMacro.test.ts
@@ -32,11 +32,11 @@ describe('composeMacros', () => {
     expect(order).toEqual(['pre', 'plain', 'post'])
   })
 
-  it('skips a macro when its `when` gate returns false', () => {
+  it('skips a macro when its `match` predicate returns false', () => {
     const root = createSchema({ type: 'integer' })
     const macro = defineMacro({
       name: 'only-string',
-      when: (node) => 'type' in node && node.type === 'string',
+      match: (node) => 'type' in node && node.type === 'string',
       schema: (node) => ({ ...node, description: 'touched' }),
     })
 

--- a/packages/ast/src/defineMacro.ts
+++ b/packages/ast/src/defineMacro.ts
@@ -24,8 +24,8 @@ function enforceWeight(enforce?: Enforce): number {
 /**
  * A named, composable transform over the Kubb AST. It carries the same per-kind callbacks as a
  * {@link Visitor} (`schema`, `operation`, …), plus a `name`, an optional `enforce` order, and an
- * optional `when` gate. Macros run on the shared AST, so the same macro works across every adapter
- * and output target. Exports follow the `macro<Name>` convention, mirroring plugins (`pluginTs`).
+ * optional `match` predicate. Macros run on the shared AST, so the same macro works across every
+ * adapter and output target. Exports follow the `macro<Name>` convention, mirroring plugins (`pluginTs`).
  */
 export type Macro = Visitor & {
   /**
@@ -38,10 +38,10 @@ export type Macro = Visitor & {
    */
   enforce?: Enforce
   /**
-   * Gate checked against the current node before any callback runs. When it returns `false`
-   * the macro is skipped for that node.
+   * Predicate checked against the current node before any callback runs. Returning `false`
+   * skips the macro for that node.
    */
-  when?: (node: Node) => boolean
+  match?: (node: Node) => boolean
 }
 
 /**
@@ -82,7 +82,7 @@ function chain({ macros, key, node, context }: ChainProps): Node | undefined {
   for (const macro of macros) {
     const callback = macro[key] as MacroCallback | undefined
     if (!callback) continue
-    if (macro.when && !macro.when(current)) continue
+    if (macro.match && !macro.match(current)) continue
 
     const next = callback(current, context)
     if (next != null) current = next

--- a/packages/core/src/KubbDriver.test.ts
+++ b/packages/core/src/KubbDriver.test.ts
@@ -527,4 +527,88 @@ describe('KubbDriver generator dispatch', () => {
     expect((normalized as Record<string, unknown>).enumType).toBe('asConst')
     localHooks.removeAllHooks()
   })
+
+  it("skips a generator's schema and operation calls for a node its match resolves false for, and still calls them when true", async () => {
+    rec = { schema: [], operation: [], operations: [] }
+    hooks = new Hookable<KubbHooks>()
+    const petOnly: Generator = {
+      ...recordingGenerator('petOnly', rec),
+      match: (node) => ('operationId' in node ? node.operationId === 'getPet' : node.name === 'Pet'),
+    }
+    const plugin = {
+      name: 'petOnlyPlugin',
+      hooks: {
+        'kubb:plugin:setup'(ctx: KubbPluginSetupContext) {
+          ctx.addGenerator(petOnly)
+        },
+      },
+    } as unknown as Plugin
+    const config = {
+      root: '.',
+      input: { path: './petStore.yaml' },
+      output: { path: './gen' },
+      parsers: [],
+      reporters: [],
+      adapter: inputAdapter(),
+      plugins: [plugin],
+      storage: memoryStorage(),
+    } satisfies Config
+    const matchDriver = new KubbDriver(config, { hooks })
+    await matchDriver.setup()
+    await matchDriver.run()
+
+    expect(rec.schema).toStrictEqual([{ plugin: 'petOnlyPlugin', name: 'Pet' }])
+    expect(rec.operation).toStrictEqual([{ plugin: 'petOnlyPlugin', id: 'getPet' }])
+    hooks.removeAllHooks()
+  })
+
+  it('filters per generator, not per plugin, when a matched and an unmatched generator share a plugin', async () => {
+    rec = { schema: [], operation: [], operations: [] }
+    hooks = new Hookable<KubbHooks>()
+    // Operation-only generators (no `schema`/`operations`) so the emitted file set below only
+    // reflects the operation loop's match filtering, with no schema/batch noise to account for.
+    const matched: Generator = {
+      name: 'matched-gen',
+      match: (node) => ('operationId' in node ? node.operationId === 'getPet' : true),
+      operation(node: OperationNode, ctx: GeneratorContext) {
+        rec.operation.push({ plugin: ctx.plugin.name, id: node.operationId })
+        return [fileNode(`matched/op-${node.operationId}.ts`)]
+      },
+    }
+    const unmatched: Generator = {
+      name: 'unmatched-gen',
+      operation(node: OperationNode, ctx: GeneratorContext) {
+        rec.operation.push({ plugin: ctx.plugin.name, id: node.operationId })
+        return [fileNode(`unmatched/op-${node.operationId}.ts`)]
+      },
+    }
+    const plugin = {
+      name: 'mixedPlugin',
+      hooks: {
+        'kubb:plugin:setup'(ctx: KubbPluginSetupContext) {
+          ctx.addGenerator(matched, unmatched)
+        },
+      },
+    } as unknown as Plugin
+    const config = {
+      root: '.',
+      input: { path: './petStore.yaml' },
+      output: { path: './gen' },
+      parsers: [],
+      reporters: [],
+      adapter: inputAdapter(),
+      plugins: [plugin],
+      storage: memoryStorage(),
+    } satisfies Config
+    const mixedDriver = new KubbDriver(config, { hooks })
+    await mixedDriver.setup()
+    await mixedDriver.run()
+
+    expect(mixedDriver.fileManager.files.map((file) => file.path).sort()).toStrictEqual([
+      'matched/op-getPet.ts',
+      'unmatched/op-getPet.ts',
+      'unmatched/op-listPets.ts',
+    ])
+    hooks.removeAllHooks()
+  })
 })

--- a/packages/core/src/KubbDriver.test.ts
+++ b/packages/core/src/KubbDriver.test.ts
@@ -528,7 +528,7 @@ describe('KubbDriver generator dispatch', () => {
     localHooks.removeAllHooks()
   })
 
-  it("skips a generator's schema and operation calls for a node its match resolves false for, and still calls them when true", async () => {
+  it("skips a generator's schema and operation calls for a node its match predicate resolves false for, and still calls them when true", async () => {
     rec = { schema: [], operation: [], operations: [] }
     hooks = new Hookable<KubbHooks>()
     const petOnly: Generator = {

--- a/packages/core/src/KubbDriver.ts
+++ b/packages/core/src/KubbDriver.ts
@@ -409,7 +409,8 @@ export class KubbDriver {
    * Runs schemas and operations through every plugin's generators. Each node is run
    * through the plugin's macros (from `this.#transforms`) before the generator sees it,
    * so plugins stay isolated and the hot path stays per-node. Schemas run before operations
-   * so file output stays deterministic across runs.
+   * so file output stays deterministic across runs. A generator with a `match` predicate that
+   * resolves `false` for a node is skipped for that node, without calling `schema`/`operation`.
    * A failing plugin contributes an error diagnostic so the rest of the build continues.
    * Every plugin also contributes a `timing` diagnostic.
    *
@@ -505,6 +506,7 @@ export class KubbDriver {
 
             const ctx = { ...generatorContext, options }
             for (const generator of schemaGenerators) {
+              if (generator.match && !(await generator.match(transformedNode, ctx))) continue
               await this.dispatch({ result: await generator.schema!(transformedNode, ctx), renderer: generator.renderer })
             }
             await this.hooks.callHook('kubb:generate:schema', transformedNode, ctx)
@@ -529,6 +531,7 @@ export class KubbDriver {
             if (operationGenerators.length) {
               const ctx = { ...generatorContext, options: resolved.options }
               for (const generator of operationGenerators) {
+                if (generator.match && !(await generator.match(resolved.transformedNode, ctx))) continue
                 await this.dispatch({ result: await generator.operation!(resolved.transformedNode, ctx), renderer: generator.renderer })
               }
               await this.hooks.callHook('kubb:generate:operation', resolved.transformedNode, ctx)

--- a/packages/core/src/KubbDriver.ts
+++ b/packages/core/src/KubbDriver.ts
@@ -506,7 +506,8 @@ export class KubbDriver {
 
             const ctx = { ...generatorContext, options }
             for (const generator of schemaGenerators) {
-              if (generator.match && !(await generator.match(transformedNode, ctx))) continue
+              const matches = generator.match ? await generator.match(transformedNode, ctx) : true
+              if (!matches) continue
               await this.dispatch({ result: await generator.schema!(transformedNode, ctx), renderer: generator.renderer })
             }
             await this.hooks.callHook('kubb:generate:schema', transformedNode, ctx)
@@ -531,7 +532,8 @@ export class KubbDriver {
             if (operationGenerators.length) {
               const ctx = { ...generatorContext, options: resolved.options }
               for (const generator of operationGenerators) {
-                if (generator.match && !(await generator.match(resolved.transformedNode, ctx))) continue
+                const matches = generator.match ? await generator.match(resolved.transformedNode, ctx) : true
+                if (!matches) continue
                 await this.dispatch({ result: await generator.operation!(resolved.transformedNode, ctx), renderer: generator.renderer })
               }
               await this.hooks.callHook('kubb:generate:operation', resolved.transformedNode, ctx)

--- a/packages/core/src/defineGenerator.ts
+++ b/packages/core/src/defineGenerator.ts
@@ -154,10 +154,11 @@ export type Generator<TOptions extends PluginFactoryOptions = PluginFactoryOptio
    */
   renderer?: RendererFactory<TElement> | null
   /**
-   * Optional predicate checked before `schema` or `operation` runs for a node. Returning `false`
-   * skips the call for that node entirely, with no context work beyond what the driver already
-   * builds per node and no render call, instead of the generator itself being invoked and
-   * returning early. Omit it to run for every node, the default when unset.
+   * Predicate checked before `schema` or `operation` runs for a node, mirroring `Macro['match']`
+   * in `@kubb/ast`. Returning `false` skips the call for that node entirely, with no context work
+   * beyond what the driver already builds per node and no render call, instead of the generator
+   * itself being invoked and returning early. Omit it to run for every node, the default when
+   * unset.
    *
    * Does not gate `operations`, which already runs once per plugin on the full batch rather than
    * per node.

--- a/packages/core/src/defineGenerator.ts
+++ b/packages/core/src/defineGenerator.ts
@@ -154,6 +154,23 @@ export type Generator<TOptions extends PluginFactoryOptions = PluginFactoryOptio
    */
   renderer?: RendererFactory<TElement> | null
   /**
+   * Optional predicate checked before `schema` or `operation` runs for a node. Returning `false`
+   * skips the call for that node entirely, with no context work beyond what the driver already
+   * builds per node and no render call, instead of the generator itself being invoked and
+   * returning early. Omit it to run for every node, the default when unset.
+   *
+   * Does not gate `operations`, which already runs once per plugin on the full batch rather than
+   * per node.
+   *
+   * @example Only match GET operations
+   * ```ts
+   * match(node, ctx) {
+   *   return ast.isHttpOperationNode(node) && node.method.toLowerCase() === 'get'
+   * }
+   * ```
+   */
+  match?: (node: SchemaNode | OperationNode, ctx: GeneratorContext<TOptions>) => PossiblePromise<boolean>
+  /**
    * Called for each schema node in the AST walk.
    * `ctx` carries the plugin context with `adapter` and `meta` (document metadata),
    * plus `ctx.options` with the per-node resolved options (after exclude/include/override).

--- a/packages/core/src/mocks.ts
+++ b/packages/core/src/mocks.ts
@@ -146,10 +146,9 @@ export async function renderGeneratorSchema<TOptions extends PluginFactoryOption
   if (!generator.schema) return
   const context = createMockedPluginContext(opts)
   const transformedNode = opts.plugin.macros?.length ? applyMacros(node, opts.plugin.macros) : node
-  const result = await generator.schema(transformedNode, {
-    ...context,
-    options: opts.options,
-  })
+  const ctx = { ...context, options: opts.options }
+  if (generator.match && !(await generator.match(transformedNode, ctx))) return
+  const result = await generator.schema(transformedNode, ctx)
   await opts.driver.dispatch({ result, renderer: generator.renderer })
 }
 
@@ -170,10 +169,9 @@ export async function renderGeneratorOperation<TOptions extends PluginFactoryOpt
   if (!generator.operation) return
   const context = createMockedPluginContext(opts)
   const transformedNode = opts.plugin.macros?.length ? applyMacros(node, opts.plugin.macros) : node
-  const result = await generator.operation(transformedNode, {
-    ...context,
-    options: opts.options,
-  })
+  const ctx = { ...context, options: opts.options }
+  if (generator.match && !(await generator.match(transformedNode, ctx))) return
+  const result = await generator.operation(transformedNode, ctx)
   await opts.driver.dispatch({ result, renderer: generator.renderer })
 }
 

--- a/packages/core/src/mocks.ts
+++ b/packages/core/src/mocks.ts
@@ -147,7 +147,8 @@ export async function renderGeneratorSchema<TOptions extends PluginFactoryOption
   const context = createMockedPluginContext(opts)
   const transformedNode = opts.plugin.macros?.length ? applyMacros(node, opts.plugin.macros) : node
   const ctx = { ...context, options: opts.options }
-  if (generator.match && !(await generator.match(transformedNode, ctx))) return
+  const matches = generator.match ? await generator.match(transformedNode, ctx) : true
+  if (!matches) return
   const result = await generator.schema(transformedNode, ctx)
   await opts.driver.dispatch({ result, renderer: generator.renderer })
 }
@@ -170,7 +171,8 @@ export async function renderGeneratorOperation<TOptions extends PluginFactoryOpt
   const context = createMockedPluginContext(opts)
   const transformedNode = opts.plugin.macros?.length ? applyMacros(node, opts.plugin.macros) : node
   const ctx = { ...context, options: opts.options }
-  if (generator.match && !(await generator.match(transformedNode, ctx))) return
+  const matches = generator.match ? await generator.match(transformedNode, ctx) : true
+  if (!matches) return
   const result = await generator.operation(transformedNode, ctx)
   await opts.driver.dispatch({ result, renderer: generator.renderer })
 }


### PR DESCRIPTION
## 🎯 Changes

`KubbDriver#runGenerators` always calls every registered generator's `schema`/`operation` method for every node it applies to. A generator that only wants a subset of nodes has no declarative way to say so, so it gets called for every node and has to classify-and-bail at the top of its own method.

This adds an optional `match` predicate to `Generator` (`packages/core/src/defineGenerator.ts`):

```ts
match?: (node: SchemaNode | OperationNode, ctx: GeneratorContext<TOptions>) => PossiblePromise<boolean>
```

`KubbDriver#runGenerators` checks it in both dispatch loops (schema and operation) and skips a generator entirely for a node when `match` resolves `false` — no extra context work beyond what's already built per node, no render call. Omitting `match` keeps today's behavior of always running, so this is purely additive and doesn't change output for any existing generator.

`renderGeneratorSchema`/`renderGeneratorOperation` in `packages/core/src/mocks.ts` honor `match` too, so a generator's own unit tests exercise the same skip behavior as real dispatch. `match` intentionally does not gate `operations`, which already runs once per plugin on the full batch rather than per node.

`Macro` (`packages/ast/src/defineMacro.ts`) already had the same concept under a different name (`when`). Since that field hasn't shipped yet — it's part of the still-pending, unreleased `macro-ast-transform-layer` changeset — this PR renames it to `match` too, so both abstractions use the same name for "skip this callback for a node." No breaking change: nothing has consumed `Macro.when` in a release yet.

This unblocks a follow-up in kubb-labs/plugins reverting `plugin-react-query`'s hand-rolled `createOperationDispatcher` (added in kubb-labs/plugins#728 to fix kubb-labs/kubb#3816) back to five plain declarative generators, each with its own `match`, instead of manually classifying once and calling `jsxRenderer()`/`ctx.upsertFile()` itself.

Fixes #3826.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).
