### PR TITLE
fix: fail loudly when input is not a readable document

### DIFF
--- a/.changeset/adapter-oas-assert-document.md
+++ b/.changeset/adapter-oas-assert-document.md
@@ -1,0 +1,7 @@
+---
+'@kubb/adapter-oas': patch
+---
+
+Fail with `KUBB_INVALID_DOCUMENT` when `input` resolves to something that is not an OpenAPI or Swagger document.
+
+`validateDocument` keeps spec violations non-fatal so imperfect but usable documents still generate. That leniency also swallowed input that was not a document at all, so a wrong file or a wrapper object produced an empty build with a success exit code. A document that declares neither `openapi` nor `swagger` is now a hard error regardless of the `validate` option, while every other validation failure stays non-fatal.

--- a/.changeset/core-reject-legacy-input-shape.md
+++ b/.changeset/core-reject-legacy-input-shape.md
@@ -1,0 +1,7 @@
+---
+'@kubb/core': patch
+---
+
+Reject the v4 `input: { path }` / `input: { data }` wrapper with a `KUBB_LEGACY_INPUT` error.
+
+v5 takes the `input` value directly, so the v4 wrapper matched the "already-parsed document" branch and Kubb read `{ path: './petStore.yaml' }` as the spec itself. The run then generated nothing but still reported success and exited `0`, which let a stale config pass CI with an empty client. The wrapper now fails with a message pointing at the unwrapped form.

--- a/packages/adapter-oas/src/adapter.ts
+++ b/packages/adapter-oas/src/adapter.ts
@@ -5,7 +5,7 @@ import { DEFAULT_PARSER_OPTIONS } from './constants.ts'
 import { buildDiscriminatorChildMap, patchDiscriminatorNode } from './emit/discriminator/propagate.ts'
 import type { DiscriminatorTarget } from './emit/discriminator/propagate.ts'
 import { assertInputExists } from './load/source.ts'
-import { parseDocument, parseFromConfig, validateDocument } from './load/normalize.ts'
+import { assertDocument, parseDocument, parseFromConfig, validateDocument } from './load/normalize.ts'
 import { getSchemas } from './model/components.ts'
 import { resolveBaseUrl } from './model/server.ts'
 import { getOperations } from './operation.ts'
@@ -187,6 +187,7 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
     async validate(input, options) {
       await assertInputExists(input)
       const document = await parseDocument(input)
+      assertDocument(document)
       await validateDocument(document, options)
     },
     async parse(source) {
@@ -195,6 +196,7 @@ export const adapterOas = createAdapter<AdapterOas>((options) => {
 
       const promise = (async () => {
         const document = await parseFromConfig(source)
+        assertDocument(document)
         if (validate) await validateDocument(document)
         parsedDocument = document
 

--- a/packages/adapter-oas/src/load/normalize.test.ts
+++ b/packages/adapter-oas/src/load/normalize.test.ts
@@ -1,7 +1,8 @@
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it, vi } from 'vitest'
-import { bundleDocument, parseDocument, parseFromConfig, validateDocument } from './normalize.ts'
+import { Diagnostics } from '@kubb/core'
+import { assertDocument, bundleDocument, parseDocument, parseFromConfig, validateDocument } from './normalize.ts'
 import type { Document } from '../types.ts'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -286,5 +287,28 @@ describe('bundleDocument', () => {
 
   it('throws when the input file does not exist', async () => {
     await expect(bundleDocument(path.resolve(__dirname, '../../mocks/doesNotExist.yaml'))).rejects.toThrow()
+  })
+})
+
+describe('assertDocument', () => {
+  it('accepts an OpenAPI document', () => {
+    expect(() => assertDocument({ openapi: '3.1.0' } as Document)).not.toThrow()
+  })
+
+  it('accepts a Swagger document', () => {
+    expect(() => assertDocument({ swagger: '2.0' } as unknown as Document)).not.toThrow()
+  })
+
+  it.each([
+    ['a v4 path wrapper read as data', { path: './petStore.yaml' }],
+    ['an empty object', {}],
+    ['a document with no version field', { info: { title: 'Pets', version: '1.0.0' } }],
+  ])('throws an invalid-document diagnostic for %s', (_name, document) => {
+    try {
+      assertDocument(document as Document)
+      expect.unreachable('expected assertDocument to throw')
+    } catch (error) {
+      expect(Diagnostics.isError(error) && error.diagnostic.code).toBe(Diagnostics.code.invalidDocument)
+    }
   })
 })

--- a/packages/adapter-oas/src/load/normalize.ts
+++ b/packages/adapter-oas/src/load/normalize.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import { Diagnostics } from '@kubb/core'
 import type { AdapterSource } from '@kubb/core'
 import { compileErrors, validate } from '@readme/openapi-parser'
 import { upgrade } from '@scalar/openapi-upgrader'
@@ -98,6 +99,26 @@ export async function parseFromConfig(source: AdapterSource): Promise<Document> 
   const resolved = path.resolve(path.dirname(source.path), source.path)
   await assertInputExists(resolved)
   return parseDocument(resolved)
+}
+
+/**
+ * Asserts the parsed input is an OpenAPI or Swagger document.
+ *
+ * {@link validateDocument} keeps spec violations non-fatal so imperfect but usable documents still
+ * generate. That leniency also swallowed input that is not a document at all, which then produced
+ * an empty build with a success exit code. A missing version field is the one failure that cannot
+ * be a usable document, so it is fatal regardless of the `validate` option.
+ */
+export function assertDocument(document: Document): void {
+  if (document && ('openapi' in document || 'swagger' in document)) return
+
+  throw new Diagnostics.Error({
+    code: Diagnostics.code.invalidDocument,
+    severity: 'error',
+    message: 'The resolved `input` is not an OpenAPI or Swagger document: it declares no `openapi` or `swagger` version.',
+    help: 'Point `input` at a document that declares `openapi` or `swagger`. If you pass an object, pass the spec itself rather than a wrapper such as `{ path }` or `{ data }`.',
+    location: { kind: 'config' },
+  })
 }
 
 /**

--- a/packages/core/src/Diagnostics.ts
+++ b/packages/core/src/Diagnostics.ts
@@ -246,6 +246,16 @@ const diagnosticCatalog: Record<DiagnosticCode, DiagnosticDoc> = {
     cause: 'An adapter is configured but no `input` was provided.',
     fix: 'Set `input` to a file path, a URL, an inline spec (JSON/YAML string), or a parsed object in your Kubb config.',
   },
+  [diagnosticCode.legacyInput]: {
+    title: 'Legacy input shape',
+    cause: '`input` is a `{ path }` or `{ data }` wrapper, which v4 used to point at a document and v5 reads as the document itself.',
+    fix: 'Unwrap it: `input: { path: "./petStore.yaml" }` becomes `input: "./petStore.yaml"`, and `input: { data: spec }` becomes `input: spec`.',
+  },
+  [diagnosticCode.invalidDocument]: {
+    title: 'Invalid document',
+    cause: 'The parsed `input` has no `openapi` or `swagger` version field, so it is not an OpenAPI or Swagger document.',
+    fix: 'Point `input` at a document that declares `openapi` or `swagger`, and check that a passed object is the spec itself rather than a wrapper around it.',
+  },
   [diagnosticCode.refNotFound]: {
     title: 'Reference not found',
     cause: 'A `$ref` could not be resolved in the source document.',

--- a/packages/core/src/KubbDriver.test.ts
+++ b/packages/core/src/KubbDriver.test.ts
@@ -27,9 +27,7 @@ describe('PluginDriver', () => {
 
   const config = {
     root: '.',
-    input: {
-      path: './petStore.yaml',
-    },
+    input: './petStore.yaml',
     output: {
       path: './src/gen',
       clean: true,
@@ -381,7 +379,7 @@ describe('KubbDriver generator dispatch', () => {
     hooks = new Hookable<KubbHooks>()
     const config = {
       root: '.',
-      input: { path: './petStore.yaml' },
+      input: './petStore.yaml',
       output: { path: './gen' },
       parsers: [],
       reporters: [],
@@ -482,7 +480,7 @@ describe('KubbDriver generator dispatch', () => {
     } as unknown as Plugin
     const config = {
       root: '.',
-      input: { path: './petStore.yaml' },
+      input: './petStore.yaml',
       output: { path: './gen' },
       parsers: [],
       reporters: [],
@@ -525,7 +523,7 @@ describe('KubbDriver generator dispatch', () => {
     const localHooks = new Hookable<KubbHooks>()
     const cfg = {
       root: '.',
-      input: { path: './petStore.yaml' },
+      input: './petStore.yaml',
       output: { path: './gen' },
       parsers: [],
       reporters: [],
@@ -555,7 +553,7 @@ describe('KubbDriver generator dispatch', () => {
     } as unknown as Plugin
     const config = {
       root: '.',
-      input: { path: './petStore.yaml' },
+      input: './petStore.yaml',
       output: { path: './gen' },
       parsers: [],
       reporters: [],
@@ -592,7 +590,7 @@ describe('KubbDriver generator dispatch', () => {
     } as unknown as Plugin
     const config = {
       root: '.',
-      input: { path: './petStore.yaml' },
+      input: './petStore.yaml',
       output: { path: './gen' },
       parsers: [],
       reporters: [],
@@ -639,7 +637,7 @@ describe('KubbDriver generator dispatch', () => {
     } as unknown as Plugin
     const config = {
       root: '.',
-      input: { path: './petStore.yaml' },
+      input: './petStore.yaml',
       output: { path: './gen' },
       parsers: [],
       reporters: [],

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -41,6 +41,16 @@ export const diagnosticCode = {
    */
   inputRequired: 'KUBB_INPUT_REQUIRED',
   /**
+   * `input` uses the v4 `{ path }` / `{ data }` wrapper, which v5 reads as a parsed
+   * document instead of a pointer to one.
+   */
+  legacyInput: 'KUBB_LEGACY_INPUT',
+  /**
+   * The parsed `input` carries no `openapi` or `swagger` version, so it is not a
+   * document the adapter can read.
+   */
+  invalidDocument: 'KUBB_INVALID_DOCUMENT',
+  /**
    * A `$ref` (or equivalent reference) could not be resolved in the source document.
    */
   refNotFound: 'KUBB_REF_NOT_FOUND',

--- a/packages/core/src/createKubb.test.ts
+++ b/packages/core/src/createKubb.test.ts
@@ -36,9 +36,7 @@ describe('createKubb', () => {
 
   const config = {
     root: '.',
-    input: {
-      path: 'https://petstore3.swagger.io/api/v3/openapi.json',
-    },
+    input: 'https://petstore3.swagger.io/api/v3/openapi.json',
     output: {
       path: './src/gen',
       clean: true,
@@ -71,9 +69,7 @@ describe('createKubb', () => {
 
   test('resolves config defaults in the constructor, before setup', () => {
     const userConfig = {
-      input: {
-        path: 'https://petstore3.swagger.io/api/v3/openapi.json',
-      },
+      input: 'https://petstore3.swagger.io/api/v3/openapi.json',
       output: {
         path: './src/gen',
       },
@@ -409,9 +405,7 @@ describe('createKubb', () => {
   it('does not throw when userConfig.plugins is undefined', async () => {
     const userConfig: UserConfig = {
       root: '.',
-      input: {
-        path: 'https://petstore3.swagger.io/api/v3/openapi.json',
-      },
+      input: 'https://petstore3.swagger.io/api/v3/openapi.json',
       output: {
         path: './src/gen',
       },
@@ -711,7 +705,7 @@ describe('createKubb', () => {
 describe('Kubb#generate', () => {
   const makeConfig = (overrides: Partial<Config> = {}): Config => ({
     root: '.',
-    input: { path: './petStore.yaml' },
+    input: './petStore.yaml',
     output: { path: './gen' },
     parsers: [],
     reporters: [],

--- a/packages/core/src/input.test.ts
+++ b/packages/core/src/input.test.ts
@@ -84,4 +84,23 @@ describe('inputToAdapterSource', () => {
       expect(Diagnostics.isError(error) && error.diagnostic.code).toBe(Diagnostics.code.inputRequired)
     }
   })
+
+  it.each([
+    ['a v4 path wrapper', { path: './petStore.yaml' }],
+    ['a v4 data wrapper', { data: { openapi: '3.1.0' } }],
+    ['a v4 wrapper carrying both keys', { path: './petStore.yaml', data: { openapi: '3.1.0' } }],
+    ['a v4 array of path wrappers', [{ path: './petStore.yaml' }]],
+  ])('throws a legacy diagnostic for %s', (_name, input) => {
+    try {
+      inputToAdapterSource(createConfig(input as Config['input']))
+      expect.unreachable('expected inputToAdapterSource to throw')
+    } catch (error) {
+      expect(Diagnostics.isError(error) && error.diagnostic.code).toBe(Diagnostics.code.legacyInput)
+    }
+  })
+
+  it('passes a parsed spec that happens to carry a path property', () => {
+    const data = { openapi: '3.1.0', path: './petStore.yaml' }
+    expect(inputToAdapterSource(createConfig(data))).toStrictEqual({ type: 'data', data })
+  })
 })

--- a/packages/core/src/input.ts
+++ b/packages/core/src/input.ts
@@ -32,6 +32,30 @@ export function getInputKind(input: NonNullable<Input>): InputKind {
 }
 
 /**
+ * The v4 `input` wrapper keys. v4 typed `input` as `{ path }` or `{ data }`; v5 takes the value
+ * directly, so the wrapper now matches the "already-parsed document" branch and silently yields
+ * an empty build.
+ */
+const legacyInputKeys = ['path', 'data']
+
+/**
+ * Detects the v4 `{ path }` / `{ data }` wrapper so it fails loudly instead of being read as a
+ * document. A real spec always carries more than these keys, so an object whose keys are drawn
+ * only from them is the old shape rather than a document that happens to have a `path` property.
+ */
+function isLegacyInput(input: unknown): boolean {
+  if (Array.isArray(input)) {
+    return input.some(isLegacyInput)
+  }
+
+  if (typeof input !== 'object' || input === null) return false
+
+  const keys = Object.keys(input)
+
+  return keys.length > 0 && keys.every((key) => legacyInputKeys.includes(key))
+}
+
+/**
  * Normalizes `config.input` into an `AdapterSource` the adapter can parse.
  *
  * A parsed object and inline content become `{ type: 'data' }`; a URL is kept verbatim and a
@@ -39,6 +63,16 @@ export function getInputKind(input: NonNullable<Input>): InputKind {
  */
 export function inputToAdapterSource(config: Config): AdapterSource {
   const input = config.input
+
+  if (input && isLegacyInput(input)) {
+    throw new Diagnostics.Error({
+      code: Diagnostics.code.legacyInput,
+      severity: 'error',
+      message: 'The `input` option uses the v4 `{ path }` / `{ data }` wrapper.',
+      help: 'Unwrap it: `input: { path: "./petStore.yaml" }` becomes `input: "./petStore.yaml"`, and `input: { data: spec }` becomes `input: spec`.',
+      location: { kind: 'config' },
+    })
+  }
 
   if (!input) {
     throw new Diagnostics.Error({

--- a/packages/kubb/src/defineConfig.test.ts
+++ b/packages/kubb/src/defineConfig.test.ts
@@ -12,9 +12,7 @@ describe('defineConfig', () => {
 
   const baseConfig: UserConfig = {
     root: '.',
-    input: {
-      path: 'https://petstore3.swagger.io/api/v3/openapi.json',
-    },
+    input: 'https://petstore3.swagger.io/api/v3/openapi.json',
     output: {
       path: './src/gen',
       clean: true,


### PR DESCRIPTION
## 🎯 Changes

Found while validating [chrisdoc/hevy-mcp](https://github.com/chrisdoc/hevy-mcp) against v5. Its config still carries the v4 `input: { path }` wrapper, and on `5.0.0-beta.106` that produced no types, no client, and no schemas while printing `Generation succeeded` and exiting `0`. A CI pipeline would go green with an empty client.

Two things combined to hide it:

1. `Input` is `string | Record<string, unknown>`, and `inputToAdapterSource` treats any non-string as an already-parsed spec. So `{ path: './petStore.yaml' }` was read as the document itself. It still type-checks, so `tsc` did not flag it either.
2. `validateDocument` defaults to `throwOnError: false` and `parse` calls it without options, so the resulting "this is not an OpenAPI document" error was swallowed.

### `KUBB_LEGACY_INPUT`

`inputToAdapterSource` now rejects the v4 `{ path }` / `{ data }` wrapper and points at the unwrapped form. Detection is deliberately narrow: an object whose keys are drawn only from `path` and `data`. A parsed spec that happens to carry a `path` property still passes, and that case is covered by a test.

### `KUBB_INVALID_DOCUMENT`

Lenient validation is the right default, so this does not change it. A document declaring neither `openapi` nor `swagger` is the one failure that can never yield a usable build, so `assertDocument` makes that case fatal regardless of the `validate` option. Every other validation failure stays non-fatal.

### Test fixtures

The `@kubb/core` and `kubb` fixtures still used the v4 wrapper and only passed because it was silently accepted, so they move to the v5 single-value form.

### Verified

Built the packages and ran the real hevy-mcp spec through the CLI:

| Input | Before | After |
| --- | --- | --- |
| `input: { path: './openapi-spec.json' }` | `✓ Generation succeeded`, 3 files, exit `0` | `KUBB_LEGACY_INPUT`, exit `1` |
| a JSON file that is not a spec | `✓ Generation succeeded`, 3 files, exit `0` | `KUBB_INVALID_DOCUMENT`, exit `1` |
| `input: './openapi-spec.json'` | 129 files, exit `0` | unchanged |

Full suite green: 89 files, 1398 tests. `pnpm lint` and `pnpm typecheck` clean.

Docs for both codes are in kubb-labs/docs#168.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).