### PR TITLE
perf(core): write generated files without a mkdir syscall each

### DIFF
--- a/.changeset/utils-write-fewer-syscalls.md
+++ b/.changeset/utils-write-fewer-syscalls.md
@@ -1,0 +1,9 @@
+---
+'@kubb/core': patch
+---
+
+Write generated files without a `mkdir` syscall each.
+
+Every write created its parent directory first, so a spec writing 2000 files into one directory made 2000 of those calls, 1999 of which did nothing. Kubb now writes the file and only creates the directory when the write reports it is missing, which also recovers when something removed the directory mid-run.
+
+Measured on 2000 generated files, medians of five runs alternating between the two builds: a cold build drops from 492ms to 427ms. A rebuild that writes nothing is unchanged.

--- a/internals/utils/src/fs.test.ts
+++ b/internals/utils/src/fs.test.ts
@@ -85,6 +85,16 @@ describe('read / write', () => {
     expect(result).toBeNull()
   })
 
+  test('write creates a missing directory, and recreates one that disappeared', async () => {
+    const nested = path.join(rwTestDir, 'nested', 'deep', 'file.ts')
+    await write(nested, 'const a = 1')
+    await rm(path.join(rwTestDir, 'nested'), { recursive: true, force: true })
+
+    await write(nested, 'const a = 1')
+
+    expect(await read(nested)).toBe('const a = 1\n')
+  })
+
   it('write returns undefined for empty/whitespace data', async () => {
     expect(await write(rwFilePath, '   ')).toBeNull()
   })

--- a/internals/utils/src/fs.ts
+++ b/internals/utils/src/fs.ts
@@ -93,8 +93,17 @@ export async function write(path: string, data: string, options: WriteOptions = 
     /* file doesn't exist yet */
   }
 
-  await mkdir(dirname(resolved), { recursive: true })
-  await writeFile(resolved, content, { encoding: 'utf-8' })
+  // Creating the directory up front costs a syscall per file, and every file after the first in a
+  // directory pays it for nothing. Write first and only fall back when the directory is missing,
+  // which also stays correct when something removed it mid-run.
+  try {
+    await writeFile(resolved, content, { encoding: 'utf-8' })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+
+    await mkdir(dirname(resolved), { recursive: true })
+    await writeFile(resolved, content, { encoding: 'utf-8' })
+  }
 
   if (options.sanity) {
     const savedData = await readFile(resolved, { encoding: 'utf-8' })


### PR DESCRIPTION
## 🎯 Changes

First item from #3863. `write()` created the parent directory before every write, so a spec writing 2000 files into one directory made 2000 `mkdir` calls and 1999 of them did nothing.

Kubb now writes the file and only creates the directory when the write reports it missing.

I picked that over caching the directories already seen. A cache goes stale the moment something removes the directory, which `output.clean` does between configs, and the write would then fail with `ENOENT` on a directory the cache still vouches for. The fallback recovers on its own. A test covers exactly that: write into a nested directory, delete it, write again.

### Measured

2000 generated files, medians of five runs per invocation, alternating between the two builds so machine drift cancels out. Four rounds:

| round | main | this branch |
| --- | --- | --- |
| 1 | 500 ms | 457 ms |
| 2 | 488 ms | 394 ms |
| 3 | 498 ms | 428 ms |
| 4 | 481 ms | 427 ms |

Cold build **492 ms → 427 ms, about -13%**, with this branch lower in every round. A rebuild that writes nothing is unchanged at ~355 ms, which is expected: no writes, no `mkdir` either. Peak RSS is unchanged at 83–85 MB.

### Two candidates measured and dropped

**Comparing without allocating a copy.** `matchesOnDisk` calls `disk.trimEnd()`, allocating a copy of every file just to compare it. Replacing that with `startsWith` plus a trim of the short tail should have cut ~10 MB of transient garbage at 2000 files. Measured three-way against a build carrying only the `mkdir` change, it was consistently **slower**:

| | main | mkdir only | mkdir + comparison |
| --- | --- | --- | --- |
| round 1 | 432 ms | **374 ms** | 413 ms |
| round 2 | 540 ms | **414 ms** | 457 ms |

So it is not in this PR. The single `trimEnd` comparison also reads better than three operations.

**Removing `fsStorage`'s inner limiter.** `FileManager` already bounds writes at `FILE_CONCURRENCY`, so the `createLimiter(50)` inside `fsStorage.writeItem` never engages when called through it. But `fsStorage` is public API and a direct caller still needs the bound, so that is a design decision rather than a cleanup. Left alone, still noted in #3863.

### A correction to the issue

#3863 estimated this at roughly 262 ms based on a micro-benchmark of 2000 sequential `mkdir` calls. The real saving is about 65 ms, because the write pipeline runs 50-way concurrent and the syscall latency largely hides behind other I/O. The micro-benchmark overstated it by roughly 4x. Still a win, and strictly fewer syscalls with no downside, but worth recording so the next person does not trust that number.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

`pnpm test` (1445 passing), `pnpm lint`, and typecheck are clean. One unrelated failure exists here and on a clean `main` alike: `packages/mcp/src/tools/generate.test.ts` cannot resolve `@kubb/adapter-oas/dist/index.cjs` without a build first.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

---
_Generated by [Claude Code](https://claude.ai/code/session_01R1yVYTKc5dHUEgMAdKRc9d)_