### PR TITLE
fix(adapter-oas): respect `type: string` when the format is numeric

### DIFF
--- a/.changeset/adapter-oas-string-numeric-format.md
+++ b/.changeset/adapter-oas-string-numeric-format.md
@@ -1,0 +1,9 @@
+---
+'@kubb/adapter-oas': patch
+---
+
+Respect `type: 'string'` when the schema carries a numeric `format` (`int64`, `uint64`, `int32`, `float`, `double`).
+
+A schema like `{ type: 'string', format: 'int64' }` produced a `bigint` node, dropping the declared type. ProtoJSON (and so every gRPC-gateway spec) encodes 64-bit integers as JSON strings, so those fields are now generated as `string`, matching what other generators do. The format stays on the node, so `@kubb/plugin-zod` adds a digits `.regex(...)` and `@kubb/plugin-faker` mocks a numeric string.
+
+A numeric format on an `integer`/`number` schema, or on a schema with no `type` at all, keeps mapping to `bigint`/`integer`/`number` as before.

--- a/packages/adapter-oas/src/constants.ts
+++ b/packages/adapter-oas/src/constants.ts
@@ -46,6 +46,15 @@ export const structuralKeys = new Set(['properties', 'items', 'additionalPropert
 export const specialCasedFormats: ReadonlySet<string> = new Set(['int64', 'uint64', 'date-time', 'date', 'time'])
 
 /**
+ * Formats that describe a number, whether they resolve through `formatMap` or through the
+ * `convertFormat` special cases. On a `type: 'string'` schema these do not make the value a
+ * number: gRPC-gateway and other ProtoJSON producers send 64-bit integers as JSON strings.
+ *
+ * @see https://protobuf.dev/programming-guides/json/#int64-strings
+ */
+export const numericFormats: ReadonlySet<string> = new Set(['int32', 'int64', 'uint64', 'float', 'double'])
+
+/**
  * Static map from OAS `format` strings to Kubb `SchemaType` values.
  *
  * Only formats whose AST type differs from the OAS `type` field appear here.

--- a/packages/adapter-oas/src/emit/converters/scalar.ts
+++ b/packages/adapter-oas/src/emit/converters/scalar.ts
@@ -1,5 +1,5 @@
 import { ast } from '@kubb/ast'
-import { enumDescriptionKeys, enumExtensionKeys } from '../../constants.ts'
+import { enumDescriptionKeys, enumExtensionKeys, numericFormats } from '../../constants.ts'
 import type { SchemaObject } from '../../types.ts'
 import { createNode } from '../createNode.ts'
 import type { ConvertContext } from '../parseSchema.ts'
@@ -70,8 +70,16 @@ export function convertConst({ schema, name, nullable, defaultValue }: ConvertCo
  * `format` rule's `match` has confirmed the format is handled (see `isHandledFormat`) and, for
  * a date-ish format, that `dateType` is not `false`.
  */
-export function convertFormat({ schema, name, nullable, defaultValue, options }: ConvertContext): ast.SchemaNode {
+export function convertFormat(context: ConvertContext): ast.SchemaNode {
+  const { schema, name, nullable, defaultValue, options, type } = context
   const ctx = { schema, name, nullable, defaultValue }
+
+  // A numeric format on a `type: 'string'` schema describes how the number is spelled, not that
+  // the value is a number, so the declared type wins. The format stays on the node for plugins
+  // that want to validate the digits.
+  if (type === 'string' && numericFormats.has(schema.format!)) {
+    return convertString(context)
+  }
 
   if (schema.format === 'int64' || schema.format === 'uint64') {
     return createNode(ctx, {

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -2795,6 +2795,58 @@ describe('parseSchema integer', () => {
     expect(node.type).toBe('bigint')
   })
 
+  it('keeps string int64 as a string node carrying the format', () => {
+    const node = parseSchema(ctx, {
+      schema: { type: 'string', format: 'int64' },
+    })
+
+    expect(node.type).toBe('string')
+    expect(node.format).toBe('int64')
+  })
+
+  it('keeps string uint64 as a string node carrying the format', () => {
+    const node = parseSchema(ctx, {
+      schema: { type: 'string', format: 'uint64' },
+    })
+
+    expect(node.type).toBe('string')
+    expect(node.format).toBe('uint64')
+  })
+
+  it('keeps string int64 as a string node when integerType is number', () => {
+    const node = parseSchema(ctx, { schema: { type: 'string', format: 'int64' } }, { integerType: 'number' })
+
+    expect(node.type).toBe('string')
+  })
+
+  it('keeps string int32, float and double as string nodes', () => {
+    for (const format of ['int32', 'float', 'double']) {
+      const node = parseSchema(ctx, { schema: { type: 'string', format } })
+
+      expect(node.type).toBe('string')
+      expect(node.format).toBe(format)
+    }
+  })
+
+  it('keeps the string length constraints on a string int64', () => {
+    const node = parseSchema(ctx, {
+      schema: { type: 'string', format: 'int64', minLength: 1, maxLength: 20 },
+    })
+    const narrowed = ast.narrowSchema(node, 'string')
+
+    expect(narrowed?.min).toBe(1)
+    expect(narrowed?.max).toBe(20)
+  })
+
+  it('keeps nullable string int64 as a nullable string node', () => {
+    const node = parseSchema(ctx, {
+      schema: { type: ['string', 'null'], format: 'int64' },
+    })
+
+    expect(node.type).toBe('string')
+    expect(node.nullable).toBe(true)
+  })
+
   it('preserves nullable on integer', () => {
     const node = parseSchema(ctx, {
       schema: { type: 'integer', nullable: true },


### PR DESCRIPTION
## 🎯 Changes

Closes #3836, using **option A** from the issue.

A schema like `{ type: 'string', format: 'int64' }` produced a `bigint` node, dropping the declared type entirely. ProtoJSON encodes 64-bit integers as JSON strings, so every gRPC-gateway spec describes those fields exactly that way, and Kubb was the only generator that overrode `type` here.

`convertFormat` now returns a string node when the schema declares `type: 'string'` and carries a numeric format. The declared type wins; the format still rides along on `node.format`, so plugins can validate or mock the digits — kubb-labs/plugins#735 adds that to `@kubb/plugin-zod` and `@kubb/plugin-faker`.

| type | format | before | after |
| --- | --- | --- | --- |
| `string` | `int64` | `bigint` | `string` |
| `string` | `uint64` | `bigint` | `string` |
| `string` | `int32` | `integer` | `string` |
| `string` | `float` / `double` | `number` | `string` |
| `integer` | `int64` | `bigint` | `bigint` (unchanged) |
| — | `int64` | `bigint` | `bigint` (unchanged) |

Length constraints (`minLength`, `maxLength`, `pattern`) and nullability on those string schemas are preserved, since the branch routes through `convertString`. A numeric format on an `integer`/`number` schema, or on a schema with no `type` at all, keeps its existing mapping, so `integerType` behavior is untouched.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`. (1388 tests pass, including 7 new `parseSchema` cases.)

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).