### PR TITLE
fix(adapter-oas): default unknownType and emptySchemaType to unknown

### DIFF
--- a/.changeset/adapter-oas-unknown-not-any-default.md
+++ b/.changeset/adapter-oas-unknown-not-any-default.md
@@ -1,0 +1,7 @@
+---
+'@kubb/adapter-oas': patch
+---
+
+Default `unknownType` and `emptySchemaType` to `'unknown'` instead of `'any'`.
+
+Schemas the parser can't pin down a type for now generate `unknown` by default instead of `any`: `additionalProperties: {}`, `patternProperties` with an empty or `true` value, a tuple's open tail (`items: true` or absent), a completely empty schema (`{}`), and a `not` schema. This matches what the `unknownType: 'unknown'` override already did for users who set it, and keeps generated output clean under `no-explicit-any` lint rules without any config. Pass `unknownType: 'any'` (and/or `emptySchemaType: 'any'`) to restore the previous behavior.

--- a/packages/adapter-oas/src/constants.ts
+++ b/packages/adapter-oas/src/constants.ts
@@ -6,8 +6,8 @@ import type { ast } from '@kubb/ast'
 export const DEFAULT_PARSER_OPTIONS = {
   dateType: 'string',
   integerType: 'bigint',
-  unknownType: 'any',
-  emptySchemaType: 'any',
+  unknownType: 'unknown',
+  emptySchemaType: 'unknown',
   enumSuffix: 'enum',
 } as const satisfies ast.ParserOptions
 

--- a/packages/adapter-oas/src/emit/converters/structural.ts
+++ b/packages/adapter-oas/src/emit/converters/structural.ts
@@ -103,14 +103,14 @@ export function convertObject({ schema, name, nullable, defaultValue, rawOptions
 /**
  * Converts an OAS 3.1 `prefixItems` tuple into a `TupleSchemaNode`.
  */
-export function convertTuple({ schema, name, nullable, defaultValue, rawOptions, parse }: ConvertContext): ast.SchemaNode {
+export function convertTuple({ schema, name, nullable, defaultValue, rawOptions, options, parse }: ConvertContext): ast.SchemaNode {
   const tupleItems = (schema.prefixItems ?? []).map((item) => parse({ schema: item as SchemaObject }, rawOptions))
-  // items: false closes the tuple; absent/true widens the tail to any.
+  // items: false closes the tuple; absent/true widens the tail to unknownType.
   const rest =
     schema.items === false
       ? undefined
       : !schema.items || schema.items === true
-        ? ast.factory.createSchema({ type: 'any' })
+        ? ast.factory.createSchema({ type: options.unknownType })
         : parse({ schema: schema.items as SchemaObject }, rawOptions)
 
   return createNode(

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -1752,7 +1752,7 @@ describe('parseSchema object additionalProperties', () => {
     const narrowed = ast.narrowSchema(node, 'object')
 
     expect(node.type).toBe('object')
-    expect(narrowed?.additionalProperties).toMatchObject({ type: 'any' })
+    expect(narrowed?.additionalProperties).toMatchObject({ type: 'unknown' })
   })
 
   it('respects unknownType option for empty additionalProperties', () => {
@@ -1825,7 +1825,7 @@ describe('parseSchema object patternProperties', () => {
     })
     const narrowed = ast.narrowSchema(node, 'object')
 
-    expect(narrowed?.patternProperties?.['^x-']).toMatchObject({ type: 'any' })
+    expect(narrowed?.patternProperties?.['^x-']).toMatchObject({ type: 'unknown' })
   })
 
   it('pattern schema true falls back to unknownType', () => {
@@ -1839,7 +1839,7 @@ describe('parseSchema object patternProperties', () => {
     })
     const narrowed = ast.narrowSchema(node, 'object')
 
-    expect(narrowed?.patternProperties?.['^x-']).toMatchObject({ type: 'any' })
+    expect(narrowed?.patternProperties?.['^x-']).toMatchObject({ type: 'unknown' })
   })
 
   it('patternProperties triggers object even without type or properties', () => {
@@ -2002,13 +2002,13 @@ describe('parseSchema prefixItems (tuple)', () => {
     expect(narrowed?.rest?.type).toBe('number')
   })
 
-  it('defaults rest to any when items is absent', () => {
+  it('defaults rest to unknownType when items is absent', () => {
     const node = parseSchema(ctx, {
       schema: { prefixItems: [{ type: 'string' }] },
     })
     const narrowed = ast.narrowSchema(node, 'tuple')
 
-    expect(narrowed?.rest?.type).toBe('any')
+    expect(narrowed?.rest?.type).toBe('unknown')
   })
 
   it('omits rest when items is false — closed tuple', () => {
@@ -2021,13 +2021,13 @@ describe('parseSchema prefixItems (tuple)', () => {
     expect(narrowed?.rest).toBeUndefined()
   })
 
-  it('defaults rest to any when items is true', () => {
+  it('defaults rest to unknownType when items is true', () => {
     const node = parseSchema(ctx, {
       schema: { prefixItems: [{ type: 'string' }], items: true },
     })
     const narrowed = ast.narrowSchema(node, 'tuple')
 
-    expect(narrowed?.rest?.type).toBe('any')
+    expect(narrowed?.rest?.type).toBe('unknown')
   })
 
   it('converts a $ref prefixItem to a ref node', () => {
@@ -3535,11 +3535,11 @@ describe('parseSchema constraints', () => {
 
 describe('parser options', () => {
   describe('emptySchemaType', () => {
-    it('defaults to any for a schema with no type information', () => {
+    it('defaults to unknown for a schema with no type information', () => {
       const ctx = { document: emptyDocument, refs: createRefs(emptyDocument) }
       const node = parseSchema(ctx, { schema: {} })
 
-      expect(node.type).toBe('any')
+      expect(node.type).toBe('unknown')
     })
 
     it('emptySchemaType: any returns any for an empty schema', () => {
@@ -3762,7 +3762,7 @@ describe('parser options', () => {
 describe('parseSchema not keyword', () => {
   const ctx = { document: emptyDocument, refs: createRefs(emptyDocument) }
 
-  it('falls through to the emptySchemaType (any by default) since "not" is not supported', () => {
+  it('falls through to the emptySchemaType (unknown by default) since "not" is not supported', () => {
     // JSON Schema `not` has no direct equivalent in most code generators.
     // The parser intentionally does not handle it and falls through to the configured emptySchemaType.
     // Cast required: `not` is valid JSON Schema / OAS 3.1 but not in the TS SchemaObject type.
@@ -3770,7 +3770,7 @@ describe('parseSchema not keyword', () => {
       schema: { not: { type: 'string' } } as SchemaObject,
     })
 
-    expect(node.type).toBe('any')
+    expect(node.type).toBe('unknown')
   })
 
   it('respects emptySchemaType option when falling through for not keyword', () => {
@@ -4342,10 +4342,10 @@ describe('buildAst – parameter description propagation', async () => {
 describe('unknownType / emptySchemaType → SchemaNode type', () => {
   const ctx = { document: emptyDocument, refs: createRefs(emptyDocument) }
 
-  it('empty schema produces type: any by default', () => {
+  it('empty schema produces type: unknown by default', () => {
     const node = parseSchema(ctx, { schema: {} as SchemaObject })
 
-    expect(node.type).toBe('any')
+    expect(node.type).toBe('unknown')
   })
 
   it('empty schema produces type: unknown when emptySchemaType is unknown', () => {
@@ -4360,7 +4360,7 @@ describe('unknownType / emptySchemaType → SchemaNode type', () => {
     expect(node.type).toBe('void')
   })
 
-  it('unannotated additionalProperties produce type: any by default', () => {
+  it('unannotated additionalProperties produce type: unknown by default', () => {
     const node = ast.narrowSchema(
       parseSchema(ctx, {
         schema: { type: 'object', additionalProperties: {} } as SchemaObject,
@@ -4368,7 +4368,7 @@ describe('unknownType / emptySchemaType → SchemaNode type', () => {
       'object',
     )
 
-    expect(node?.additionalProperties).toMatchObject({ type: 'any' })
+    expect(node?.additionalProperties).toMatchObject({ type: 'unknown' })
   })
 
   it('unannotated additionalProperties produce type: unknown when unknownType is unknown', () => {


### PR DESCRIPTION
## 🎯 Changes

While benchmarking kubb v5 beta against a DEV.to comparison article (openapi-typescript vs hey-api vs Orval vs Kubb), generated output on a synthetic 1,200-operation drf-spectacular-shaped schema produced 1,000 `oxlint no-explicit-any` errors, all traceable to one root cause: `@kubb/adapter-oas`'s `DEFAULT_PARSER_OPTIONS` defaulted `unknownType` and `emptySchemaType` to `'any'`.

Every place the parser can't pin down a concrete type fell back to `any` by default:
- `additionalProperties: {}` (and `patternProperties` with an empty or `true` value)
- a tuple's open tail (`items: true` or absent) — this one was hardcoded to `'any'` directly in `convertTuple`, bypassing the option entirely
- a completely empty schema (`{}`)
- an unsupported `not` schema
- a response status with no content (e.g. a 204), which resolves through the same empty-schema fallback

This change defaults both options to `'unknown'` instead, matching what `unknownType: 'unknown'` already did for users who set it explicitly (as the `plugin-fetch`/`plugin-axios` example configs in the plugins repo already do). `unknownType: 'any'` (and/or `emptySchemaType: 'any'`) still restores the previous behavior.

Verified on the same synthetic schema: `oxlint --no-explicit-any` on generated output went from 1,000 errors to 0, with no change in generation time or file count, and `tsc --noEmit` still passes clean.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test` (adapter-oas: 504/504 passing; full suite: 1380/1381 passing, the one pre-existing failure is unrelated — a missing `verkit` dependency in this sandbox, reproduced identically on unmodified `main`).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).


---
_Generated by [Claude Code](https://claude.ai/code/session_01QLVhDXazJnNvU7bypUF7ad)_