### PR TITLE
fix(cli): install kubb at the CLI version in the init wizard

### DIFF
--- a/.changeset/init-pin-kubb-to-cli-version.md
+++ b/.changeset/init-pin-kubb-to-cli-version.md
@@ -1,0 +1,5 @@
+---
+"@kubb/cli": patch
+---
+
+`kubb init` now installs `kubb` at the exact version of the CLI running the wizard instead of resolving the `kubb@beta` dist-tag again. Plugins keep following the dist-tag of that release channel, since they ship from their own repo.

--- a/internals/shared/src/constants.ts
+++ b/internals/shared/src/constants.ts
@@ -2,6 +2,8 @@ import type { PluginOption } from './types.ts'
 
 export const KUBB_CONFIG_FILENAME = 'kubb.config.ts' as const
 
+export const KUBB_PACKAGE_NAME = 'kubb' as const
+
 export const initDefaults = {
   inputPath: './openapi.yaml',
   outputPath: './src/gen',

--- a/internals/shared/src/index.ts
+++ b/internals/shared/src/index.ts
@@ -1,4 +1,4 @@
 export type * from './types.ts'
-export { KUBB_CONFIG_FILENAME, initDefaults, availablePlugins } from './constants.ts'
-export { generateConfigFile, resolvePlugins, withDistTag } from './init.ts'
+export { KUBB_CONFIG_FILENAME, KUBB_PACKAGE_NAME, initDefaults, availablePlugins } from './constants.ts'
+export { generateConfigFile, resolveInstallVersions, resolvePlugins } from './init.ts'
 export { createModuleLoader } from './loader.ts'

--- a/internals/shared/src/init.test.ts
+++ b/internals/shared/src/init.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { availablePlugins } from './constants.ts'
-import { generateConfigFile, resolvePlugins, withDistTag } from './init.ts'
+import { generateConfigFile, resolveInstallVersions, resolvePlugins } from './init.ts'
 
 describe('resolvePlugins', () => {
   it('returns an empty list when no flag is given', () => {
@@ -142,19 +142,19 @@ describe('generateConfigFile', () => {
   })
 })
 
-describe('withDistTag', () => {
-  it('pins packages to the beta tag for a beta CLI version', () => {
-    const result = withDistTag({ packages: ['kubb', '@kubb/plugin-ts'], version: '5.0.0-beta.94' })
-    expect(result).toStrictEqual(['kubb@beta', '@kubb/plugin-ts@beta'])
+describe('resolveInstallVersions', () => {
+  it('pins kubb to the CLI version and plugins to the beta tag for a beta CLI version', () => {
+    const result = resolveInstallVersions({ packages: ['kubb', '@kubb/plugin-ts'], version: '5.0.0-beta.94' })
+    expect(result).toStrictEqual(['kubb@5.0.0-beta.94', '@kubb/plugin-ts@beta'])
   })
 
-  it('pins packages to another prerelease tag when the version carries one', () => {
-    const result = withDistTag({ packages: ['kubb'], version: '5.0.0-alpha.1' })
-    expect(result).toStrictEqual(['kubb@alpha'])
+  it('pins plugins to another prerelease tag when the version carries one', () => {
+    const result = resolveInstallVersions({ packages: ['kubb', '@kubb/plugin-zod'], version: '5.0.0-alpha.1' })
+    expect(result).toStrictEqual(['kubb@5.0.0-alpha.1', '@kubb/plugin-zod@alpha'])
   })
 
-  it('pins packages to latest for a stable CLI version', () => {
-    const result = withDistTag({ packages: ['kubb', '@kubb/plugin-zod'], version: '5.0.0' })
-    expect(result).toStrictEqual(['kubb@latest', '@kubb/plugin-zod@latest'])
+  it('pins plugins to latest for a stable CLI version', () => {
+    const result = resolveInstallVersions({ packages: ['kubb', '@kubb/plugin-zod'], version: '5.0.0' })
+    expect(result).toStrictEqual(['kubb@5.0.0', '@kubb/plugin-zod@latest'])
   })
 })

--- a/internals/shared/src/init.ts
+++ b/internals/shared/src/init.ts
@@ -1,4 +1,4 @@
-import { availablePlugins } from './constants.ts'
+import { availablePlugins, KUBB_PACKAGE_NAME } from './constants.ts'
 import type { PluginOption } from './types.ts'
 
 /**
@@ -47,11 +47,16 @@ ${pluginConfigs}
 }
 
 /**
- * Appends the dist-tag matching the running CLI version to each package name,
- * so a beta CLI scaffolds beta packages instead of the older stable majors.
+ * Turns package names into install specifiers for the wizard.
+ *
+ * `kubb` is pinned to the exact version of the running CLI, since both ship from the same release
+ * and resolving `kubb@beta` separately can land on a different version than the CLI doing the
+ * scaffolding. Plugins release from their own repo on their own cadence, so they follow the
+ * release channel of the CLI through its dist-tag.
  */
-export function withDistTag({ packages, version }: { packages: Array<string>; version: string }): Array<string> {
+export function resolveInstallVersions({ packages, version }: { packages: Array<string>; version: string }): Array<string> {
   const prerelease = version.match(/-([a-z]+)/)?.[1]
   const tag = prerelease ?? 'latest'
-  return packages.map((name) => `${name}@${tag}`)
+
+  return packages.map((name) => (name === KUBB_PACKAGE_NAME ? `${name}@${version}` : `${name}@${tag}`))
 }

--- a/packages/cli/src/runners/init/run.ts
+++ b/packages/cli/src/runners/init/run.ts
@@ -3,7 +3,16 @@ import path from 'node:path'
 import process from 'node:process'
 import { styleText } from 'node:util'
 import * as clack from '@clack/prompts'
-import { availablePlugins, generateConfigFile, initDefaults, KUBB_CONFIG_FILENAME, type PluginOption, resolvePlugins, withDistTag } from '@internals/shared'
+import {
+  availablePlugins,
+  generateConfigFile,
+  initDefaults,
+  KUBB_CONFIG_FILENAME,
+  KUBB_PACKAGE_NAME,
+  type PluginOption,
+  resolveInstallVersions,
+  resolvePlugins,
+} from '@internals/shared'
 import { hasPackageJson, initPackageJson, installPackages } from './utils.ts'
 import { detectPackageManager } from '../../tools.ts'
 
@@ -141,8 +150,8 @@ export async function run({ yes, version, input: inputFlag, output: outputFlag, 
       return availablePlugins.filter((p) => (values as Array<string>).includes(p.value))
     })()
 
-    // Install packages, pinned to the dist-tag of the running CLI version
-    const packagesToInstall = withDistTag({ packages: ['kubb', ...selectedPlugins.map((p) => p.packageName)], version })
+    // Install packages, matching the release of the running CLI
+    const packagesToInstall = resolveInstallVersions({ packages: [KUBB_PACKAGE_NAME, ...selectedPlugins.map((p) => p.packageName)], version })
 
     const spinner = clack.spinner()
     spinner.start(`Installing ${packagesToInstall.length} packages with ${packageManager.name}`)


### PR DESCRIPTION
## 🎯 Changes

Part of the fix for #3839.

`kubb init` built its install list by appending the dist-tag of the running CLI to every package name, so `npx kubb@beta init` ran `npm install kubb@beta @kubb/plugin-ts@beta ...` and let npm resolve each `beta` tag on its own. The `kubb` tag can move to a different release than the CLI doing the scaffolding, so the wizard could install a `kubb` that is not the one the user asked for.

`resolveInstallVersions` (renamed from `withDistTag`) now pins `kubb` to the exact version of the running CLI, since `kubb` and `@kubb/cli` ship from the same release. Plugins release from their own repo on their own cadence, so they keep following the release channel through the dist-tag.

```
npx kubb@5.0.0-beta.105 init
→ npm install kubb@5.0.0-beta.105 @kubb/plugin-ts@beta @kubb/plugin-zod@beta
```

The `ERESOLVE` in the issue also needs the peer dependency fix in kubb-labs/plugins#736: published plugins pin `peerDependencies.kubb` to one exact version, so no `kubb` release other than that one installs next to them. That PR turns the pin into a range.

Documentation for the new behavior is in kubb-labs/docs (branch `claude/github-issue-3839-qny42h`).

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

---
_Generated by [Claude Code](https://claude.ai/code/session_01HNsssRYNsMT3eRNZE3N6rG)_