### PR TITLE
Improve package metadata for registry front-ends

### DIFF
--- a/packages/adapter-oas/package.json
+++ b/packages/adapter-oas/package.json
@@ -20,6 +20,16 @@
     "url": "git+https://github.com/kubb-labs/kubb.git",
     "directory": "packages/adapter-oas"
   },
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/stijnvanhulle"
+    },
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/kubb"
+    }
+  ],
   "files": [
     "dist",
     "!/**/**.test.**",

--- a/packages/adapter-oas/package.json
+++ b/packages/adapter-oas/package.json
@@ -14,6 +14,7 @@
   ],
   "license": "MIT",
   "author": "stijnvanhulle",
+  "homepage": "https://kubb.dev/adapters/adapter-oas",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/adapter-oas/package.json
+++ b/packages/adapter-oas/package.json
@@ -12,9 +12,9 @@
     "swagger",
     "typescript"
   ],
+  "homepage": "https://kubb.dev/adapters/adapter-oas",
   "license": "MIT",
   "author": "stijnvanhulle",
-  "homepage": "https://kubb.dev/adapters/adapter-oas",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -17,6 +17,16 @@
     "url": "git+https://github.com/kubb-labs/kubb.git",
     "directory": "packages/ast"
   },
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/stijnvanhulle"
+    },
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/kubb"
+    }
+  ],
   "files": [
     "dist",
     "!/**/**.test.**",

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -9,9 +9,9 @@
     "meta-framework",
     "typescript"
   ],
+  "homepage": "https://kubb.dev",
   "license": "MIT",
   "author": "stijnvanhulle",
-  "homepage": "https://kubb.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -11,6 +11,7 @@
   ],
   "license": "MIT",
   "author": "stijnvanhulle",
+  "homepage": "https://kubb.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -19,6 +19,16 @@
     "url": "git+https://github.com/kubb-labs/kubb.git",
     "directory": "packages/cli"
   },
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/stijnvanhulle"
+    },
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/kubb"
+    }
+  ],
   "bin": {
     "kubb": "bin/kubb.js"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,6 +13,7 @@
   ],
   "license": "MIT",
   "author": "stijnvanhulle",
+  "homepage": "https://kubb.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,9 +11,9 @@
     "sdk-generator",
     "typescript"
   ],
+  "homepage": "https://kubb.dev",
   "license": "MIT",
   "author": "stijnvanhulle",
-  "homepage": "https://kubb.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -18,6 +18,16 @@
     "url": "git+https://github.com/kubb-labs/kubb.git",
     "directory": "packages/core"
   },
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/stijnvanhulle"
+    },
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/kubb"
+    }
+  ],
   "files": [
     "schemas",
     "dist",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,9 +10,9 @@
     "plugin-system",
     "typescript"
   ],
+  "homepage": "https://kubb.dev",
   "license": "MIT",
   "author": "stijnvanhulle",
-  "homepage": "https://kubb.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,7 @@
   ],
   "license": "MIT",
   "author": "stijnvanhulle",
+  "homepage": "https://kubb.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -12,6 +12,7 @@
   ],
   "license": "MIT",
   "author": "stijnvanhulle",
+  "homepage": "https://kubb.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -10,9 +10,9 @@
     "plugin",
     "typescript"
   ],
+  "homepage": "https://kubb.dev",
   "license": "MIT",
   "author": "stijnvanhulle",
-  "homepage": "https://kubb.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -18,6 +18,16 @@
     "url": "git+https://github.com/kubb-labs/kubb.git",
     "directory": "packages/kit"
   },
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/stijnvanhulle"
+    },
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/kubb"
+    }
+  ],
   "files": [
     "dist",
     "*.d.ts",

--- a/packages/kubb/package.json
+++ b/packages/kubb/package.json
@@ -23,6 +23,16 @@
     "url": "git+https://github.com/kubb-labs/kubb.git",
     "directory": "packages/kubb"
   },
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/stijnvanhulle"
+    },
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/kubb"
+    }
+  ],
   "bin": {
     "kubb": "bin/kubb.js"
   },

--- a/packages/kubb/package.json
+++ b/packages/kubb/package.json
@@ -15,9 +15,9 @@
     "typescript",
     "zod"
   ],
+  "homepage": "https://kubb.dev",
   "license": "MIT",
   "author": "stijnvanhulle",
-  "homepage": "https://kubb.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/kubb/package.json
+++ b/packages/kubb/package.json
@@ -17,6 +17,7 @@
   ],
   "license": "MIT",
   "author": "stijnvanhulle",
+  "homepage": "https://kubb.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -12,9 +12,9 @@
     "model-context-protocol",
     "typescript"
   ],
+  "homepage": "https://kubb.dev",
   "license": "MIT",
   "author": "stijnvanhulle",
-  "homepage": "https://kubb.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -14,6 +14,7 @@
   ],
   "license": "MIT",
   "author": "stijnvanhulle",
+  "homepage": "https://kubb.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -20,6 +20,16 @@
     "url": "git+https://github.com/kubb-labs/kubb.git",
     "directory": "packages/mcp"
   },
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/stijnvanhulle"
+    },
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/kubb"
+    }
+  ],
   "bin": {
     "kubb-mcp": "bin/kubb-mcp.cjs"
   },

--- a/packages/parser-md/package.json
+++ b/packages/parser-md/package.json
@@ -13,6 +13,7 @@
   ],
   "license": "MIT",
   "author": "stijnvanhulle",
+  "homepage": "https://kubb.dev/parsers/parser-md",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/parser-md/package.json
+++ b/packages/parser-md/package.json
@@ -11,9 +11,9 @@
     "parser",
     "yaml"
   ],
+  "homepage": "https://kubb.dev/parsers/parser-md",
   "license": "MIT",
   "author": "stijnvanhulle",
-  "homepage": "https://kubb.dev/parsers/parser-md",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/parser-md/package.json
+++ b/packages/parser-md/package.json
@@ -19,6 +19,16 @@
     "url": "git+https://github.com/kubb-labs/kubb.git",
     "directory": "packages/parser-md"
   },
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/stijnvanhulle"
+    },
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/kubb"
+    }
+  ],
   "files": [
     "dist",
     "!/**/**.test.**",

--- a/packages/parser-ts/package.json
+++ b/packages/parser-ts/package.json
@@ -10,9 +10,9 @@
     "tsx",
     "typescript"
   ],
+  "homepage": "https://kubb.dev/parsers/parser-ts",
   "license": "MIT",
   "author": "stijnvanhulle",
-  "homepage": "https://kubb.dev/parsers/parser-ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/parser-ts/package.json
+++ b/packages/parser-ts/package.json
@@ -12,6 +12,7 @@
   ],
   "license": "MIT",
   "author": "stijnvanhulle",
+  "homepage": "https://kubb.dev/parsers/parser-ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/parser-ts/package.json
+++ b/packages/parser-ts/package.json
@@ -18,6 +18,16 @@
     "url": "git+https://github.com/kubb-labs/kubb.git",
     "directory": "packages/parser-ts"
   },
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/stijnvanhulle"
+    },
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/kubb"
+    }
+  ],
   "files": [
     "dist",
     "!/**/**.test.**",

--- a/packages/plugin-barrel/package.json
+++ b/packages/plugin-barrel/package.json
@@ -10,9 +10,9 @@
     "plugin",
     "typescript"
   ],
+  "homepage": "https://kubb.dev/plugins/plugin-barrel",
   "license": "MIT",
   "author": "stijnvanhulle",
-  "homepage": "https://kubb.dev/plugins/plugin-barrel",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/plugin-barrel/package.json
+++ b/packages/plugin-barrel/package.json
@@ -12,6 +12,7 @@
   ],
   "license": "MIT",
   "author": "stijnvanhulle",
+  "homepage": "https://kubb.dev/plugins/plugin-barrel",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/plugin-barrel/package.json
+++ b/packages/plugin-barrel/package.json
@@ -18,6 +18,16 @@
     "url": "git+https://github.com/kubb-labs/kubb.git",
     "directory": "packages/plugin-barrel"
   },
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/stijnvanhulle"
+    },
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/kubb"
+    }
+  ],
   "files": [
     "dist",
     "*.d.ts",

--- a/packages/renderer-jsx/package.json
+++ b/packages/renderer-jsx/package.json
@@ -18,6 +18,16 @@
     "url": "git+https://github.com/kubb-labs/kubb.git",
     "directory": "packages/renderer-jsx"
   },
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/stijnvanhulle"
+    },
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/kubb"
+    }
+  ],
   "files": [
     "dist",
     "*.d.ts",

--- a/packages/renderer-jsx/package.json
+++ b/packages/renderer-jsx/package.json
@@ -12,6 +12,7 @@
   ],
   "license": "MIT",
   "author": "stijnvanhulle",
+  "homepage": "https://kubb.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/renderer-jsx/package.json
+++ b/packages/renderer-jsx/package.json
@@ -10,9 +10,9 @@
     "meta-framework",
     "typescript"
   ],
+  "homepage": "https://kubb.dev",
   "license": "MIT",
   "author": "stijnvanhulle",
-  "homepage": "https://kubb.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/unplugin-kubb/package.json
+++ b/packages/unplugin-kubb/package.json
@@ -17,9 +17,9 @@
     "vite",
     "webpack"
   ],
+  "homepage": "https://kubb.dev",
   "license": "MIT",
   "author": "stijnvanhulle",
-  "homepage": "https://kubb.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",

--- a/packages/unplugin-kubb/package.json
+++ b/packages/unplugin-kubb/package.json
@@ -25,6 +25,16 @@
     "url": "git+https://github.com/kubb-labs/kubb.git",
     "directory": "packages/unplugin-kubb"
   },
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/stijnvanhulle"
+    },
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/kubb"
+    }
+  ],
   "files": [
     "dist",
     "!/**/**.test.**",

--- a/packages/unplugin-kubb/package.json
+++ b/packages/unplugin-kubb/package.json
@@ -19,10 +19,11 @@
   ],
   "license": "MIT",
   "author": "stijnvanhulle",
+  "homepage": "https://kubb.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/kubb-labs/kubb.git",
-    "directory": "packages/unplugin"
+    "directory": "packages/unplugin-kubb"
   },
   "files": [
     "dist",


### PR DESCRIPTION
## 🎯 Changes

Audited what registry front-ends read from `package.json` and filled the gaps:

- `unplugin-kubb`'s `repository.directory` pointed at `packages/unplugin`, which does not exist. The actual source lives in `packages/unplugin-kubb`, so the "view source" link resolved to nothing.
- No package set `homepage`, leaving front-ends with no project link. Added one to every package: extension packages (`@kubb/adapter-oas`, `@kubb/parser-md`, `@kubb/parser-ts`, `@kubb/plugin-barrel`) point at their kubb.dev doc page, the rest at kubb.dev.
- No package set `funding`, so the sponsor links never surfaced on package pages or through `npm fund`. Added the GitHub Sponsors and Open Collective entries already listed in the README.

`engines`, `types`, `exports`, `license`, `keywords`, and `description` were already in place, and provenance attestations already come from the OIDC trusted publishing in `release.yml`, so no changes were needed there.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).
