### PR TITLE
perf(adapter-oas): skip api-ref-bundler for self-contained documents

### DIFF
--- a/.changeset/skip-bundle-self-contained.md
+++ b/.changeset/skip-bundle-self-contained.md
@@ -1,0 +1,17 @@
+---
+'@kubb/adapter-oas': patch
+---
+
+Skip `api-ref-bundler` when the document has no `$ref` outside itself.
+
+`bundleDocument` called `api-ref-bundler`'s `bundle()` on every input to hoist external file
+`$ref`s into named `components.schemas` entries. `bundle` only rewrites external refs, so on a
+document where every `$ref` is already an internal `#/...` fragment, the call is a no-op that
+still walks the entire document to confirm that. Most real-world specs are a single file with no
+external refs, and that walk is not free: profiling a 288-operation spec showed it accounting for
+roughly 9% of total CPU time, and skipping it cut wall-clock time on that same case by about 30%.
+
+`bundleDocument` now checks the parsed root for any `$ref` value that does not start with `#`
+before calling `bundle`, and returns the parsed document directly when there is none. A document
+that mixes internal and external refs, or has external refs anywhere, still bundles exactly as
+before.

--- a/packages/adapter-oas/src/load/normalize.test.ts
+++ b/packages/adapter-oas/src/load/normalize.test.ts
@@ -2,7 +2,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it, vi } from 'vitest'
 import { Diagnostics } from '@kubb/core'
-import { assertDocument, bundleDocument, parseDocument, parseFromConfig, validateDocument } from './normalize.ts'
+import { assertDocument, bundleDocument, hasExternalRef, parseDocument, parseFromConfig, validateDocument } from './normalize.ts'
 import type { Document } from '../types.ts'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
@@ -293,6 +293,44 @@ describe('bundleDocument', () => {
 
   it('throws when the input file does not exist', async () => {
     await expect(bundleDocument(path.resolve(__dirname, '../../mocks/doesNotExist.yaml'))).rejects.toThrow()
+  })
+
+  it('returns a document with only internal refs unchanged, via the api-ref-bundler skip', async () => {
+    const doc = await bundleDocument(path.resolve(__dirname, '../../mocks/petStore.yaml'))
+
+    expect(doc.paths?.['/pet']).toBeDefined()
+    expect(doc.components?.schemas?.['Pet']).toBeDefined()
+  })
+})
+
+describe('hasExternalRef', () => {
+  it('returns false for a document with no $ref at all', () => {
+    expect(hasExternalRef({ openapi: '3.1.0', paths: {} })).toBe(false)
+  })
+
+  it('returns false for an internal #/ ref, at any depth', () => {
+    expect(
+      hasExternalRef({
+        paths: { '/pets': { get: { responses: { '200': { schema: { $ref: '#/components/schemas/Pet' } } } } } },
+      }),
+    ).toBe(false)
+  })
+
+  it('returns true for a relative file ref', () => {
+    expect(hasExternalRef({ components: { schemas: { Pet: { $ref: './schemas/Pet.yaml' } } } })).toBe(true)
+  })
+
+  it('returns true for a URL ref', () => {
+    expect(hasExternalRef({ components: { schemas: { Pet: { $ref: 'https://example.com/pet.yaml' } } } })).toBe(true)
+  })
+
+  it('finds an external ref nested inside an array', () => {
+    expect(hasExternalRef({ allOf: [{ $ref: '#/components/schemas/Base' }, { $ref: './extra.yaml' }] })).toBe(true)
+  })
+
+  it('returns false for non-object input', () => {
+    expect(hasExternalRef(null)).toBe(false)
+    expect(hasExternalRef('a string')).toBe(false)
   })
 })
 

--- a/packages/adapter-oas/src/load/normalize.ts
+++ b/packages/adapter-oas/src/load/normalize.ts
@@ -10,26 +10,21 @@ import { assertInputExists, resolveSource, urlRegExp } from './source.ts'
 /**
  * True when `node` contains a `$ref` pointing outside the current document (a relative path,
  * absolute path, or URL). An internal `#/...` fragment does not count.
+ *
+ * `Object.values` reads array elements and object property values alike, so the same recursion
+ * walks both without a separate array branch.
  */
 export function hasExternalRef(node: unknown): boolean {
-  if (Array.isArray(node)) {
-    return node.some(hasExternalRef)
-  }
-
   if (!node || typeof node !== 'object') {
     return false
   }
 
-  for (const [key, value] of Object.entries(node)) {
-    if (key === '$ref' && typeof value === 'string' && !value.startsWith('#')) {
-      return true
-    }
-    if (hasExternalRef(value)) {
-      return true
-    }
+  const ref = (node as { $ref?: unknown }).$ref
+  if (typeof ref === 'string' && !ref.startsWith('#')) {
+    return true
   }
 
-  return false
+  return Object.values(node).some(hasExternalRef)
 }
 
 /**

--- a/packages/adapter-oas/src/load/normalize.ts
+++ b/packages/adapter-oas/src/load/normalize.ts
@@ -8,12 +8,42 @@ import type { Document } from '../types.ts'
 import { assertInputExists, resolveSource, urlRegExp } from './source.ts'
 
 /**
+ * True when `node` contains a `$ref` pointing outside the current document (a relative path,
+ * absolute path, or URL). An internal `#/...` fragment does not count.
+ */
+export function hasExternalRef(node: unknown): boolean {
+  if (Array.isArray(node)) {
+    return node.some(hasExternalRef)
+  }
+
+  if (!node || typeof node !== 'object') {
+    return false
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    if (key === '$ref' && typeof value === 'string' && !value.startsWith('#')) {
+      return true
+    }
+    if (hasExternalRef(value)) {
+      return true
+    }
+  }
+
+  return false
+}
+
+/**
  * Bundles a multi-file OpenAPI document into a single document via `api-ref-bundler`.
  *
  * External file schemas are hoisted into named `components.schemas` entries, so a property
  * pointing at `./schemas/User.yaml` ends up referencing `#/components/schemas/User`. Generators
  * can then emit a named type with an import instead of inlining the shape. Sources are read with
  * the Bun-aware `read` util for local YAML and JSON files, and with `fetch` for HTTP(S) URLs.
+ *
+ * A document with no `$ref` outside itself has nothing to bundle, so it skips `api-ref-bundler`
+ * and returns as parsed. `bundle` only rewrites external refs into internal ones; on an
+ * all-internal document it is a no-op that still walks the whole tree to confirm that, which
+ * costs real time on a large spec.
  *
  * @example Local file
  * `const document = await bundleDocument('./openapi.yaml')`
@@ -40,7 +70,11 @@ export async function bundleDocument(pathOrUrl: string): Promise<Document> {
 
   // api-ref-bundler swallows resolver errors and leaves refs unresolved, so surface an
   // unreadable input document as a hard error before bundling.
-  await resolver(pathOrUrl)
+  const root = await resolver(pathOrUrl)
+
+  if (typeof root === 'object' && root !== null && !hasExternalRef(root)) {
+    return root as Document
+  }
 
   return (await bundle(pathOrUrl, resolver)) as Document
 }


### PR DESCRIPTION
## 🎯 Changes

Found while profiling generation speed for the v5 blog post's benchmark numbers.

`bundleDocument` calls `api-ref-bundler`'s `bundle()` on every input to hoist external file `$ref`s (`./schemas/User.yaml`) into named `components.schemas` entries. `bundle` only rewrites *external* refs — on a document where every `$ref` is already an internal `#/...` fragment, it has nothing to rewrite, but it still walks the entire document to confirm that.

CPU-profiling a real run (288-operation spec, `plugin-ts` + `plugin-axios` + `plugin-zod` + `plugin-faker`) showed that walk taking **~9% of total CPU time**. I checked the spec: 1,325 `$ref`s, all internal, zero external. Most real-world OpenAPI specs are a single file like this, so this cost is paid on nearly every generate run for no benefit.

`bundleDocument` now scans the parsed root for any `$ref` value that doesn't start with `#` before calling `bundle`, and returns the parsed document directly when there are none. A document with any external ref, anywhere in the tree, still goes through `bundle` exactly as before — the existing external-ref, URL-ref, and fragment-ref tests are untouched and still pass.

**Measured impact** on the same 288-op, four-plugin case: median wall-clock time drops from **~5,845ms to ~4,045ms**, about 31% faster, 5 runs each after a warmup.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

`pnpm test` (92 files, 1468 tests), `pnpm typecheck`, `pnpm lint`, and `pnpm format` all pass.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QdYUhsBMumAzTGNnxPodPs)_