### PR TITLE
feat(adapter-oas): code URL input failures instead of KUBB_UNKNOWN

### DIFF
--- a/.changeset/coded-url-input-failures.md
+++ b/.changeset/coded-url-input-failures.md
@@ -1,0 +1,19 @@
+---
+'@kubb/adapter-oas': minor
+'@kubb/core': minor
+---
+
+Give a failing URL `input` its own diagnostic code instead of `KUBB_UNKNOWN`.
+
+A URL that answers with a 4xx or 5xx status now reports `KUBB_INPUT_REQUEST_FAILED`, with the
+status in the message and a fix tuned to it: a 401 or 403 points at the missing credentials Kubb
+does not send, a 404 at the URL, and a 5xx at the server.
+
+A URL that never answers reports `KUBB_INPUT_UNREACHABLE`. Node hides the reason for a refused
+connection behind a bare `fetch failed` with an empty message, so the run used to print only a
+stack. The reason is now dug out of the cause chain and shown, for example
+`Cannot reach http://localhost:8000/api/schema/: connect ECONNREFUSED 127.0.0.1:8000`.
+
+Both codes cover URLs reached through a `$ref` as well, so a document that pulls a remote schema
+names the URL that failed. Each has a page under
+[Diagnostics](https://kubb.dev/docs/5.x/reference/diagnostics), linked from the terminal output.

--- a/.changeset/coded-url-input-failures.md
+++ b/.changeset/coded-url-input-failures.md
@@ -5,15 +5,4 @@
 
 Give a failing URL `input` its own diagnostic code instead of `KUBB_UNKNOWN`.
 
-A URL that answers with a 4xx or 5xx status now reports `KUBB_INPUT_REQUEST_FAILED`, with the
-status in the message and a fix tuned to it: a 401 or 403 points at the missing credentials Kubb
-does not send, a 404 at the URL, and a 5xx at the server.
-
-A URL that never answers reports `KUBB_INPUT_UNREACHABLE`. Node hides the reason for a refused
-connection behind a bare `fetch failed` with an empty message, so the run used to print only a
-stack. The reason is now dug out of the cause chain and shown, for example
-`Cannot reach http://localhost:8000/api/schema/: connect ECONNREFUSED 127.0.0.1:8000`.
-
-Both codes cover URLs reached through a `$ref` as well, so a document that pulls a remote schema
-names the URL that failed. Each has a page under
-[Diagnostics](https://kubb.dev/docs/5.x/reference/diagnostics), linked from the terminal output.
+`KUBB_INPUT_REQUEST_FAILED` covers a 4xx or 5xx response and carries the status. `KUBB_INPUT_UNREACHABLE` covers a URL that never answers, with the reason (`connect ECONNREFUSED 127.0.0.1:8000`) pulled out of the cause chain Node hides behind an empty `fetch failed`. Both also apply to URLs reached through a `$ref`.

--- a/packages/adapter-oas/src/load/normalize.test.ts
+++ b/packages/adapter-oas/src/load/normalize.test.ts
@@ -279,10 +279,16 @@ describe('bundleDocument', () => {
     expect(requestedUrls).toStrictEqual(['https://specs.example.com/main.yaml', 'https://specs.example.com/schemas/Pet.yaml'])
   })
 
-  it('throws when the input URL cannot be fetched', async () => {
+  it('throws an input-request-failed diagnostic when the input URL answers with an error status', async () => {
     using _fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(mockFetch)
 
-    await expect(bundleDocument('https://specs.example.com/missing.yaml')).rejects.toThrow('HTTP 404')
+    try {
+      await bundleDocument('https://specs.example.com/missing.yaml')
+      expect.unreachable('expected bundleDocument to throw')
+    } catch (error) {
+      expect(Diagnostics.isError(error) && error.diagnostic.code).toBe(Diagnostics.code.inputRequestFailed)
+      expect(Diagnostics.isError(error) && error.diagnostic.message).toContain('HTTP 404')
+    }
   })
 
   it('throws when the input file does not exist', async () => {

--- a/packages/adapter-oas/src/load/source.test.ts
+++ b/packages/adapter-oas/src/load/source.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from 'vitest'
+import { Diagnostics } from '@kubb/core'
+import { resolveSource } from './source.ts'
+
+function codeOf(error: unknown): string | undefined {
+  return Diagnostics.isError(error) ? error.diagnostic.code : undefined
+}
+
+describe('resolveSource', () => {
+  it.each([
+    [401, 'Kubb sends no credentials'],
+    [403, 'Kubb sends no credentials'],
+    [404, 'Open it in a browser'],
+    [418, 'Open the URL in a browser'],
+    [500, 'The server failed while serving the document'],
+    [503, 'The server failed while serving the document'],
+  ])('reports HTTP %i as an input-request-failed diagnostic', async (status, help) => {
+    using _fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('nope', { status }))
+
+    try {
+      await resolveSource('https://specs.example.com/openapi.yaml')
+      expect.unreachable('expected resolveSource to throw')
+    } catch (error) {
+      expect(codeOf(error)).toBe(Diagnostics.code.inputRequestFailed)
+      expect(Diagnostics.isError(error) && error.diagnostic.message).toContain(`HTTP ${status}`)
+      expect(Diagnostics.isError(error) && error.diagnostic.help).toContain(help)
+    }
+  })
+
+  it('names the URL that failed so a broken $ref is identifiable', async () => {
+    using _fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('nope', { status: 404 }))
+
+    await expect(resolveSource('https://specs.example.com/schemas/Pet.yaml')).rejects.toThrow('https://specs.example.com/schemas/Pet.yaml')
+  })
+
+  it('reports an unreachable host as an input-unreachable diagnostic carrying the connection reason', async () => {
+    const failure = new TypeError('fetch failed', { cause: new AggregateError([new Error('connect ECONNREFUSED 127.0.0.1:8000')], '') })
+    using _fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(failure)
+
+    try {
+      await resolveSource('http://localhost:8000/api/schema/')
+      expect.unreachable('expected resolveSource to throw')
+    } catch (error) {
+      expect(codeOf(error)).toBe(Diagnostics.code.inputUnreachable)
+      expect(Diagnostics.isError(error) && error.diagnostic.message).toBe('Cannot reach http://localhost:8000/api/schema/: connect ECONNREFUSED 127.0.0.1:8000')
+    }
+  })
+
+  it('parses the document when the server answers with 200', async () => {
+    using _fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response("openapi: '3.1.0'", { status: 200 }))
+
+    await expect(resolveSource('https://specs.example.com/openapi.yaml')).resolves.toStrictEqual({ openapi: '3.1.0' })
+  })
+})

--- a/packages/adapter-oas/src/load/source.ts
+++ b/packages/adapter-oas/src/load/source.ts
@@ -5,10 +5,9 @@ import { parse } from 'yaml'
 const urlRegExp = /^https?:\/+/i
 
 /**
- * Digs the specific reason out of a `fetch` rejection. Node reports every connection failure as
- * `TypeError: fetch failed` and keeps the useful part (`connect ECONNREFUSED 127.0.0.1:8000`)
- * on `cause`, one level deeper again when a host resolves to several addresses and the attempts
- * are collected into an `AggregateError`.
+ * Node reports every connection failure as `TypeError: fetch failed` and keeps the useful part
+ * (`connect ECONNREFUSED 127.0.0.1:8000`) on `cause`, one level deeper again when a host resolves
+ * to several addresses and the attempts collect into an `AggregateError`.
  */
 function describeFetchFailure(error: unknown): string {
   if (error instanceof AggregateError && error.errors.length > 0) {
@@ -21,10 +20,6 @@ function describeFetchFailure(error: unknown): string {
   return getErrorMessage(error)
 }
 
-/**
- * The fix for a failed request, tuned to the status class so an authentication wall does not read
- * like a typo in the URL.
- */
 function helpForStatus(status: number): string {
   if (status === 401 || status === 403) {
     return 'The server refused the request. Kubb sends no credentials, so serve the document without authentication or download it and set `input` to the local file.'
@@ -39,11 +34,6 @@ function helpForStatus(status: number): string {
   return 'Open the URL in a browser or with `curl` to see what the server returns, then point `input` at a URL that serves the OpenAPI document.'
 }
 
-/**
- * Fetches a source URL, reporting a failure to reach the host as a coded `KUBB_INPUT_UNREACHABLE`
- * diagnostic. Node's `fetch` rejection carries an empty message, so the reason is dug out of the
- * cause chain and put in the message.
- */
 async function fetchSource(url: URL): Promise<Response> {
   try {
     return await fetch(url)

--- a/packages/adapter-oas/src/load/source.ts
+++ b/packages/adapter-oas/src/load/source.ts
@@ -1,18 +1,81 @@
-import { exists, read } from '@internals/utils'
+import { exists, getErrorMessage, read } from '@internals/utils'
 import { Diagnostics } from '@kubb/core'
 import { parse } from 'yaml'
 
 const urlRegExp = /^https?:\/+/i
+
+/**
+ * Digs the specific reason out of a `fetch` rejection. Node reports every connection failure as
+ * `TypeError: fetch failed` and keeps the useful part (`connect ECONNREFUSED 127.0.0.1:8000`)
+ * on `cause`, one level deeper again when a host resolves to several addresses and the attempts
+ * are collected into an `AggregateError`.
+ */
+function describeFetchFailure(error: unknown): string {
+  if (error instanceof AggregateError && error.errors.length > 0) {
+    return describeFetchFailure(error.errors[0])
+  }
+  if (error instanceof Error && error.cause instanceof Error) {
+    return describeFetchFailure(error.cause) || error.message
+  }
+
+  return getErrorMessage(error)
+}
+
+/**
+ * The fix for a failed request, tuned to the status class so an authentication wall does not read
+ * like a typo in the URL.
+ */
+function helpForStatus(status: number): string {
+  if (status === 401 || status === 403) {
+    return 'The server refused the request. Kubb sends no credentials, so serve the document without authentication or download it and set `input` to the local file.'
+  }
+  if (status === 404) {
+    return 'Check the URL. Open it in a browser or with `curl` to confirm it serves the OpenAPI document.'
+  }
+  if (status >= 500) {
+    return 'The server failed while serving the document. Check that it is healthy, then run Kubb again.'
+  }
+
+  return 'Open the URL in a browser or with `curl` to see what the server returns, then point `input` at a URL that serves the OpenAPI document.'
+}
+
+/**
+ * Fetches a source URL, reporting a failure to reach the host as a coded `KUBB_INPUT_UNREACHABLE`
+ * diagnostic. Node's `fetch` rejection carries an empty message, so the reason is dug out of the
+ * cause chain and put in the message.
+ */
+async function fetchSource(url: URL): Promise<Response> {
+  try {
+    return await fetch(url)
+  } catch (error) {
+    throw new Diagnostics.Error({
+      code: Diagnostics.code.inputUnreachable,
+      severity: 'error',
+      message: `Cannot reach ${url.href}: ${describeFetchFailure(error)}`,
+      help: 'Check that the host is running and reachable from this machine. For a local server, start it and confirm the port matches the one in `input`.',
+      location: { kind: 'config' },
+      cause: error instanceof Error ? error : undefined,
+    })
+  }
+}
 
 async function readSource(sourcePath: string): Promise<string> {
   if (urlRegExp.test(sourcePath)) {
     // api-ref-bundler joins relative refs with posix normalization, collapsing `https://` to
     // `https:/`. The WHATWG URL parser restores the double slash.
     const url = new URL(sourcePath)
-    const response = await fetch(url)
+    const response = await fetchSource(url)
 
     if (!response.ok) {
-      throw new Error(`Cannot fetch the OAS document at ${url.href} (HTTP ${response.status})`)
+      const status = response.statusText ? `${response.status} ${response.statusText}` : String(response.status)
+
+      throw new Diagnostics.Error({
+        code: Diagnostics.code.inputRequestFailed,
+        severity: 'error',
+        message: `The server at ${url.href} answered with HTTP ${status} instead of the OpenAPI document.`,
+        help: helpForStatus(response.status),
+        location: { kind: 'config' },
+      })
     }
 
     return response.text()
@@ -37,7 +100,8 @@ export async function resolveSource(sourcePath: string): Promise<object | string
 
 /**
  * Throws a coded `KUBB_INPUT_NOT_FOUND` diagnostic when a local input path does not exist.
- * URLs are skipped, and a malformed but readable file is left for `parseDocument` to surface
+ * URLs are skipped: a remote input reports `KUBB_INPUT_REQUEST_FAILED` or `KUBB_INPUT_UNREACHABLE`
+ * from the request itself. A malformed but readable file is left for `parseDocument` to surface
  * its parse error instead.
  */
 export async function assertInputExists(input: string): Promise<void> {

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -172,14 +172,14 @@ describe('buildAst', () => {
       const root = parseOas(oas)
       const nullableRef = ast.narrowSchema(
         root.schemas.find((s) => s.name === 'NullableRef'),
-        'ref',
+        'union',
       )
 
-      // Should be flattened to a ref — not an intersection
-      expect(nullableRef?.type).toBe('ref')
-      expect(nullableRef?.ref).toBe('#/components/schemas/Pet')
-      // nullable from the allOf member sibling is propagated to the ref node via buildSchemaNode.
-      expect(nullableRef?.nullable).toBe(true)
+      // The 3.1 upgrade rewrites `{ $ref, nullable: true }` into `anyOf: [$ref, null]`, so the
+      // single-member allOf flattens to that union instead of a ref carrying `nullable`.
+      expect(nullableRef?.type).toBe('union')
+      expect(nullableRef?.members?.map((member) => member.type)).toStrictEqual(['ref', 'null'])
+      expect(ast.narrowSchema(nullableRef?.members?.[0], 'ref')?.ref).toBe('#/components/schemas/Pet')
     })
 
     it('maps format date-time to datetime SchemaType', async () => {

--- a/packages/core/src/Diagnostics.ts
+++ b/packages/core/src/Diagnostics.ts
@@ -238,8 +238,20 @@ const diagnosticCatalog: Record<DiagnosticCode, DiagnosticDoc> = {
   },
   [diagnosticCode.inputNotFound]: {
     title: 'Input not found',
-    cause: 'The file or URL set as `input` (or passed as `kubb generate PATH`) could not be read.',
-    fix: 'Check that the path or URL exists and is readable, then set it as `input` or pass it on the CLI.',
+    cause:
+      'The file set as `input` (or passed as `kubb generate PATH`) could not be read. A URL reports `KUBB_INPUT_REQUEST_FAILED` or `KUBB_INPUT_UNREACHABLE` instead.',
+    fix: 'Check that the path exists and is readable, then set it as `input` or pass it on the CLI.',
+  },
+  [diagnosticCode.inputRequestFailed]: {
+    title: 'Input request failed',
+    cause: 'A URL set as `input` (or reached through a `$ref`) answered with a 4xx or 5xx status instead of the document.',
+    fix: 'Open the URL to see what the server returns. A 401 or 403 needs credentials Kubb does not send, so download the document and point `input` at the local file. A 404 means the path is wrong, and a 5xx means the server itself failed.',
+  },
+  [diagnosticCode.inputUnreachable]: {
+    title: 'Input unreachable',
+    cause:
+      'A URL set as `input` (or reached through a `$ref`) never answered, so the request failed before a status came back. A refused connection, an unknown host, an expired certificate, and a timeout all land here.',
+    fix: 'Check that the host is running and reachable from this machine. For a local server, start it and confirm the port matches the one in `input`.',
   },
   [diagnosticCode.inputRequired]: {
     title: 'Input required',

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -37,6 +37,16 @@ export const diagnosticCode = {
    */
   inputNotFound: 'KUBB_INPUT_NOT_FOUND',
   /**
+   * A URL set as `input` (or referenced by a `$ref`) answered with a 4xx or 5xx status
+   * instead of the document.
+   */
+  inputRequestFailed: 'KUBB_INPUT_REQUEST_FAILED',
+  /**
+   * A URL set as `input` (or referenced by a `$ref`) never answered, so the request failed
+   * before a status was returned.
+   */
+  inputUnreachable: 'KUBB_INPUT_UNREACHABLE',
+  /**
    * An adapter was configured without an `input`.
    */
   inputRequired: 'KUBB_INPUT_REQUIRED',


### PR DESCRIPTION
## 🎯 Changes

A URL set as `input` had no coded failure of its own. A 4xx or 5xx threw a bare `Error` and a connection failure threw Node's `TypeError: fetch failed`, so both landed on `KUBB_UNKNOWN` with no docs link, the second one printing an empty message and a stack.

Two codes now cover it, thrown from the OAS adapter's source reader so they also apply to URLs reached through a `$ref`:

```text
[KUBB_INPUT_REQUEST_FAILED]: The server at http://localhost:8000/api/schema/ answered with HTTP 404 Not Found instead of the OpenAPI document.
  fix: Check the URL. Open it in a browser or with `curl` to confirm it serves the OpenAPI document.
  see: https://kubb.dev/docs/5.x/reference/diagnostics/kubb-input-request-failed

[KUBB_INPUT_UNREACHABLE]: Cannot reach http://localhost:8000/api/schema/: connect ECONNREFUSED 127.0.0.1:8000
  fix: Check that the host is running and reachable from this machine. For a local server, start it and confirm the port matches the one in `input`.
  see: https://kubb.dev/docs/5.x/reference/diagnostics/kubb-input-unreachable
```

The request-failed help is tuned to the status class (401/403 to credentials, 404 to the URL, 5xx to the server). The unreachable reason is pulled out of the cause chain Node hides behind an empty `fetch failed`. Both are in the `diagnosticCatalog`, so they carry a title, cause, and fix through `Diagnostics.explain` and serialize with a `docsUrl` into `--reporter json` and the MCP tools.

Docs pages: kubb-labs/docs#175.

Separately, `parser.test.ts > flattens single-member allOf for nullable $ref` was already red on `main`. The 3.1 upgrade rewrites `{ $ref, nullable: true }` into `anyOf: [$ref, null]`, so the single-member allOf flattens to a union rather than a ref carrying `nullable`, and the test still described the pre-upgrade shape. Fixed here, so the suite is green.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

`pnpm build && pnpm test` is 1407 passing, 0 failing. `pnpm lint` and `pnpm typecheck` are clean.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).