### PR TITLE
chore(ci): bump kubb-labs/config pin to latest main

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
+        uses: kubb-labs/config/.github/setup@909a85919614def70d99dff599c943f1c5755975 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/changeset-format.yml
+++ b/.github/workflows/changeset-format.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
+        uses: kubb-labs/config/.github/setup@909a85919614def70d99dff599c943f1c5755975 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
+        uses: kubb-labs/config/.github/setup@909a85919614def70d99dff599c943f1c5755975 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
+        uses: kubb-labs/config/.github/setup@909a85919614def70d99dff599c943f1c5755975 # main
         with:
           node-version: '22.22.3'
 
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
+        uses: kubb-labs/config/.github/setup@909a85919614def70d99dff599c943f1c5755975 # main
         with:
           node-version: '22.22.3'
 
@@ -72,7 +72,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
+        uses: kubb-labs/config/.github/setup@909a85919614def70d99dff599c943f1c5755975 # main
         with:
           node-version: '22.22.3'
 
@@ -102,7 +102,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
+        uses: kubb-labs/config/.github/setup@909a85919614def70d99dff599c943f1c5755975 # main
         with:
           node-version: '22.22.3'
 
@@ -127,7 +127,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
+        uses: kubb-labs/config/.github/setup@909a85919614def70d99dff599c943f1c5755975 # main
         with:
           node-version: '22.22.3'
 
@@ -152,7 +152,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
+        uses: kubb-labs/config/.github/setup@909a85919614def70d99dff599c943f1c5755975 # main
         with:
           node-version: '22.22.3'
 
@@ -199,7 +199,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
+        uses: kubb-labs/config/.github/setup@909a85919614def70d99dff599c943f1c5755975 # main
         with:
           node-version: '22.22.3'
 
@@ -225,7 +225,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
+        uses: kubb-labs/config/.github/setup@909a85919614def70d99dff599c943f1c5755975 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
+        uses: kubb-labs/config/.github/setup@909a85919614def70d99dff599c943f1c5755975 # main
         with:
           node-version: '22.22.3'
           cache: 'false'
@@ -48,7 +48,7 @@ jobs:
 
       - name: Release
         id: release
-        uses: kubb-labs/config/.github/actions/release@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
+        uses: kubb-labs/config/.github/actions/release@909a85919614def70d99dff599c943f1c5755975 # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -90,7 +90,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
+        uses: kubb-labs/config/.github/setup@909a85919614def70d99dff599c943f1c5755975 # main
         with:
           node-version: '22.22.3'
           cache: 'false'
@@ -104,7 +104,7 @@ jobs:
       # version independently.
       - name: Promote
         id: promote
-        uses: kubb-labs/config/.github/actions/promote@86eda99b453a969ba4d2dcc52cde1363f59eb9df # main
+        uses: kubb-labs/config/.github/actions/promote@909a85919614def70d99dff599c943f1c5755975 # main
         with:
           staged-packages: ${{ needs.release.outputs.staged_packages }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Repoints all `kubb-labs/config/.github` reusable action/workflow references from `86eda99` to the latest commit on `main` (`909a859`)
- Covers `pr.yml`, `autofix.yml`, `release.yml`, `changeset-format.yml`, and `copilot-setup-steps.yml`

## Test plan
- [x] CI runs on this PR using the updated pin

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXZtCB4wbDhnB4awjPeBjT)_