### PR TITLE
docs: fix broken config examples in package READMEs

### DIFF
--- a/.changeset/readme-config-examples.md
+++ b/.changeset/readme-config-examples.md
@@ -1,0 +1,19 @@
+---
+'@kubb/adapter-oas': patch
+'@kubb/plugin-barrel': patch
+'@kubb/mcp': patch
+---
+
+Fix the config examples in the package READMEs.
+
+`input` took an object (`input: { path: './openapi.yaml' }`) in the examples. Kubb reads a non-string `input` as an
+already-parsed spec, so that form silently produced an empty document instead of reading the file. The examples now pass
+the path as a string.
+
+The `@kubb/adapter-oas` README passed the adapter as `adapters: [adapterOas()]`, but the config key is the singular
+`adapter`. It also documented `mergeDocuments`, which is no longer exported, and listed `HttpMethod` among the
+re-exported types, which this package does not export. The API section now matches `src/index.ts` and documents
+`adapterOasName`.
+
+The `@kubb/mcp` README imported `pluginOas` from `@kubb/plugin-oas`, a package that no longer exists. The example now
+uses `adapterOas` from `@kubb/adapter-oas`.

--- a/packages/adapter-oas/README.md
+++ b/packages/adapter-oas/README.md
@@ -45,29 +45,31 @@ import { defineConfig } from 'kubb'
 import { adapterOas } from '@kubb/adapter-oas'
 
 export default defineConfig({
-  input: {
-    path: './openapi.yaml',
-  },
+  input: './openapi.yaml',
   output: {
     path: './src/gen',
   },
-  adapters: [adapterOas()],
+  adapter: adapterOas(),
 })
 ```
+
+`input` accepts a file path, a URL, an inline JSON or YAML string, or a parsed spec object.
 
 ## API
 
 ### `adapterOas(options?)`
 
-Creates the OAS adapter instance. Pass it in the `adapters` array of `defineConfig`.
+Creates the OAS adapter instance. Pass it as `adapter` in `defineConfig`.
 
-### `mergeDocuments(documents)`
+### `adapterOasName`
 
-Merges multiple OpenAPI documents into a single document before parsing.
+The adapter's name, `'oas'`. Use it to identify this adapter in a Kubb config.
 
 ### Types
 
-All OpenAPI types (`Document`, `Operation`, `SchemaObject`, `HttpMethod`, etc.) are re-exported from this package.
+The package re-exports the OpenAPI types it works with: `ContentType`, `DiscriminatorObject`, `Document`,
+`MediaTypeObject`, `Operation`, `ReferenceObject`, `ResponseObject`, and `SchemaObject`. Its own option types are
+`AdapterOas`, `AdapterOasOptions`, and `AdapterOasResolvedOptions`.
 
 ## Supporting Kubb
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -155,18 +155,17 @@ Example `kubb.config.ts`:
 
 ```typescript
 import { defineConfig } from 'kubb'
-import { pluginOas } from '@kubb/plugin-oas'
+import { adapterOas } from '@kubb/adapter-oas'
 import { pluginTs } from '@kubb/plugin-ts'
 import { pluginAxios } from '@kubb/plugin-axios'
 
 export default defineConfig({
-  input: {
-    path: './petstore.yaml',
-  },
+  input: './petstore.yaml',
   output: {
     path: './src/generated',
   },
-  plugins: [pluginOas(), pluginTs(), pluginAxios()],
+  adapter: adapterOas(),
+  plugins: [pluginTs(), pluginAxios()],
 })
 ```
 

--- a/packages/plugin-barrel/README.md
+++ b/packages/plugin-barrel/README.md
@@ -45,9 +45,7 @@ import { defineConfig } from 'kubb'
 import { pluginBarrel } from '@kubb/plugin-barrel'
 
 export default defineConfig({
-  input: {
-    path: './openapi.yaml',
-  },
+  input: './openapi.yaml',
   output: {
     path: './src/gen',
   },


### PR DESCRIPTION
## 🎯 Changes

Found while reading `@kubb/adapter-oas` to write up how the adapter works. The config examples in three package READMEs do not run on v5.

**`input` took an object.** All three READMEs showed `input: { path: './openapi.yaml' }`. `Input` is `string | Record<string, unknown>`, and `inputToAdapterSource` treats any non-string as an already-parsed spec (`packages/core/src/input.ts:53`). That object was passed to the upgrader as a document rather than read as a file path, so the example silently generated from nothing instead of failing loudly. The examples now pass the path as a string.

**`@kubb/adapter-oas` README.** Three more problems in the same file:

- The example passed `adapters: [adapterOas()]`. The config key is the singular `adapter`, per `KubbConfig` and the JSDoc on `adapterOas` itself.
- It documented `mergeDocuments(documents)`, which was removed from `src/index.ts` (see the existing `adapter-oas-lazy-load-heavy-deps` changeset).
- The Types section listed `HttpMethod` among the re-exported types. This package does not export it; it lives in `@kubb/ast`. The section now lists exactly what `src/index.ts` exports, and documents `adapterOasName`.

**`@kubb/mcp` README.** The example imported `pluginOas` from `@kubb/plugin-oas`, a package that no longer exists in this repo. It now uses `adapterOas` from `@kubb/adapter-oas`.

No source changes, docs only.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`. Not run: this touches only markdown, so no test can exercise it. `oxfmt --check` and `oxlint` pass on the changed packages.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md). Patch for the three packages, since READMEs ship to npm and the current ones show a config that does not work.
- [ ] This change is for the docs (no release).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QRMqFpL6etW3UV8uB7dkQD)_