### PR TITLE
Fix npmx.dev badge links in kubb package README

### DIFF
--- a/packages/kubb/README.md
+++ b/packages/kubb/README.md
@@ -187,15 +187,15 @@ See [LICENSE](./LICENSE) for details.
 <!-- Badges -->
 
 [npm-version-src]: https://shieldcn.dev/npm/v/@kubb/core.svg?variant=secondary&size=xs&theme=zinc&mode=dark
-[npm-version-href]: https://npmx.dev/package/kubb
+[npm-version-href]: https://npmx.dev/package/@kubb/core
 [npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/core.svg?variant=secondary&size=xs&theme=zinc&mode=dark
-[npm-downloads-href]: https://npmx.dev/package/kubb
+[npm-downloads-href]: https://npmx.dev/package/@kubb/core
 [stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [stars-href]: https://github.com/kubb-labs/kubb
 [license-src]: https://shieldcn.dev/npm/license/kubb.svg?variant=secondary&size=xs&theme=zinc
 [license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
 [node-src]: https://shieldcn.dev/npm/node/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
-[node-href]: https://npmx.dev/package/kubb
+[node-href]: https://npmx.dev/package/@kubb/core
 [contributors-src]: https://shieldcn.dev/github/contributors/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
 [contributors-href]: #contributors-
 [coverage-src]: https://shieldcn.dev/codecov/github/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark


### PR DESCRIPTION
## 🎯 Changes

`packages/kubb/README.md` badges use the `@kubb/core` npm package for the version, downloads, and node badge images, but the corresponding `npmx.dev` links pointed at the unscoped `kubb` package name, which does not exist on npmx.dev. This gave readers a broken link on every one of those three badges.

Fixed the `npm-version-href`, `npm-downloads-href`, and `node-href` link references to point to `https://npmx.dev/package/@kubb/core`, matching the badge images and the pattern already used consistently elsewhere in this repo and in `kubb-labs/plugins`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).


---
_Generated by [Claude Code](https://claude.ai/code/session_01TAFoMfzzgzsEiJ9ABPr6X3)_