### PR TITLE
feat(adapter-oas): add uint64 format support alongside int64

### DIFF
--- a/.changeset/adapter-oas-uint64-format.md
+++ b/.changeset/adapter-oas-uint64-format.md
@@ -1,0 +1,7 @@
+---
+"@kubb/adapter-oas": minor
+---
+
+Add support for `uint64` format alongside existing `int64` handling.
+
+`uint64` is now recognized as a handled format like `int64`. When `integerType: "bigint"` (the default), `uint64` maps to `bigint`; when `integerType: "number"`, it maps to `integer`.

--- a/packages/adapter-oas/src/constants.ts
+++ b/packages/adapter-oas/src/constants.ts
@@ -39,11 +39,11 @@ export const structuralKeys = new Set(['properties', 'items', 'additionalPropert
 
 /**
  * Formats `convertFormat` maps to a dedicated type without going through `formatMap`:
- * `int64` and the date/time family. Keep this in sync with the `convertFormat`
+ * `int64`, `uint64` and the date/time family. Keep this in sync with the `convertFormat`
  * special-cases in `parser.ts`. `isHandledFormat` reads it so the
  * `KUBB_UNSUPPORTED_FORMAT` diagnostic and the parser agree on what is handled.
  */
-export const specialCasedFormats: ReadonlySet<string> = new Set(['int64', 'date-time', 'date', 'time'])
+export const specialCasedFormats: ReadonlySet<string> = new Set(['int64', 'uint64', 'date-time', 'date', 'time'])
 
 /**
  * Static map from OAS `format` strings to Kubb `SchemaType` values.

--- a/packages/adapter-oas/src/emit/converters/scalar.ts
+++ b/packages/adapter-oas/src/emit/converters/scalar.ts
@@ -73,7 +73,7 @@ export function convertConst({ schema, name, nullable, defaultValue }: ConvertCo
 export function convertFormat({ schema, name, nullable, defaultValue, options }: ConvertContext): ast.SchemaNode {
   const ctx = { schema, name, nullable, defaultValue }
 
-  if (schema.format === 'int64') {
+  if (schema.format === 'int64' || schema.format === 'uint64') {
     return createNode(ctx, {
       type: options.integerType === 'bigint' ? 'bigint' : 'integer',
       primitive: 'integer',

--- a/packages/adapter-oas/src/emit/schemaShape.ts
+++ b/packages/adapter-oas/src/emit/schemaShape.ts
@@ -5,7 +5,7 @@ import type { SchemaObject } from '../types.ts'
 
 /**
  * Returns the Kubb `SchemaType` for a given OAS `format` string, or `null` if not found.
- * Formats not in `formatMap` (e.g., `int64`, `date-time`) are handled separately by parser options.
+ * Formats not in `formatMap` (e.g., `int64`, `uint64`, `date-time`) are handled separately by parser options.
  */
 export function getSchemaType(format: string): ast.SchemaType | null {
   return formatMap[format as keyof typeof formatMap] ?? null
@@ -13,7 +13,7 @@ export function getSchemaType(format: string): ast.SchemaType | null {
 
 /**
  * Whether the parser maps `format` to a dedicated type. True for any `formatMap` entry, plus the
- * `specialCasedFormats` that `convertFormat` handles directly. False means the format falls back to
+ * `specialCasedFormats` that `convertFormat` handles directly (int64, uint64, date-time, date, time). False means the format falls back to
  * the base type, which is what `KUBB_UNSUPPORTED_FORMAT` flags. Reading both sources keeps the
  * diagnostic in step with the parser as `formatMap` grows.
  */

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -893,6 +893,15 @@ describe('parseSchema format preservation', () => {
     expect(node.format).toBe('int64')
   })
 
+  it('preserves format on uint64 schema (default integerType bigint)', () => {
+    const node = parseSchema(ctx, {
+      schema: { type: 'integer', format: 'uint64' },
+    })
+
+    expect(node.type).toBe('bigint')
+    expect(node.format).toBe('uint64')
+  })
+
   it('preserves format on enum schema', () => {
     const node = parseSchema(ctx, {
       schema: { type: 'string', format: 'custom-enum', enum: ['a', 'b'] },
@@ -2766,8 +2775,22 @@ describe('parseSchema integer', () => {
     expect(node.type).toBe('bigint')
   })
 
+  it('maps integer uint64 to bigint when integerType is bigint (default)', () => {
+    const node = parseSchema(ctx, {
+      schema: { type: 'integer', format: 'uint64' },
+    })
+
+    expect(node.type).toBe('bigint')
+  })
+
   it('maps format int64 without type to bigint (format overrides type)', () => {
     const node = parseSchema(ctx, { schema: { format: 'int64' } })
+
+    expect(node.type).toBe('bigint')
+  })
+
+  it('maps format uint64 without type to bigint (format overrides type)', () => {
+    const node = parseSchema(ctx, { schema: { format: 'uint64' } })
 
     expect(node.type).toBe('bigint')
   })
@@ -3516,6 +3539,20 @@ describe('parser options', () => {
     it('integerType: bigint maps int64 to bigint', () => {
       const ctx = { document: emptyDocument, refs: createRefs(emptyDocument) }
       const node = parseSchema(ctx, { schema: { type: 'integer', format: 'int64' } }, { integerType: 'bigint' })
+
+      expect(node.type).toBe('bigint')
+    })
+
+    it('integerType: number keeps uint64 as integer', () => {
+      const ctx = { document: emptyDocument, refs: createRefs(emptyDocument) }
+      const node = parseSchema(ctx, { schema: { type: 'integer', format: 'uint64' } }, { integerType: 'number' })
+
+      expect(node.type).toBe('integer')
+    })
+
+    it('integerType: bigint maps uint64 to bigint', () => {
+      const ctx = { document: emptyDocument, refs: createRefs(emptyDocument) }
+      const node = parseSchema(ctx, { schema: { type: 'integer', format: 'uint64' } }, { integerType: 'bigint' })
 
       expect(node.type).toBe('bigint')
     })


### PR DESCRIPTION
## 🎯 Changes

### Problem

`format: uint64` is absent from both `formatMap` and `specialCasedFormats` in `@kubb/adapter-oas`. This means:

- `integer + uint64` always falls through to `number` (the `integerType` option is never applied)
- A `KUBB_UNSUPPORTED_FORMAT` diagnostic warning is emitted on every run

### Comparison with other generators

| type | format | Kubb (integerType: bigint) | Kubb (integerType: number) | Orval (useBigInt: false) | Orval (useBigInt: true) |
|---|---|---|---|---|---|
| integer | int64 | `bigint` | `number` | `number` | `bigint` |
| integer | uint64 | `number` (warning) | `number` (warning) | `number` | `bigint` |

`integerType: "bigint"` (the default) correctly maps `int64` to `bigint`, but `uint64` is not recognized by the parser — it falls through to `number` regardless of the `integerType` setting. Orval also defaults to `number` for `uint64`, but supports switching it to `bigint` via `useBigInt: true`.

The uint64 range `[0, 18446744073709551615]` exceeds `Number.MAX_SAFE_INTEGER` (2^53), so users need the same `integerType` control for `uint64` as they have for `int64`.

### Request

1. Add `"uint64"` to `specialCasedFormats` alongside `"int64"`
2. Apply `integerType` handling to `uint64` the same way it is applied to `int64`
3. Remove the `KUBB_UNSUPPORTED_FORMAT` warning for `uint64`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).
