### PR TITLE
ci: bump kubb-labs/config SHA pin to latest main

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
+        uses: kubb-labs/config/.github/setup@295e9ddb607c5df27ae6ecf5044e1afd01fd24b4 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/changeset-format.yml
+++ b/.github/workflows/changeset-format.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
+        uses: kubb-labs/config/.github/setup@295e9ddb607c5df27ae6ecf5044e1afd01fd24b4 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
+        uses: kubb-labs/config/.github/setup@295e9ddb607c5df27ae6ecf5044e1afd01fd24b4 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
+        uses: kubb-labs/config/.github/setup@295e9ddb607c5df27ae6ecf5044e1afd01fd24b4 # main
         with:
           node-version: '22.22.3'
 
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
+        uses: kubb-labs/config/.github/setup@295e9ddb607c5df27ae6ecf5044e1afd01fd24b4 # main
         with:
           node-version: '22.22.3'
 
@@ -72,7 +72,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
+        uses: kubb-labs/config/.github/setup@295e9ddb607c5df27ae6ecf5044e1afd01fd24b4 # main
         with:
           node-version: '22.22.3'
 
@@ -102,7 +102,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
+        uses: kubb-labs/config/.github/setup@295e9ddb607c5df27ae6ecf5044e1afd01fd24b4 # main
         with:
           node-version: '22.22.3'
 
@@ -127,7 +127,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
+        uses: kubb-labs/config/.github/setup@295e9ddb607c5df27ae6ecf5044e1afd01fd24b4 # main
         with:
           node-version: '22.22.3'
 
@@ -152,7 +152,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
+        uses: kubb-labs/config/.github/setup@295e9ddb607c5df27ae6ecf5044e1afd01fd24b4 # main
         with:
           node-version: '22.22.3'
 
@@ -199,7 +199,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
+        uses: kubb-labs/config/.github/setup@295e9ddb607c5df27ae6ecf5044e1afd01fd24b4 # main
         with:
           node-version: '22.22.3'
 
@@ -225,7 +225,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
+        uses: kubb-labs/config/.github/setup@295e9ddb607c5df27ae6ecf5044e1afd01fd24b4 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
+        uses: kubb-labs/config/.github/setup@295e9ddb607c5df27ae6ecf5044e1afd01fd24b4 # main
         with:
           node-version: '22.22.3'
           cache: 'false'
@@ -48,7 +48,7 @@ jobs:
 
       - name: Release
         id: release
-        uses: kubb-labs/config/.github/actions/release@b673ab918489eb77823cac38fc17d67f325177b8 # main
+        uses: kubb-labs/config/.github/actions/release@295e9ddb607c5df27ae6ecf5044e1afd01fd24b4 # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -90,7 +90,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@b673ab918489eb77823cac38fc17d67f325177b8 # main
+        uses: kubb-labs/config/.github/setup@295e9ddb607c5df27ae6ecf5044e1afd01fd24b4 # main
         with:
           node-version: '22.22.3'
           cache: 'false'
@@ -104,7 +104,7 @@ jobs:
       # version independently.
       - name: Promote
         id: promote
-        uses: kubb-labs/config/.github/actions/promote@b673ab918489eb77823cac38fc17d67f325177b8 # main
+        uses: kubb-labs/config/.github/actions/promote@295e9ddb607c5df27ae6ecf5044e1afd01fd24b4 # main
         with:
           staged-packages: ${{ needs.release.outputs.staged_packages }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 🎯 Changes

kubb-labs/config#24 merged (SHA-pinned action bumps), on top of #22 (actions/checkout bump) and #23 (dependency refresh) which had already landed since this repo's pin was last updated. Every `kubb-labs/config/.github/...` reference here was still pinned to `b673ab9` (from config's PR #21, merged 2026-07-15) — three merges stale. Bumped all 15 references to the new tip `295e9dd`.

I also checked the Slice 1 low-impact bumps tracked in kubb-labs/platform#362 for this repo (`@changesets/cli`, `@changesets/changelog-github`, `oxlint`/`oxfmt`, `turbo`, `@readme/openapi-parser`, `@scalar/openapi-upgrader`) — all were already at their latest available version, and the few further patches available are blocked by this workspace's `minimumReleaseAge` supply-chain policy. Nothing to change there.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`. (Workflow-only change; validated YAML syntax for every edited file.)

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release). (CI workflow metadata only.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiY2B3Gu3pasmF58uooUU9)_