### PR TITLE
Bump kubb-labs/config setup action to pick up safe-chain exclusions

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3f4c08f50e67174c9e0ba09290bc79199f50ddfb # main
+        uses: kubb-labs/config/.github/setup@b6c32300e26286508cc3da47d55b0a7a4c8d5583 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/changeset-format.yml
+++ b/.github/workflows/changeset-format.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3f4c08f50e67174c9e0ba09290bc79199f50ddfb # main
+        uses: kubb-labs/config/.github/setup@b6c32300e26286508cc3da47d55b0a7a4c8d5583 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3f4c08f50e67174c9e0ba09290bc79199f50ddfb # main
+        uses: kubb-labs/config/.github/setup@b6c32300e26286508cc3da47d55b0a7a4c8d5583 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3f4c08f50e67174c9e0ba09290bc79199f50ddfb # main
+        uses: kubb-labs/config/.github/setup@b6c32300e26286508cc3da47d55b0a7a4c8d5583 # main
         with:
           node-version: '22.22.3'
 
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3f4c08f50e67174c9e0ba09290bc79199f50ddfb # main
+        uses: kubb-labs/config/.github/setup@b6c32300e26286508cc3da47d55b0a7a4c8d5583 # main
         with:
           node-version: '22.22.3'
 
@@ -72,7 +72,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3f4c08f50e67174c9e0ba09290bc79199f50ddfb # main
+        uses: kubb-labs/config/.github/setup@b6c32300e26286508cc3da47d55b0a7a4c8d5583 # main
         with:
           node-version: '22.22.3'
 
@@ -102,7 +102,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3f4c08f50e67174c9e0ba09290bc79199f50ddfb # main
+        uses: kubb-labs/config/.github/setup@b6c32300e26286508cc3da47d55b0a7a4c8d5583 # main
         with:
           node-version: '22.22.3'
 
@@ -127,7 +127,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3f4c08f50e67174c9e0ba09290bc79199f50ddfb # main
+        uses: kubb-labs/config/.github/setup@b6c32300e26286508cc3da47d55b0a7a4c8d5583 # main
         with:
           node-version: '22.22.3'
 
@@ -152,7 +152,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3f4c08f50e67174c9e0ba09290bc79199f50ddfb # main
+        uses: kubb-labs/config/.github/setup@b6c32300e26286508cc3da47d55b0a7a4c8d5583 # main
         with:
           node-version: '22.22.3'
 
@@ -199,7 +199,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3f4c08f50e67174c9e0ba09290bc79199f50ddfb # main
+        uses: kubb-labs/config/.github/setup@b6c32300e26286508cc3da47d55b0a7a4c8d5583 # main
         with:
           node-version: '22.22.3'
 
@@ -225,7 +225,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3f4c08f50e67174c9e0ba09290bc79199f50ddfb # main
+        uses: kubb-labs/config/.github/setup@b6c32300e26286508cc3da47d55b0a7a4c8d5583 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3f4c08f50e67174c9e0ba09290bc79199f50ddfb # main
+        uses: kubb-labs/config/.github/setup@b6c32300e26286508cc3da47d55b0a7a4c8d5583 # main
         with:
           node-version: '22.22.3'
           cache: 'false'
@@ -88,7 +88,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3f4c08f50e67174c9e0ba09290bc79199f50ddfb # main
+        uses: kubb-labs/config/.github/setup@b6c32300e26286508cc3da47d55b0a7a4c8d5583 # main
         with:
           node-version: '22.22.3'
           cache: 'false'


### PR DESCRIPTION
## Summary
- Bump the pinned SHA of `kubb-labs/config/.github/setup` used across all workflows to `b6c32300e26286508cc3da47d55b0a7a4c8d5583`
- That commit adds `SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS=kubb,@kubb/*,unplugin-kubb` to the shared setup action (kubb-labs/config#29), so CI's safe-chain no longer blocks direct downloads of our own fresh releases under the 48h minimum-age check

## Test plan
- [ ] CI installs successfully without an `ERR_PNPM_FETCH_403` safe-chain block

---
_Generated by [Claude Code](https://claude.ai/code/session_01WdeiW5wQw5SFqW85RQZg9i)_