### PR TITLE
ci: bump kubb-labs/config pin to latest main

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@cb44de9ea0229e29f9a73be415381f44c96f99bb # main
+        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/changeset-format.yml
+++ b/.github/workflows/changeset-format.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@cb44de9ea0229e29f9a73be415381f44c96f99bb # main
+        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@cb44de9ea0229e29f9a73be415381f44c96f99bb # main
+        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@cb44de9ea0229e29f9a73be415381f44c96f99bb # main
+        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
         with:
           node-version: '22.22.3'
 
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@cb44de9ea0229e29f9a73be415381f44c96f99bb # main
+        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
         with:
           node-version: '22.22.3'
 
@@ -72,7 +72,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@cb44de9ea0229e29f9a73be415381f44c96f99bb # main
+        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
         with:
           node-version: '22.22.3'
 
@@ -102,7 +102,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@cb44de9ea0229e29f9a73be415381f44c96f99bb # main
+        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
         with:
           node-version: '22.22.3'
 
@@ -127,7 +127,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@cb44de9ea0229e29f9a73be415381f44c96f99bb # main
+        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
         with:
           node-version: '22.22.3'
 
@@ -152,7 +152,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@cb44de9ea0229e29f9a73be415381f44c96f99bb # main
+        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
         with:
           node-version: '22.22.3'
 
@@ -199,7 +199,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@cb44de9ea0229e29f9a73be415381f44c96f99bb # main
+        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
         with:
           node-version: '22.22.3'
 
@@ -225,7 +225,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@cb44de9ea0229e29f9a73be415381f44c96f99bb # main
+        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@cb44de9ea0229e29f9a73be415381f44c96f99bb # main
+        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
         with:
           node-version: '22.22.3'
           cache: 'false'
@@ -48,7 +48,7 @@ jobs:
 
       - name: Release
         id: release
-        uses: kubb-labs/config/.github/actions/release@cb44de9ea0229e29f9a73be415381f44c96f99bb # main
+        uses: kubb-labs/config/.github/actions/release@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -90,7 +90,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@cb44de9ea0229e29f9a73be415381f44c96f99bb # main
+        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
         with:
           node-version: '22.22.3'
           cache: 'false'
@@ -104,7 +104,7 @@ jobs:
       # version independently.
       - name: Promote
         id: promote
-        uses: kubb-labs/config/.github/actions/promote@cb44de9ea0229e29f9a73be415381f44c96f99bb # main
+        uses: kubb-labs/config/.github/actions/promote@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
         with:
           staged-packages: ${{ needs.release.outputs.staged_packages }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 🎯 Changes

Bumps the pinned `kubb-labs/config` commit SHA used by `.github/setup`, `.github/actions/release`, and `.github/actions/promote` to the latest `main` (`kubb-labs/config#26`, commit `86eda99b453a969ba4d2dcc52cde1363f59eb9df`).

That config-repo change corrected a stale `actions/checkout` version comment (the pin already pointed at the `v7.0.1` commit but was labeled `# v6`) and brought the README's documented `.github/setup` inputs back in line with `action.yml` (`node-version` has no default and is required; `force-install` was undocumented). No behavior change for this repo's workflows.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).

---
_Generated by [Claude Code](https://claude.ai/code/session_01VhDXxZpupSZWQ8a7RBdZWE)_