### PR TITLE
Use a minimal v5.0.0 CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,9 @@
 # Changelog
+
+## v5.0.0
+
+Kubb v5 rebuilds code generation around adapters, a universal AST, parsers, and storage, and generates code up to 5.4x faster than v4. Config gets shorter, generated client calls change shape, and plugins move to their own repo ([kubb-labs/plugins](https://github.com/kubb-labs/plugins)).
+
+Read the [release blog post](https://kubb.dev/blog/v5) for the highlights, and the [migration guide](https://kubb.dev/docs/5.x/migration) for the full, per-package breaking-change list and upgrade steps.
+
+For prior releases, see [GitHub Releases](https://github.com/kubb-labs/kubb/releases).


### PR DESCRIPTION
## Summary
- Replace the auto-generated, per-changeset v5.0.0 entry in `CHANGELOG.md` (see #3888) with a short summary
- Point readers to the [release blog post](https://kubb.dev/blog/v5) and the [migration guide](https://kubb.dev/docs/5.x/migration) for the full breaking-change list and upgrade steps, instead of duplicating every changeset inline

## Test plan
- [ ] Confirm `CHANGELOG.md` renders correctly and links resolve once the blog post and migration guide are live

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mn4ACJNuzUqtDXqAZEp51m)_