### PR TITLE
fix(utils): camelCase hyphenated param names in URLPath#toURLPath

### DIFF
--- a/.changeset/fix-hyphenated-path-params-v4.md
+++ b/.changeset/fix-hyphenated-path-params-v4.md
@@ -1,0 +1,5 @@
+---
+"@kubb/plugin-msw": patch
+---
+
+Fix `URLPath#URL` producing an invalid Express-style route for a hyphenated path parameter (e.g. `{point-id}` became `:point-id`). `path-to-regexp` treats a hyphen as ending the parameter name, so the generated MSW handler matched `:point` followed by a literal `-id` and rejected valid values. `toURLPath` now camelCases the parameter name the same way `toTemplateString` already does, so `{point-id}` becomes `:pointId`.

--- a/internals/utils/src/urlPath.test.ts
+++ b/internals/utils/src/urlPath.test.ts
@@ -18,7 +18,13 @@ describe('URLPath', () => {
   })
 
   test('if URL path returns the correct format', () => {
-    expect(path.URL).toBe('/user/:userID/monetary-account/:monetary-accountID/whitelist-sdd/:itemId')
+    expect(path.URL).toBe('/user/:userID/monetary-account/:monetaryAccountID/whitelist-sdd/:itemId')
+  })
+
+  test('camelCases a hyphenated param name so path-to-regexp accepts it', () => {
+    // path-to-regexp (used by MSW/Express) treats a hyphen as terminating the param name,
+    // so `:point-id` parses as param `point` followed by literal `-id`
+    expect(new URLPath('/point/{point-id}').URL).toBe('/point/:pointId')
   })
 
   test('if params is getting returned', () => {

--- a/internals/utils/src/urlPath.ts
+++ b/internals/utils/src/urlPath.ts
@@ -151,6 +151,6 @@ export class URLPath {
 
   /** Converts the OpenAPI path to Express-style colon syntax, e.g. `/pet/{petId}` → `/pet/:petId`. */
   toURLPath(): string {
-    return this.path.replace(/\{([^}]+)\}/g, ':$1')
+    return this.path.replace(/\{([^}]+)\}/g, (_match, param: string) => `:${this.#transformParam(param)}`)
   }
 }

--- a/packages/plugin-client/src/generators/__snapshots__/dashedPathParams.ts
+++ b/packages/plugin-client/src/generators/__snapshots__/dashedPathParams.ts
@@ -14,7 +14,7 @@ export function getGetOrganizationByIdUrl({ organizationId }: { organizationId: 
 /**
  * @description Retrieves detailed information about an organization by ID.
  * @summary /organizations/{organization-id}
- * {@link /organizations/:organization-id}
+ * {@link /organizations/:organizationId}
  */
 export async function getOrganizationById(
   { organizationId }: { organizationId: GetOrganizationByIdPathParams['organizationId'] },

--- a/packages/plugin-client/src/generators/__snapshots__/dashedPathParamsInline.ts
+++ b/packages/plugin-client/src/generators/__snapshots__/dashedPathParamsInline.ts
@@ -14,7 +14,7 @@ export function getGetOrganizationByIdUrl(organizationId: GetOrganizationByIdPat
 /**
  * @description Retrieves detailed information about an organization by ID.
  * @summary /organizations/{organization-id}
- * {@link /organizations/:organization-id}
+ * {@link /organizations/:organizationId}
  */
 export async function getOrganizationById(
   organizationId: GetOrganizationByIdPathParams['organizationId'],

--- a/packages/plugin-react-query/src/generators/__snapshots__/getPetIdCamelCase.ts
+++ b/packages/plugin-react-query/src/generators/__snapshots__/getPetIdCamelCase.ts
@@ -7,7 +7,7 @@ import type { QueryKey, QueryClient, QueryObserverOptions, UseQueryResult } from
 import { fetch } from './test/.kubb/fetch'
 import { queryOptions, useQuery } from '@tanstack/react-query'
 
-export const getPetByIdQueryKey = (petId: GetPetByIdPathParams['petId'] | undefined) => [{ url: '/pet/:pet_id', params: { petId: petId } }] as const
+export const getPetByIdQueryKey = (petId: GetPetByIdPathParams['petId'] | undefined) => [{ url: '/pet/:petId', params: { petId: petId } }] as const
 
 export type GetPetByIdQueryKey = ReturnType<typeof getPetByIdQueryKey>
 


### PR DESCRIPTION
## 🎯 Changes

`URLPath#toURLPath` converted an OpenAPI path parameter to Express-style colon syntax with a plain string replacement, so `{point-id}` became `:point-id`. `path-to-regexp`, used by MSW under the hood, treats a hyphen as ending a route parameter name, so `:point-id` parsed as a param named `point` followed by the literal `-id`, and the generated MSW handler rejected valid values like `abc-id`.

`toTemplateString` already camelCases parameter names that aren't valid JS identifiers via `#transformParam`. `toURLPath` now applies the same transform, so `{point-id}` becomes `:pointId`.

This is the v4-branch equivalent of the fix on `main` (`Url.toPath` in `internals/utils/src/Url.ts`), which uses a different `URLPath`/`urlPath.ts` implementation on this branch.

Fixes #3893

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ux398aiWRxTYWG92MGV5PG)_