### PR TITLE
fix(utils): camelCase hyphenated param names in Url.toPath

### DIFF
--- a/.changeset/fix-hyphenated-path-params.md
+++ b/.changeset/fix-hyphenated-path-params.md
@@ -1,0 +1,5 @@
+---
+"@kubb/kit": patch
+---
+
+Fix `Url.toPath` producing an invalid Express-style route for a hyphenated path parameter (e.g. `{point-id}` became `:point-id`). `path-to-regexp` treats a hyphen as ending the parameter name, so the generated MSW handler matched `:point` followed by a literal `-id` and rejected valid values. `Url.toPath` now camelCases the parameter name the same way `Url.toTemplateString` already does, so `{point-id}` becomes `:pointId`.

--- a/internals/utils/src/Url.test.ts
+++ b/internals/utils/src/Url.test.ts
@@ -30,9 +30,15 @@ describe('Url.toTemplateString', () => {
 describe('Url.toPath', () => {
   test('converts path params to Express-style colon syntax', () => {
     expect(Url.toPath('/user/{userID}/monetary-account/{monetary-accountID}/whitelist-sdd/{itemId}')).toBe(
-      '/user/:userID/monetary-account/:monetary-accountID/whitelist-sdd/:itemId',
+      '/user/:userID/monetary-account/:monetaryAccountID/whitelist-sdd/:itemId',
     )
     expect(Url.toPath('/pet/{petId}:search')).toBe('/pet/:petId:search')
+  })
+
+  test('camelCases a hyphenated param name so path-to-regexp accepts it', () => {
+    // path-to-regexp (used by MSW/Express) treats a hyphen as terminating the param name,
+    // so `:point-id` parses as param `point` followed by literal `-id`
+    expect(Url.toPath('/point/{point-id}')).toBe('/point/:pointId')
   })
 })
 

--- a/internals/utils/src/Url.ts
+++ b/internals/utils/src/Url.ts
@@ -72,9 +72,12 @@ export class Url {
    *
    * @example
    * Url.toPath('/pet/{petId}') // '/pet/:petId'
+   *
+   * @example
+   * Url.toPath('/point/{point-id}') // '/point/:pointId'
    */
   static toPath(path: string): string {
-    return path.replace(/\{([^}]+)\}/g, ':$1')
+    return path.replace(/\{([^}]+)\}/g, (_match, param: string) => `:${transformParam(param)}`)
   }
 
   /**


### PR DESCRIPTION
## 🎯 Changes

`Url.toPath` converted an OpenAPI path parameter to Express-style colon syntax with a plain string replacement, so `{point-id}` became `:point-id`. `path-to-regexp`, used by MSW under the hood, treats a hyphen as ending a route parameter name, so `:point-id` parsed as a param named `point` followed by the literal `-id`, and the generated MSW handler rejected valid values like `abc-id`.

`Url.toTemplateString` already camelCases parameter names that aren't valid JS identifiers via `transformParam`. `Url.toPath` now applies the same transform, so `{point-id}` becomes `:pointId`.

Fixes #3893

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ux398aiWRxTYWG92MGV5PG)_