### PR TITLE
perf(core): drop the parsed source from file-processing update rows

### DIFF
--- a/.changeset/core-stream-processing-updates.md
+++ b/.changeset/core-stream-processing-updates.md
@@ -2,8 +2,8 @@
 '@kubb/core': patch
 ---
 
-Release file-processing updates as they happen instead of holding the whole batch.
+Stop holding every generated source in memory during the write pass.
 
-Every row was collected and only handed to `kubb:files:processing:update` once the last file had landed. Each row carries the parsed source, so the whole output tree sat in memory until the batch finished.
+`kubb:files:processing:update` rows carried the file's parsed source, and the driver buffered every row until the last file had been written, so the whole output tree stayed live for the batch. Nothing read that field: the CLI loggers, the MCP tool, and the Studio agent all use `file`, `processed`, `total`, and `percentage`.
 
-A row now goes out as soon as every earlier one has, which keeps them in generation order. On 5000 files of about 8KB, peak heap drops from 102MB to 67MB and peak RSS from 179MB to 141MB, with generation time unchanged.
+`source` is gone from `KubbFileProcessingUpdate`, and rows are skipped altogether when no listener is registered. Batching, ordering, and the single flush at the end of the pass are unchanged. On 5000 files of about 8KB, peak heap drops from 102MB to 68MB and peak RSS from 179MB to 141MB.

--- a/.changeset/core-stream-processing-updates.md
+++ b/.changeset/core-stream-processing-updates.md
@@ -4,8 +4,6 @@
 
 Release file-processing updates as they happen instead of holding the whole batch.
 
-The write pass bounds how many files it parses at once, but the driver collected every row it emitted and only handed them to `kubb:files:processing:update` once the last file had landed. Each row carries the parsed source, so the whole output tree sat in memory until the batch finished, and progress arrived in one jump at the end.
+Every row was collected and only handed to `kubb:files:processing:update` once the last file had landed. Each row carries the parsed source, so the whole output tree sat in memory until the batch finished.
 
-A row now goes out as soon as every earlier one has. That keeps them in generation order, and the only rows waiting are the ones the concurrent writes finished early.
-
-Measured on 5000 generated files of about 8KB, medians of three runs alternating between the two builds: peak heap drops from 102MB to 67MB, peak RSS from 179MB to 141MB. Generation time is unchanged.
+A row now goes out as soon as every earlier one has, which keeps them in generation order. On 5000 files of about 8KB, peak heap drops from 102MB to 67MB and peak RSS from 179MB to 141MB, with generation time unchanged.

--- a/.changeset/core-stream-processing-updates.md
+++ b/.changeset/core-stream-processing-updates.md
@@ -1,0 +1,11 @@
+---
+'@kubb/core': patch
+---
+
+Release file-processing updates as they happen instead of holding the whole batch.
+
+The write pass bounds how many files it parses at once, but the driver collected every row it emitted and only handed them to `kubb:files:processing:update` once the last file had landed. Each row carries the parsed source, so the whole output tree sat in memory until the batch finished, and progress arrived in one jump at the end.
+
+A row now goes out as soon as every earlier one has. That keeps them in generation order, and the only rows waiting are the ones the concurrent writes finished early.
+
+Measured on 5000 generated files of about 8KB, medians of three runs alternating between the two builds: peak heap drops from 102MB to 67MB, peak RSS from 179MB to 141MB. Generation time is unchanged.

--- a/packages/core/src/KubbDriver.ts
+++ b/packages/core/src/KubbDriver.ts
@@ -309,12 +309,9 @@ export class KubbDriver {
         await hooks.callHook('kubb:files:processing:start', { files })
       },
       update: ({ file, processed, total, percentage }) => {
-        // Nobody is listening, so there is nothing to buffer for.
-        if (hooks.listenerCount('kubb:files:processing:update') === 0) return
-
-        // The parsed source is deliberately dropped here. It is the only heavy field on a row, and
-        // keeping it would hold every generated file in memory until the batch ends, undoing the
-        // bound `fileManager.write` puts on how many sources exist at once.
+        // The row deliberately leaves `source` behind. It is the only heavy field, and buffering it
+        // holds every generated file in memory until the batch ends, undoing the bound
+        // `fileManager.write` puts on how many sources exist at once.
         updateBuffer.push({ file, processed, total, percentage, config })
       },
       end: async (files: Array<FileNode>) => {

--- a/packages/core/src/KubbDriver.ts
+++ b/packages/core/src/KubbDriver.ts
@@ -16,7 +16,17 @@ import { createNodeCache } from './nodeCache.ts'
 import type { OutputManifest } from './outputManifest.ts'
 import { inputToAdapterSource } from './input.ts'
 
-import type { Adapter, AdapterSource, Config, GeneratorContext, Group, KubbHooks, NormalizedPlugin, PluginFactoryOptions } from './types.ts'
+import type {
+  Adapter,
+  AdapterSource,
+  Config,
+  GeneratorContext,
+  Group,
+  KubbFileProcessingUpdate,
+  KubbHooks,
+  NormalizedPlugin,
+  PluginFactoryOptions,
+} from './types.ts'
 import type { Hookable } from './Hookable.ts'
 
 type Options = {
@@ -284,7 +294,6 @@ export class KubbDriver {
   async run(): Promise<{ diagnostics: Array<Diagnostic> }> {
     const { hooks, config, fileManager } = this
     const diagnostics: Array<Diagnostic> = []
-    const updateBuffer: Array<{ file: FileNode; source?: string; processed: number; total: number; percentage: number }> = []
     const parsersMap = new Map<FileNode['extname'], Parser>()
 
     for (const parser of config.parsers) {
@@ -293,22 +302,53 @@ export class KubbDriver {
       }
     }
 
+    // Files parse concurrently, so rows arrive in completion order while `processed` carries each
+    // file's input position. A row waits here only until every earlier one has gone out, which is
+    // what keeps generation order. Holding them all until the batch ends would instead pin every
+    // parsed source in memory for the whole write pass, undoing the bound `fileManager.write` puts
+    // on how many sources exist at once.
+    const pending = new Map<number, KubbFileProcessingUpdate>()
+    let nextToSend = 1
+    // Chunks are handed to the hook one at a time, so a listener that awaits cannot let a later
+    // chunk overtake an earlier one.
+    let sending: Promise<void> = Promise.resolve()
+
+    const send = (rows: Array<KubbFileProcessingUpdate>): Promise<void> => {
+      sending = sending.then(() => hooks.callHook('kubb:files:processing:update', { files: rows }))
+      return sending
+    }
+
+    const takeReady = (): Array<KubbFileProcessingUpdate> => {
+      const rows: Array<KubbFileProcessingUpdate> = []
+      for (let row = pending.get(nextToSend); row; row = pending.get(nextToSend)) {
+        rows.push(row)
+        pending.delete(nextToSend)
+        nextToSend++
+      }
+      return rows
+    }
+
     const unhookWrites = fileManager.hooks.addHooks({
       start: async (files) => {
         await hooks.callHook('kubb:files:processing:start', { files })
       },
       update: (item) => {
-        updateBuffer.push(item)
+        pending.set(item.processed, { ...item, config })
+
+        // Queued, not awaited. Returning the promise here would make each file wait for every
+        // earlier one to be delivered, which turns the concurrent write pass back into a serial
+        // one. A listener that rejects surfaces at `end`, where the chain is awaited.
+        const rows = takeReady()
+        if (rows.length) void send(rows)
       },
       end: async (files: Array<FileNode>) => {
-        // Files parse concurrently, so the buffer arrives in completion order. `processed` is each
-        // file's input position, so sorting by it restores generation order for the streamed rows.
-        updateBuffer.sort((a, b) => a.processed - b.processed)
+        // Every file reports, so the run above always drains. Release anything left in input order
+        // regardless, so a future caller that skips a position cannot strand the rows behind it.
+        const rows = [...pending.values()].sort((a, b) => a.processed - b.processed)
+        pending.clear()
+        if (rows.length) await send(rows)
 
-        await hooks.callHook('kubb:files:processing:update', {
-          files: updateBuffer.map((item) => ({ ...item, config })),
-        })
-        updateBuffer.length = 0
+        await sending
         await hooks.callHook('kubb:files:processing:end', { files })
       },
     })

--- a/packages/core/src/KubbDriver.ts
+++ b/packages/core/src/KubbDriver.ts
@@ -302,53 +302,28 @@ export class KubbDriver {
       }
     }
 
-    // Files parse concurrently, so rows arrive in completion order while `processed` carries each
-    // file's input position. A row waits here only until every earlier one has gone out, which is
-    // what keeps generation order. Holding them all until the batch ends would instead pin every
-    // parsed source in memory for the whole write pass, undoing the bound `fileManager.write` puts
-    // on how many sources exist at once.
-    const pending = new Map<number, KubbFileProcessingUpdate>()
-    let nextToSend = 1
-    // Chunks are handed to the hook one at a time, so a listener that awaits cannot let a later
-    // chunk overtake an earlier one.
-    let sending: Promise<void> = Promise.resolve()
-
-    const send = (rows: Array<KubbFileProcessingUpdate>): Promise<void> => {
-      sending = sending.then(() => hooks.callHook('kubb:files:processing:update', { files: rows }))
-      return sending
-    }
-
-    const takeReady = (): Array<KubbFileProcessingUpdate> => {
-      const rows: Array<KubbFileProcessingUpdate> = []
-      for (let row = pending.get(nextToSend); row; row = pending.get(nextToSend)) {
-        rows.push(row)
-        pending.delete(nextToSend)
-        nextToSend++
-      }
-      return rows
-    }
+    const updateBuffer: Array<KubbFileProcessingUpdate> = []
 
     const unhookWrites = fileManager.hooks.addHooks({
       start: async (files) => {
         await hooks.callHook('kubb:files:processing:start', { files })
       },
-      update: (item) => {
-        pending.set(item.processed, { ...item, config })
+      update: ({ file, processed, total, percentage }) => {
+        // Nobody is listening, so there is nothing to buffer for.
+        if (hooks.listenerCount('kubb:files:processing:update') === 0) return
 
-        // Queued, not awaited. Returning the promise here would make each file wait for every
-        // earlier one to be delivered, which turns the concurrent write pass back into a serial
-        // one. A listener that rejects surfaces at `end`, where the chain is awaited.
-        const rows = takeReady()
-        if (rows.length) void send(rows)
+        // The parsed source is deliberately dropped here. It is the only heavy field on a row, and
+        // keeping it would hold every generated file in memory until the batch ends, undoing the
+        // bound `fileManager.write` puts on how many sources exist at once.
+        updateBuffer.push({ file, processed, total, percentage, config })
       },
       end: async (files: Array<FileNode>) => {
-        // Every file reports, so the run above always drains. Release anything left in input order
-        // regardless, so a future caller that skips a position cannot strand the rows behind it.
-        const rows = [...pending.values()].sort((a, b) => a.processed - b.processed)
-        pending.clear()
-        if (rows.length) await send(rows)
+        // Files parse concurrently, so the buffer arrives in completion order. `processed` is each
+        // file's input position, so sorting by it restores generation order for the streamed rows.
+        updateBuffer.sort((a, b) => a.processed - b.processed)
 
-        await sending
+        await hooks.callHook('kubb:files:processing:update', { files: updateBuffer })
+        updateBuffer.length = 0
         await hooks.callHook('kubb:files:processing:end', { files })
       },
     })

--- a/packages/core/src/createKubb.test.ts
+++ b/packages/core/src/createKubb.test.ts
@@ -376,6 +376,41 @@ describe('createKubb', () => {
     ])
   })
 
+  it('releases each file-processing row as it completes instead of holding the batch', async () => {
+    const hooks = new Hookable<KubbHooks>()
+    const chunks: Array<Array<number>> = []
+    hooks.hook('kubb:files:processing:update', ({ files }) => {
+      chunks.push(files.map((row) => row.processed))
+    })
+
+    const filePlugin = definePlugin(() => ({
+      name: 'streaming-plugin',
+      hooks: {
+        'kubb:plugin:setup'(ctx) {
+          for (const index of [1, 2, 3, 4]) {
+            ctx.injectFile(
+              ast.factory.createFile({
+                path: `/workspace/src/gen/file${index}.ts`,
+                baseName: `file${index}.ts`,
+                sources: [ast.factory.createSource({ nodes: [ast.factory.createText(`export const file${index} = ${index}`)] })],
+                imports: [],
+                exports: [],
+              }),
+            )
+          }
+        },
+      },
+    }))()
+
+    await createKubb({ ...config, storage: memoryStorage(), plugins: [filePlugin as unknown as Plugin] }, { hooks }).build()
+
+    // Rows go out as the write pass finishes them, so the sources they carry are not pinned in
+    // memory until the last file lands. Chunk boundaries follow completion timing, so only the
+    // flattened order is fixed.
+    expect(chunks.length).toBeGreaterThan(1)
+    expect(chunks.flat()).toStrictEqual([1, 2, 3, 4])
+  })
+
   it('cleans up hook-style plugin listeners between builds on shared hooks', async () => {
     const hooks = new Hookable<KubbHooks>()
     const hookPlugin = definePlugin(() => ({

--- a/packages/core/src/createKubb.test.ts
+++ b/packages/core/src/createKubb.test.ts
@@ -376,15 +376,15 @@ describe('createKubb', () => {
     ])
   })
 
-  it('releases each file-processing row as it completes instead of holding the batch', async () => {
+  it('reports processed files without carrying their source', async () => {
     const hooks = new Hookable<KubbHooks>()
-    const chunks: Array<Array<number>> = []
+    const rows: Array<Record<string, unknown>> = []
     hooks.hook('kubb:files:processing:update', ({ files }) => {
-      chunks.push(files.map((row) => row.processed))
+      for (const row of files) rows.push(row)
     })
 
     const filePlugin = definePlugin(() => ({
-      name: 'streaming-plugin',
+      name: 'reporting-plugin',
       hooks: {
         'kubb:plugin:setup'(ctx) {
           for (const index of [1, 2, 3, 4]) {
@@ -404,11 +404,10 @@ describe('createKubb', () => {
 
     await createKubb({ ...config, storage: memoryStorage(), plugins: [filePlugin as unknown as Plugin] }, { hooks }).build()
 
-    // Rows go out as the write pass finishes them, so the sources they carry are not pinned in
-    // memory until the last file lands. Chunk boundaries follow completion timing, so only the
-    // flattened order is fixed.
-    expect(chunks.length).toBeGreaterThan(1)
-    expect(chunks.flat()).toStrictEqual([1, 2, 3, 4])
+    // Every file is reported, in generation order, and no row holds the file's parsed source.
+    // Buffering the sources is what used to keep the whole output tree in memory for the batch.
+    expect(rows.map((row) => row.processed)).toStrictEqual([1, 2, 3, 4])
+    expect(rows.every((row) => !('source' in row))).toBe(true)
   })
 
   it('cleans up hook-style plugin listeners between builds on shared hooks', async () => {

--- a/packages/core/src/createKubb.test.ts
+++ b/packages/core/src/createKubb.test.ts
@@ -376,38 +376,18 @@ describe('createKubb', () => {
     ])
   })
 
-  it('reports processed files without carrying their source', async () => {
+  it('reports a processed file without its parsed source', async () => {
     const hooks = new Hookable<KubbHooks>()
-    const rows: Array<Record<string, unknown>> = []
+    const rows: Array<unknown> = []
     hooks.hook('kubb:files:processing:update', ({ files }) => {
-      for (const row of files) rows.push(row)
+      rows.push(...files)
     })
 
-    const filePlugin = definePlugin(() => ({
-      name: 'reporting-plugin',
-      hooks: {
-        'kubb:plugin:setup'(ctx) {
-          for (const index of [1, 2, 3, 4]) {
-            ctx.injectFile(
-              ast.factory.createFile({
-                path: `/workspace/src/gen/file${index}.ts`,
-                baseName: `file${index}.ts`,
-                sources: [ast.factory.createSource({ nodes: [ast.factory.createText(`export const file${index} = ${index}`)] })],
-                imports: [],
-                exports: [],
-              }),
-            )
-          }
-        },
-      },
-    }))()
+    await createKubb({ ...config, storage: memoryStorage() }, { hooks }).build()
 
-    await createKubb({ ...config, storage: memoryStorage(), plugins: [filePlugin as unknown as Plugin] }, { hooks }).build()
-
-    // Every file is reported, in generation order, and no row holds the file's parsed source.
-    // Buffering the sources is what used to keep the whole output tree in memory for the batch.
-    expect(rows.map((row) => row.processed)).toStrictEqual([1, 2, 3, 4])
-    expect(rows.every((row) => !('source' in row))).toBe(true)
+    // Buffering the source is what used to hold the whole output tree in memory for the batch.
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).not.toHaveProperty('source')
   })
 
   it('cleans up hook-style plugin listeners between builds on shared hooks', async () => {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -585,10 +585,6 @@ export type KubbFileProcessingUpdate = {
    */
   percentage: number
   /**
-   * Serialized file content, or `undefined` when the file produced no output.
-   */
-  source?: string
-  /**
    * The file that was just processed.
    */
   file: FileNode


### PR DESCRIPTION
## 🎯 Changes

Also under #3863.

`KubbDriver.run()` buffered every `kubb:files:processing:update` row until the write pass finished, and each row carried the file's parsed source. So although `FileManager.write` bounds how many sources it parses at once (#3808: "keeps at most 50 parsed sources in memory rather than holding every source"), the driver handed that bound straight back and kept the whole output tree live for the batch. The `.map((item) => ({ ...item, config }))` at flush time then allocated a second full array on top.

The fix is to stop putting `source` on the row. It is removed from `KubbFileProcessingUpdate`, and `config` is attached at push time instead of in a second pass.

Nothing reads `source`. The CLI loggers and the MCP tool take `file`, and `apps/agent/server/utils/ws.ts` destructures exactly `{ file, processed, total, percentage }` and drops the rest.

### Measured

5000 generated files of ~8KB, three rounds alternating between builds.

| | main | this branch |
| --- | --- | --- |
| peak heap | 102.5 / 102.9 / 102.8 MB | 67.8 / 67.6 / 67.6 MB |
| peak RSS | 179.6 / 178.2 / 179.5 MB | 141.5 / 140.5 / 141.0 MB |
| time | 1878 / 1806 / 1576 ms | 1947 / 1854 / 1469 ms |
| flushes | 1 | 1 |

Peak heap **102.8 → 67.6 MB (-34%)**, peak RSS **179.5 → 141.0 MB (-21%)**, time unchanged.

### This replaces an earlier, wrong approach on this branch

The first version streamed rows out as they became contiguous instead of buffering. A review found, and reproduced against the real pipeline, that it was broken in ways the benchmark could not show:

- `void send(rows)` left the chain unobserved, so a listener that throws became an unhandled rejection. Node 22 aborts on that, and nothing in core or the CLI installs a handler, so it killed the process instead of surfacing as a diagnostic.
- Once any chunk rejected, `sending` stayed rejected and every later chunk was silently skipped. Measured: a listener throwing on the first of 40 files received 1 of 40 updates.
- Not awaiting removed backpressure. The MCP tool and the agent bridge register async listeners, so the chunk chain would grow faster than they drain and each queued closure pins its row, rebuilding the same buffer for exactly the consumers streaming was meant to help.
- One chunk per file turned a single Studio WebSocket frame and MCP notification into one per file, up to 5000. `apps/kubb.studio/app/utils/eventStream.ts` documents and depends on the batching, expanding one message into per-file rows itself.
- The update also started firing before the file reached storage, since `FileManager.write` emits `update` before `storage.writeItem`.

Batching, ordering, the single flush, backpressure, and error propagation are all back to what `main` does. The memory result is the same, because the buffering was never the cost.

### Note for reviewers

Removing `source` from `KubbFileProcessingUpdate` is a type-level breaking change to a hook payload, though the field is optional and unread anywhere I can find across kubb, plugins, and platform. Say the word if you would rather keep the field and take a smaller win.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

`packages/core` (306 passing), `pnpm lint`, `oxfmt`, and typecheck are clean. The one test covering this asserts the row carries no `source`, and fails when the field is put back.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).