### PR TITLE
fix(release): use pnpm instead of npm to bump canary version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           canary_version="0.0.0-canary-$(date -u +%Y%m%d%H%M%S)"
           echo "Canary version: ${canary_version}"
-          pnpm -r exec bash -c "npm --no-git-tag-version version '${canary_version}' || true"
+          pnpm -r exec pnpm version "${canary_version}" --no-git-tag-version --allow-same-version
           pnpm run build
           pnpm exec changeset publish --tag canary
 


### PR DESCRIPTION
## 🎯 Changes

The canary publish step on every `main` push shells out to `npm --no-git-tag-version version` to bump each workspace package to the canary version. npm doesn't understand pnpm's `catalog:` protocol, which several packages use in their dependencies (`yaml: catalog:`, `typescript: catalog:`, etc.), so the command fails with `EUNSUPPORTEDPROTOCOL`. The `|| true` swallowed the failure per package, and the step itself has `continue-on-error: true`, so the workflow kept going without visibly failing, but the version bump silently didn't happen for affected packages.

Switches the version bump to `pnpm version`, which is catalog-aware and accepts the same flags.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`. (workflow-only change, not covered by the test suite; verified `pnpm version --help` supports the flags used)

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release). (CI workflow only)


---
_Generated by [Claude Code](https://claude.ai/code/session_0134ZZmfEVbBr88NuS9CDfmD)_