### PR TITLE
perf(adapter-oas): try JSON.parse before the YAML parser

### DIFF
--- a/.changeset/json-parse-fast-path.md
+++ b/.changeset/json-parse-fast-path.md
@@ -1,0 +1,15 @@
+---
+'@kubb/adapter-oas': patch
+---
+
+Parse a JSON input with `JSON.parse` instead of always routing it through the `yaml` package.
+
+`resolveSource` called `yaml`'s `parse` on every source, JSON included, since JSON is valid YAML.
+A general-purpose YAML parser (comments, anchors, block scalars, multi-document streams) does far
+more work than `JSON.parse` needs for something that is already JSON.
+
+`resolveSource` now tries `JSON.parse` first and falls back to the YAML parser on failure. A real
+YAML document fails `JSON.parse` on or near its first character, so the fallback costs
+essentially nothing on non-JSON input. Measured on a 288-operation spec read from a `.json` file
+(`plugin-ts` + `plugin-axios` + `plugin-zod` + `plugin-faker`): median wall-clock time for that
+case drops from ~5,845ms to ~3,960ms.

--- a/packages/adapter-oas/src/load/source.test.ts
+++ b/packages/adapter-oas/src/load/source.test.ts
@@ -51,4 +51,24 @@ describe('resolveSource', () => {
 
     await expect(resolveSource('https://specs.example.com/openapi.yaml')).resolves.toStrictEqual({ openapi: '3.1.0' })
   })
+
+  it('parses a JSON document via the JSON.parse fast path', async () => {
+    using _fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({ openapi: '3.1.0', paths: {} }), { status: 200 }))
+
+    await expect(resolveSource('https://specs.example.com/openapi.json')).resolves.toStrictEqual({ openapi: '3.1.0', paths: {} })
+  })
+
+  it('falls back to the YAML parser for a document JSON.parse rejects', async () => {
+    using _fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        `
+openapi: '3.1.0'
+paths: {}
+`,
+        { status: 200 },
+      ),
+    )
+
+    await expect(resolveSource('https://specs.example.com/openapi.yaml')).resolves.toStrictEqual({ openapi: '3.1.0', paths: {} })
+  })
 })

--- a/packages/adapter-oas/src/load/source.ts
+++ b/packages/adapter-oas/src/load/source.ts
@@ -77,6 +77,11 @@ async function readSource(sourcePath: string): Promise<string> {
 /**
  * Reads and parses one source file or URL referenced during bundling: YAML/JSON is parsed into an
  * object, Markdown is returned as-is (bundled inline rather than dereferenced).
+ *
+ * JSON is valid YAML, so `yaml`'s `parse` handles both, but its general-purpose parser (comments,
+ * anchors, block scalars, multi-document streams) does much more work than `JSON.parse` needs to.
+ * `JSON.parse` runs first and fails fast on the first non-JSON character, so a real YAML document
+ * falls through to `parse` at negligible cost.
  */
 export async function resolveSource(sourcePath: string): Promise<object | string> {
   const data = await readSource(sourcePath)
@@ -85,7 +90,11 @@ export async function resolveSource(sourcePath: string): Promise<object | string
     return data
   }
 
-  return parse(data) as object
+  try {
+    return JSON.parse(data) as object
+  } catch {
+    return parse(data) as object
+  }
 }
 
 /**


### PR DESCRIPTION
## 🎯 Changes

Found alongside #3880 while profiling generation speed for the v5 blog post's benchmark numbers.

`resolveSource` calls `yaml`'s `parse()` on every input source, JSON included, since JSON happens to be valid YAML. A general-purpose YAML parser (comments, anchors, block scalars, multi-document streams) does far more work than `JSON.parse` needs for content that's already JSON — profiling showed `yaml`'s parser functions (`next`, `flowCollection`, `parseFlowCollection`, `composeScalar`, `resolveFlowCollection`, `resolveFlowScalar`) scattered across the CPU profile on a run whose input was a plain `.json` file.

`resolveSource` now tries `JSON.parse` first and falls back to `yaml`'s `parse` on failure. A real YAML document fails `JSON.parse` on or near its first character (YAML's `key: value` syntax isn't valid JSON), so the fallback costs essentially nothing on non-JSON input — I added a test confirming a YAML document still parses correctly through the fallback.

**Measured impact** on a 288-op spec read from `.json` (`plugin-ts` + `plugin-axios` + `plugin-zod` + `plugin-faker`): median wall-clock time drops from **~5,845ms to ~3,960ms**, 5 runs each after a warmup. This is independent of #3880 (that one skips `api-ref-bundler`, this one changes how the source is parsed) — both PRs individually show a similar-sized win on the same benchmark case, and should stack when both land.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

`pnpm test` (92 files, 1463 tests), `pnpm typecheck`, `pnpm lint`, and `pnpm format` all pass.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QdYUhsBMumAzTGNnxPodPs)_