### PR TITLE
Fix/3891 vue query type not portable

### DIFF
--- a/.changeset/explicit-vue-query-options-return-type.md
+++ b/.changeset/explicit-vue-query-options-return-type.md
@@ -1,0 +1,7 @@
+---
+'@kubb/plugin-vue-query': patch
+---
+
+Emit explicit return types on generated `*QueryOptions` and `*InfiniteQueryOptions` functions (`UndefinedInitialQueryOptions`/`UndefinedInitialDataInfiniteOptions` plus the `DataTag`-branded `queryKey`).
+Without the annotation, consumers running `tsc` with declaration emit against `@tanstack/vue-query` >= 5.98.0 fail with TS2527/TS2883 because the inferred return type references non-exported unique symbols (see [TanStack/query#10904](https://github.com/TanStack/query/issues/10904)).
+The referenced types are available in `@tanstack/vue-query` >= 5.81.5 (verified floor).

--- a/packages/plugin-vue-query/src/components/InfiniteQueryOptions.tsx
+++ b/packages/plugin-vue-query/src/components/InfiniteQueryOptions.tsx
@@ -12,6 +12,7 @@ type Props = {
   name: string
   clientName: string
   queryKeyName: string
+  queryKeyTypeName: string
   typeSchemas: OperationSchemas
   paramsCasing: PluginVueQuery['resolvedOptions']['paramsCasing']
   paramsType: PluginVueQuery['resolvedOptions']['paramsType']
@@ -138,9 +139,12 @@ export function InfiniteQueryOptions({
   pathParamsType,
   queryParam,
   queryKeyName,
+  queryKeyTypeName,
 }: Props): FabricReactNode {
   const TData = dataReturnType === 'data' ? typeSchemas.response.name : `ResponseConfig<${typeSchemas.response.name}>`
   const TError = `ResponseErrorConfig<${typeSchemas.errors?.map((item) => item.name).join(' | ') || 'Error'}>`
+  // Explicit return type so declaration emit does not depend on @tanstack/vue-query's non-exported unique symbols (TS2527/TS2883)
+  const returnType = `UndefinedInitialDataInfiniteOptions<${TData}, ${TError}, ${TData}, ${queryKeyTypeName}, number> & { queryKey: DataTag<${queryKeyTypeName}, InfiniteData<${TData}>, ${TError}> }`
 
   const params = getParams({ paramsType, paramsCasing, pathParamsType, typeSchemas })
   const clientParams = Client.getParams({
@@ -221,7 +225,7 @@ export function InfiniteQueryOptions({
 
   return (
     <File.Source name={name} isExportable isIndexable>
-      <Function name={name} export params={params.toConstructor()}>
+      <Function name={name} export params={params.toConstructor()} returnType={returnType}>
         {`
       const queryKey = ${queryKeyName}(${queryKeyParams.toCall()})
       return infiniteQueryOptions<${TData}, ${TError}, ${TData}, typeof queryKey, number>({

--- a/packages/plugin-vue-query/src/components/QueryOptions.tsx
+++ b/packages/plugin-vue-query/src/components/QueryOptions.tsx
@@ -11,6 +11,7 @@ type Props = {
   name: string
   clientName: string
   queryKeyName: string
+  queryKeyTypeName: string
   typeSchemas: OperationSchemas
   paramsCasing: PluginVueQuery['resolvedOptions']['paramsCasing']
   paramsType: PluginVueQuery['resolvedOptions']['paramsType']
@@ -127,9 +128,12 @@ export function QueryOptions({
   paramsType,
   pathParamsType,
   queryKeyName,
+  queryKeyTypeName,
 }: Props): FabricReactNode {
   const TData = dataReturnType === 'data' ? typeSchemas.response.name : `ResponseConfig<${typeSchemas.response.name}>`
   const TError = `ResponseErrorConfig<${typeSchemas.errors?.map((item) => item.name).join(' | ') || 'Error'}>`
+  // Explicit return type so declaration emit does not depend on @tanstack/vue-query's non-exported unique symbols (TS2527/TS2883)
+  const returnType = `UndefinedInitialQueryOptions<${TData}, ${TError}, ${TData}, ${queryKeyTypeName}> & { queryKey: DataTag<${queryKeyTypeName}, ${TData}, ${TError}> }`
 
   const params = getParams({ paramsType, paramsCasing, pathParamsType, typeSchemas })
   const clientParams = Client.getParams({
@@ -159,7 +163,7 @@ export function QueryOptions({
 
   return (
     <File.Source name={name} isExportable isIndexable>
-      <Function name={name} export params={params.toConstructor()}>
+      <Function name={name} export params={params.toConstructor()} returnType={returnType}>
         {`
       const queryKey = ${queryKeyName}(${queryKeyParams.toCall()})
       return queryOptions<${TData}, ${TError}, ${TData}, typeof queryKey>({

--- a/packages/plugin-vue-query/src/generators/__snapshots__/clientDataReturnTypeFull.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/clientDataReturnTypeFull.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 import type { Client, RequestConfig, ResponseErrorConfig, ResponseConfig } from './test/.kubb/fetch'
-import type { QueryKey, QueryClient, UseQueryOptions, UseQueryReturnType } from '@tanstack/react-query'
+import type { UndefinedInitialQueryOptions, DataTag, QueryKey, QueryClient, UseQueryOptions, UseQueryReturnType } from '@tanstack/react-query'
 import type { MaybeRefOrGetter } from 'vue'
 import { fetch } from './test/.kubb/fetch'
 import { queryOptions, useQuery } from '@tanstack/react-query'
@@ -40,7 +40,12 @@ export function findPetsByTagsQueryOptions(
   headers: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   config: Partial<RequestConfig> & { client?: Client } = {},
-) {
+): UndefinedInitialQueryOptions<
+  ResponseConfig<FindPetsByTagsQueryResponse>,
+  ResponseErrorConfig<FindPetsByTags400>,
+  ResponseConfig<FindPetsByTagsQueryResponse>,
+  FindPetsByTagsQueryKey
+> & { queryKey: DataTag<FindPetsByTagsQueryKey, ResponseConfig<FindPetsByTagsQueryResponse>, ResponseErrorConfig<FindPetsByTags400>> } {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<
     ResponseConfig<FindPetsByTagsQueryResponse>,

--- a/packages/plugin-vue-query/src/generators/__snapshots__/clientGetImportPath.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/clientGetImportPath.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 import fetch from 'axios'
-import type { QueryKey, QueryClient, UseQueryOptions, UseQueryReturnType } from '@tanstack/react-query'
+import type { UndefinedInitialQueryOptions, DataTag, QueryKey, QueryClient, UseQueryOptions, UseQueryReturnType } from '@tanstack/react-query'
 import type { Client, RequestConfig, ResponseErrorConfig } from 'axios'
 import type { MaybeRefOrGetter } from 'vue'
 import { queryOptions, useQuery } from '@tanstack/react-query'
@@ -40,7 +40,9 @@ export function findPetsByTagsQueryOptions(
   headers: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   config: Partial<RequestConfig> & { client?: Client } = {},
-) {
+): UndefinedInitialQueryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, FindPetsByTagsQueryResponse, FindPetsByTagsQueryKey> & {
+  queryKey: DataTag<FindPetsByTagsQueryKey, FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>>
+} {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, FindPetsByTagsQueryResponse, typeof queryKey>({
     queryKey,

--- a/packages/plugin-vue-query/src/generators/__snapshots__/findByTags.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/findByTags.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 import type { Client, RequestConfig, ResponseErrorConfig } from './test/.kubb/fetch'
-import type { QueryKey, QueryClient, UseQueryOptions, UseQueryReturnType } from '@tanstack/react-query'
+import type { UndefinedInitialQueryOptions, DataTag, QueryKey, QueryClient, UseQueryOptions, UseQueryReturnType } from '@tanstack/react-query'
 import type { MaybeRefOrGetter } from 'vue'
 import { fetch } from './test/.kubb/fetch'
 import { queryOptions, useQuery } from '@tanstack/react-query'
@@ -40,7 +40,9 @@ export function findPetsByTagsQueryOptions(
   headers: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   config: Partial<RequestConfig> & { client?: Client } = {},
-) {
+): UndefinedInitialQueryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, FindPetsByTagsQueryResponse, FindPetsByTagsQueryKey> & {
+  queryKey: DataTag<FindPetsByTagsQueryKey, FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>>
+} {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, FindPetsByTagsQueryResponse, typeof queryKey>({
     queryKey,

--- a/packages/plugin-vue-query/src/generators/__snapshots__/findByTagsObject.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/findByTagsObject.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 import type { Client, RequestConfig, ResponseErrorConfig } from './test/.kubb/fetch'
-import type { QueryKey, QueryClient, UseQueryOptions, UseQueryReturnType } from '@tanstack/react-query'
+import type { UndefinedInitialQueryOptions, DataTag, QueryKey, QueryClient, UseQueryOptions, UseQueryReturnType } from '@tanstack/react-query'
 import type { MaybeRefOrGetter } from 'vue'
 import { fetch } from './test/.kubb/fetch'
 import { queryOptions, useQuery } from '@tanstack/react-query'
@@ -38,7 +38,9 @@ export async function findPetsByTags(
 export function findPetsByTagsQueryOptions(
   { headers, params }: { headers: MaybeRefOrGetter<FindPetsByTagsQueryParams>; params?: MaybeRefOrGetter<FindPetsByTagsQueryParams> },
   config: Partial<RequestConfig> & { client?: Client } = {},
-) {
+): UndefinedInitialQueryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, FindPetsByTagsQueryResponse, FindPetsByTagsQueryKey> & {
+  queryKey: DataTag<FindPetsByTagsQueryKey, FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>>
+} {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, FindPetsByTagsQueryResponse, typeof queryKey>({
     queryKey,

--- a/packages/plugin-vue-query/src/generators/__snapshots__/findByTagsPathParamsObject.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/findByTagsPathParamsObject.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 import type { Client, RequestConfig, ResponseErrorConfig } from './test/.kubb/fetch'
-import type { QueryKey, QueryClient, UseQueryOptions, UseQueryReturnType } from '@tanstack/react-query'
+import type { UndefinedInitialQueryOptions, DataTag, QueryKey, QueryClient, UseQueryOptions, UseQueryReturnType } from '@tanstack/react-query'
 import type { MaybeRefOrGetter } from 'vue'
 import { fetch } from './test/.kubb/fetch'
 import { queryOptions, useQuery } from '@tanstack/react-query'
@@ -40,7 +40,9 @@ export function findPetsByTagsQueryOptions(
   headers: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   config: Partial<RequestConfig> & { client?: Client } = {},
-) {
+): UndefinedInitialQueryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, FindPetsByTagsQueryResponse, FindPetsByTagsQueryKey> & {
+  queryKey: DataTag<FindPetsByTagsQueryKey, FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>>
+} {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, FindPetsByTagsQueryResponse, typeof queryKey>({
     queryKey,

--- a/packages/plugin-vue-query/src/generators/__snapshots__/findByTagsTemplateString.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/findByTagsTemplateString.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 import type { Client, RequestConfig, ResponseErrorConfig } from './test/.kubb/fetch'
-import type { QueryKey, QueryClient, UseQueryOptions, UseQueryReturnType } from '@tanstack/react-query'
+import type { UndefinedInitialQueryOptions, DataTag, QueryKey, QueryClient, UseQueryOptions, UseQueryReturnType } from '@tanstack/react-query'
 import type { MaybeRefOrGetter } from 'vue'
 import { fetch } from './test/.kubb/fetch'
 import { queryOptions, useQuery } from '@tanstack/react-query'
@@ -41,7 +41,9 @@ export function findPetsByTagsQueryOptions(
   headers: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   config: Partial<RequestConfig> & { client?: Client } = {},
-) {
+): UndefinedInitialQueryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, FindPetsByTagsQueryResponse, FindPetsByTagsQueryKey> & {
+  queryKey: DataTag<FindPetsByTagsQueryKey, FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>>
+} {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, FindPetsByTagsQueryResponse, typeof queryKey>({
     queryKey,

--- a/packages/plugin-vue-query/src/generators/__snapshots__/findByTagsWithCustomQueryKey.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/findByTagsWithCustomQueryKey.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 import type { Client, RequestConfig, ResponseErrorConfig } from './test/.kubb/fetch'
-import type { QueryKey, QueryClient, UseQueryOptions, UseQueryReturnType } from '@tanstack/react-query'
+import type { UndefinedInitialQueryOptions, DataTag, QueryKey, QueryClient, UseQueryOptions, UseQueryReturnType } from '@tanstack/react-query'
 import type { MaybeRefOrGetter } from 'vue'
 import { fetch } from './test/.kubb/fetch'
 import { queryOptions, useQuery } from '@tanstack/react-query'
@@ -40,7 +40,9 @@ export function findPetsByTagsQueryOptions(
   headers: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   config: Partial<RequestConfig> & { client?: Client } = {},
-) {
+): UndefinedInitialQueryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, FindPetsByTagsQueryResponse, FindPetsByTagsQueryKey> & {
+  queryKey: DataTag<FindPetsByTagsQueryKey, FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>>
+} {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, FindPetsByTagsQueryResponse, typeof queryKey>({
     queryKey,

--- a/packages/plugin-vue-query/src/generators/__snapshots__/findByTagsWithZod.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/findByTagsWithZod.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 import type { Client, RequestConfig, ResponseErrorConfig } from './test/.kubb/fetch'
-import type { QueryKey, QueryClient, UseQueryOptions, UseQueryReturnType } from '@tanstack/react-query'
+import type { UndefinedInitialQueryOptions, DataTag, QueryKey, QueryClient, UseQueryOptions, UseQueryReturnType } from '@tanstack/react-query'
 import type { MaybeRefOrGetter } from 'vue'
 import { fetch } from './test/.kubb/fetch'
 import { queryOptions, useQuery } from '@tanstack/react-query'
@@ -40,7 +40,9 @@ export function findPetsByTagsQueryOptions(
   headers: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   config: Partial<RequestConfig> & { client?: Client } = {},
-) {
+): UndefinedInitialQueryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, FindPetsByTagsQueryResponse, FindPetsByTagsQueryKey> & {
+  queryKey: DataTag<FindPetsByTagsQueryKey, FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>>
+} {
   const queryKey = findPetsByTagsQueryKey(params)
   return queryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, FindPetsByTagsQueryResponse, typeof queryKey>({
     queryKey,

--- a/packages/plugin-vue-query/src/generators/__snapshots__/findInfiniteByTags.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/findInfiniteByTags.ts
@@ -3,7 +3,15 @@
  * Do not edit manually.
  */
 import type { Client, RequestConfig, ResponseErrorConfig } from './test/.kubb/fetch'
-import type { InfiniteData, QueryKey, QueryClient, UseInfiniteQueryOptions, UseInfiniteQueryReturnType } from '@tanstack/react-query'
+import type {
+  UndefinedInitialDataInfiniteOptions,
+  DataTag,
+  InfiniteData,
+  QueryKey,
+  QueryClient,
+  UseInfiniteQueryOptions,
+  UseInfiniteQueryReturnType,
+} from '@tanstack/react-query'
 import type { MaybeRefOrGetter } from 'vue'
 import { fetch } from './test/.kubb/fetch'
 import { infiniteQueryOptions, useInfiniteQuery } from '@tanstack/react-query'
@@ -40,7 +48,13 @@ export function findPetsByTagsInfiniteQueryOptions(
   headers: MaybeRefOrGetter<FindPetsByTagsHeaderParams>,
   params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   config: Partial<RequestConfig> & { client?: Client } = {},
-) {
+): UndefinedInitialDataInfiniteOptions<
+  FindPetsByTagsQueryResponse,
+  ResponseErrorConfig<FindPetsByTags400>,
+  FindPetsByTagsQueryResponse,
+  FindPetsByTagsInfiniteQueryKey,
+  number
+> & { queryKey: DataTag<FindPetsByTagsInfiniteQueryKey, InfiniteData<FindPetsByTagsQueryResponse>, ResponseErrorConfig<FindPetsByTags400>> } {
   const queryKey = findPetsByTagsInfiniteQueryKey(params)
   return infiniteQueryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, FindPetsByTagsQueryResponse, typeof queryKey, number>({
     queryKey,

--- a/packages/plugin-vue-query/src/generators/__snapshots__/findInfiniteByTagsCursor.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/findInfiniteByTagsCursor.ts
@@ -3,7 +3,15 @@
  * Do not edit manually.
  */
 import type { Client, RequestConfig, ResponseErrorConfig } from './test/.kubb/fetch'
-import type { InfiniteData, QueryKey, QueryClient, UseInfiniteQueryOptions, UseInfiniteQueryReturnType } from '@tanstack/react-query'
+import type {
+  UndefinedInitialDataInfiniteOptions,
+  DataTag,
+  InfiniteData,
+  QueryKey,
+  QueryClient,
+  UseInfiniteQueryOptions,
+  UseInfiniteQueryReturnType,
+} from '@tanstack/react-query'
 import type { MaybeRefOrGetter } from 'vue'
 import { fetch } from './test/.kubb/fetch'
 import { infiniteQueryOptions, useInfiniteQuery } from '@tanstack/react-query'
@@ -40,7 +48,13 @@ export function findPetsByTagsInfiniteQueryOptions(
   headers: MaybeRefOrGetter<FindPetsByTagsHeaderParams>,
   params?: MaybeRefOrGetter<FindPetsByTagsQueryParams>,
   config: Partial<RequestConfig> & { client?: Client } = {},
-) {
+): UndefinedInitialDataInfiniteOptions<
+  FindPetsByTagsQueryResponse,
+  ResponseErrorConfig<FindPetsByTags400>,
+  FindPetsByTagsQueryResponse,
+  FindPetsByTagsInfiniteQueryKey,
+  number
+> & { queryKey: DataTag<FindPetsByTagsInfiniteQueryKey, InfiniteData<FindPetsByTagsQueryResponse>, ResponseErrorConfig<FindPetsByTags400>> } {
   const queryKey = findPetsByTagsInfiniteQueryKey(params)
   return infiniteQueryOptions<FindPetsByTagsQueryResponse, ResponseErrorConfig<FindPetsByTags400>, FindPetsByTagsQueryResponse, typeof queryKey, number>({
     queryKey,

--- a/packages/plugin-vue-query/src/generators/__snapshots__/postAsQuery.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/postAsQuery.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 import type { Client, RequestConfig, ResponseErrorConfig } from './test/.kubb/fetch'
-import type { QueryKey, QueryClient, UseQueryOptions, UseQueryReturnType } from 'custom-query'
+import type { UndefinedInitialQueryOptions, DataTag, QueryKey, QueryClient, UseQueryOptions, UseQueryReturnType } from 'custom-query'
 import type { MaybeRefOrGetter } from 'vue'
 import { fetch } from './test/.kubb/fetch'
 import { queryOptions, useQuery } from 'custom-query'
@@ -46,7 +46,12 @@ export function updatePetWithFormQueryOptions(
   data?: MaybeRefOrGetter<UpdatePetWithFormMutationRequest>,
   params?: MaybeRefOrGetter<UpdatePetWithFormQueryParams>,
   config: Partial<RequestConfig<UpdatePetWithFormMutationRequest>> & { client?: Client } = {},
-) {
+): UndefinedInitialQueryOptions<
+  UpdatePetWithFormMutationResponse,
+  ResponseErrorConfig<UpdatePetWithForm405>,
+  UpdatePetWithFormMutationResponse,
+  UpdatePetWithFormQueryKey
+> & { queryKey: DataTag<UpdatePetWithFormQueryKey, UpdatePetWithFormMutationResponse, ResponseErrorConfig<UpdatePetWithForm405>> } {
   const queryKey = updatePetWithFormQueryKey(petId, data, params)
   return queryOptions<UpdatePetWithFormMutationResponse, ResponseErrorConfig<UpdatePetWithForm405>, UpdatePetWithFormMutationResponse, typeof queryKey>({
     enabled: () => !!toValue(petId),

--- a/packages/plugin-vue-query/src/generators/__snapshots__/postAsQueryObjectParams.ts
+++ b/packages/plugin-vue-query/src/generators/__snapshots__/postAsQueryObjectParams.ts
@@ -3,7 +3,7 @@
  * Do not edit manually.
  */
 import type { Client, RequestConfig, ResponseErrorConfig } from './test/.kubb/fetch'
-import type { QueryKey, QueryClient, UseQueryOptions, UseQueryReturnType } from 'custom-query'
+import type { UndefinedInitialQueryOptions, DataTag, QueryKey, QueryClient, UseQueryOptions, UseQueryReturnType } from 'custom-query'
 import type { MaybeRefOrGetter } from 'vue'
 import { fetch } from './test/.kubb/fetch'
 import { queryOptions, useQuery } from 'custom-query'
@@ -50,7 +50,12 @@ export function updatePetWithFormQueryOptions(
     params?: MaybeRefOrGetter<UpdatePetWithFormQueryParams>
   },
   config: Partial<RequestConfig<UpdatePetWithFormMutationRequest>> & { client?: Client } = {},
-) {
+): UndefinedInitialQueryOptions<
+  UpdatePetWithFormMutationResponse,
+  ResponseErrorConfig<UpdatePetWithForm405>,
+  UpdatePetWithFormMutationResponse,
+  UpdatePetWithFormQueryKey
+> & { queryKey: DataTag<UpdatePetWithFormQueryKey, UpdatePetWithFormMutationResponse, ResponseErrorConfig<UpdatePetWithForm405>> } {
   const queryKey = updatePetWithFormQueryKey({ petId }, data, params)
   return queryOptions<UpdatePetWithFormMutationResponse, ResponseErrorConfig<UpdatePetWithForm405>, UpdatePetWithFormMutationResponse, typeof queryKey>({
     enabled: () => !!toValue(petId),

--- a/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/infiniteQueryGenerator.tsx
@@ -172,10 +172,12 @@ export const infiniteQueryGenerator = createReactGenerator<PluginVueQuery>({
           <>
             <File.Import name={['InfiniteData']} isTypeOnly path={importPath} />
             <File.Import name={['infiniteQueryOptions']} path={importPath} />
+            <File.Import name={['UndefinedInitialDataInfiniteOptions', 'DataTag']} path={importPath} isTypeOnly />
             <InfiniteQueryOptions
               name={queryOptions.name}
               clientName={client.name}
               queryKeyName={queryKey.name}
+              queryKeyTypeName={queryKey.typeName}
               typeSchemas={type.schemas}
               paramsType={options.paramsType}
               paramsCasing={options.paramsCasing}

--- a/packages/plugin-vue-query/src/generators/queryGenerator.tsx
+++ b/packages/plugin-vue-query/src/generators/queryGenerator.tsx
@@ -157,10 +157,12 @@ export const queryGenerator = createReactGenerator<PluginVueQuery>({
           />
         )}
         <File.Import name={['queryOptions']} path={importPath} />
+        <File.Import name={['UndefinedInitialQueryOptions', 'DataTag']} path={importPath} isTypeOnly />
         <QueryOptions
           name={queryOptions.name}
           clientName={client.name}
           queryKeyName={queryKey.name}
+          queryKeyTypeName={queryKey.typeName}
           paramsCasing={options.paramsCasing}
           typeSchemas={type.schemas}
           paramsType={options.paramsType}


### PR DESCRIPTION
## 🎯 Changes

Fixes #3891 

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).
