### PR TITLE
perf(adapter-oas): load the OpenAPI validator only when validation runs

### DIFF
--- a/.changeset/adapter-oas-lazy-validator.md
+++ b/.changeset/adapter-oas-lazy-validator.md
@@ -1,0 +1,9 @@
+---
+'@kubb/adapter-oas': patch
+---
+
+Load the OpenAPI validator only when validation runs.
+
+`@readme/openapi-parser` is the heaviest dependency in the package, and it was imported at the top of the module that holds `validateDocument`. Importing `@kubb/adapter-oas` pulled it in, which every `kubb.config.ts` does, so the cost landed on runs that never validate anything.
+
+It is now loaded inside `validateDocument`. Importing the adapter drops from 144ms to 88ms, medians of three runs. Setting `validate: false` saves that outright, and so does any tool that loads the adapter without parsing a document. With validation on, which is the default, the same work moves into the parse step instead of disappearing.

--- a/.changeset/adapter-oas-lazy-validator.md
+++ b/.changeset/adapter-oas-lazy-validator.md
@@ -4,6 +4,6 @@
 
 Load the OpenAPI validator only when validation runs.
 
-`@readme/openapi-parser` is the heaviest dependency in the package, and it was imported at the top of the module that holds `validateDocument`. Importing `@kubb/adapter-oas` pulled it in, which every `kubb.config.ts` does, so the cost landed on runs that never validate anything.
+`@readme/openapi-parser` is used by `validateDocument` alone, but it was imported at the top of the file, so every config importing `@kubb/adapter-oas` paid for it even with `validate: false`.
 
-It is now loaded inside `validateDocument`. Importing the adapter drops from 144ms to 88ms, medians of three runs. Setting `validate: false` saves that outright, and so does any tool that loads the adapter without parsing a document. With validation on, which is the default, the same work moves into the parse step instead of disappearing.
+Importing the adapter drops from 144ms to 88ms. With validation on, the cost moves into the parse step rather than going away.

--- a/packages/adapter-oas/src/load/normalize.ts
+++ b/packages/adapter-oas/src/load/normalize.ts
@@ -1,7 +1,6 @@
 import path from 'node:path'
 import { Diagnostics } from '@kubb/core'
 import type { AdapterSource } from '@kubb/core'
-import { compileErrors, validate } from '@readme/openapi-parser'
 import { upgrade } from '@scalar/openapi-upgrader'
 import { bundle } from 'api-ref-bundler'
 import { parse } from 'yaml'
@@ -130,6 +129,12 @@ export function assertDocument(document: Document): void {
  * ```
  */
 export async function validateDocument(document: Document, { throwOnError = false }: { throwOnError?: boolean } = {}): Promise<void> {
+  // Imported here rather than at the top of the file. It is the heaviest dependency in the package
+  // by a wide margin, and importing `@kubb/adapter-oas` at all, which every config does, would
+  // otherwise pay for it even when `validate` is off and this function never runs. Kept outside the
+  // try so a module that fails to load still surfaces instead of being read as a spec violation.
+  const { compileErrors, validate } = await import('@readme/openapi-parser')
+
   try {
     // `validate` dereferences its input in place, so clone to keep the cached document intact.
     const result = await validate(structuredClone(document), {

--- a/packages/adapter-oas/src/load/normalize.ts
+++ b/packages/adapter-oas/src/load/normalize.ts
@@ -129,10 +129,8 @@ export function assertDocument(document: Document): void {
  * ```
  */
 export async function validateDocument(document: Document, { throwOnError = false }: { throwOnError?: boolean } = {}): Promise<void> {
-  // Imported here rather than at the top of the file. It is the heaviest dependency in the package
-  // by a wide margin, and importing `@kubb/adapter-oas` at all, which every config does, would
-  // otherwise pay for it even when `validate` is off and this function never runs. Kept outside the
-  // try so a module that fails to load still surfaces instead of being read as a spec violation.
+  // The heaviest dependency in the package, and every config importing `@kubb/adapter-oas` would
+  // pay for it even with `validate` off.
   const { compileErrors, validate } = await import('@readme/openapi-parser')
 
   try {


### PR DESCRIPTION
## 🎯 Changes

Also under #3863, independent of #3868 and #3870 (different package).

`load/normalize.ts` imported `compileErrors` and `validate` from `@readme/openapi-parser` at the top of the file. Both are used only inside `validateDocument`. `adapter.ts` imports that module, so importing `@kubb/adapter-oas` at all pulls the dependency in, and every `kubb.config.ts` does that.

`adapter.ts:200` is `if (validate) await validateDocument(document)`, so a project running `adapterOas({ validate: false })` paid for the heaviest dependency in the package and then never called into it.

The import now sits inside `validateDocument`.

### Measured

`@readme/openapi-parser` alone: 93.1 / 104.9 / 94.9 ms.

Importing the built adapter, alternating between the two builds:

| | main | this branch |
| --- | --- | --- |
| round 1 | 188.8 ms | 97.2 ms |
| round 2 | 138.3 ms | 76.2 ms |
| round 3 | 143.9 ms | 88.4 ms |

Median **143.9 ms → 88.4 ms**, about -39%.

Worth being precise about who gets what. This is an outright saving for `validate: false`, and for anything that loads the adapter without parsing a document. With the default `validate: true` it is a **deferral, not a saving** — the same work happens inside `parse()` instead. It still gets the dependency off the config-load path.

### ESM and CJS

tsdown leaves it as a real dynamic import in both outputs rather than downleveling to `require()`, and both were exercised against the built bundles (`parse()` with `validate: true`, plus an invalid document with `throwOnError: true` so `validate` and `compileErrors` both run). Details in [this comment](https://github.com/kubb-labs/kubb/pull/3871#issuecomment-5291499282).

One consequence worth a decision before merge: a native `await import()` inside `dist/index.cjs` resolves the `import` condition, so CJS consumers now load the ESM copy of `@readme/openapi-parser` where the static `require` gave them the CJS one. A CJS host that also requires the package directly ends up with two copies, failing `instanceof` across the boundary and keeping separate ajv caches. Nothing in this repo does that. `createRequire` in the CJS path would avoid it at the cost of a format-specific branch.

### Two things left undone

`yaml` (38.2 ms), `@scalar/openapi-upgrader` (11.0 ms), and `api-ref-bundler` (7.0 ms) are also used only inside parse-time functions and stay eager, so about 56 ms is still on the config-load path.

Nothing asserts the dependency stays off that path, so a future static import would reintroduce the cost with all 513 tests still green. A guard would need a child process loading the built entry and checking the module is absent.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

`pnpm test` for `packages/adapter-oas` (513 passing), `pnpm lint`, `oxfmt`, and typecheck are clean.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).