### PR TITLE
chore(deps): bump verkit and @tmcp/transport-stdio

### DIFF
--- a/.changeset/bump-verkit-tmcp-transport.md
+++ b/.changeset/bump-verkit-tmcp-transport.md
@@ -1,0 +1,6 @@
+---
+"@kubb/cli": patch
+"@kubb/mcp": patch
+---
+
+Bump `verkit` to 0.4.0 and `@tmcp/transport-stdio` to 0.5.0.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -72,7 +72,7 @@
     "jiti": "^2.7.0",
     "tinyexec": "catalog:",
     "unconfig": "^7.5.0",
-    "verkit": "^0.3.2"
+    "verkit": "^0.4.0"
   },
   "devDependencies": {
     "@internals/shared": "workspace:*",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -71,7 +71,7 @@
     "@kubb/adapter-oas": "workspace:*",
     "@kubb/core": "workspace:*",
     "@tmcp/adapter-valibot": "^0.1.6",
-    "@tmcp/transport-stdio": "^0.4.3",
+    "@tmcp/transport-stdio": "^0.5.0",
     "tmcp": "^1.20.0",
     "valibot": "^1.4.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,8 +166,8 @@ importers:
         specifier: ^7.5.0
         version: 7.5.0
       verkit:
-        specifier: ^0.3.2
-        version: 0.3.2
+        specifier: ^0.4.0
+        version: 0.4.0
     devDependencies:
       '@internals/shared':
         specifier: workspace:*
@@ -278,8 +278,8 @@ importers:
         specifier: ^0.1.6
         version: 0.1.6(tmcp@1.20.0(typescript@6.0.3))(valibot@1.4.2(typescript@6.0.3))
       '@tmcp/transport-stdio':
-        specifier: ^0.4.3
-        version: 0.4.3(tmcp@1.20.0(typescript@6.0.3))
+        specifier: ^0.5.0
+        version: 0.5.0(tmcp@1.20.0(typescript@6.0.3))
       tmcp:
         specifier: ^1.20.0
         version: 1.20.0(typescript@6.0.3)
@@ -1516,10 +1516,15 @@ packages:
       tmcp: ^1.17.0
       valibot: ^1.1.0
 
-  '@tmcp/transport-stdio@0.4.3':
-    resolution: {integrity: sha512-chdmSwk7PSXjkaQId2OAY8ZMFrTFWwckfCyXJuw6b6WFK9IMK95EoU2VDFioybcmawuQox0MNPM5R2DVxlptoA==}
+  '@tmcp/session-manager@0.3.0':
+    resolution: {integrity: sha512-L16r8qlzXUoS0ec7kuap1P1nQorCcZHHUFe7UGijwwrfBRXB0hFnfC+/BM1PVdGlM7Ade8YxomecybQN5imYXA==}
     peerDependencies:
-      tmcp: ^1.16.3
+      tmcp: ^1.20.0-next.0 || ^1.20.0
+
+  '@tmcp/transport-stdio@0.5.0':
+    resolution: {integrity: sha512-1NZsGDveDraa/KWsOOn8VybPn5PbYJi5hRWuIRUKIX7joa3Lx7tSf+0EeXwzG1OyPlsEeTNagBWpBpvpfh5lpw==}
+    peerDependencies:
+      tmcp: ^1.20.0-next.0 || ^1.20.0
 
   '@turbo/darwin-64@2.10.10':
     resolution: {integrity: sha512-gFDD+wRP5hWxBRghGyEbjpbLOY7aIU/wvsnKdMM7odQcp/wHMrnI83p0FyxxMRZnFH9ZD+S59MvcpOC5b+nrCA==}
@@ -3519,6 +3524,10 @@ packages:
     resolution: {integrity: sha512-zj/ob3UsvJGN0whEAKFp53REA5X66hvffVqoCtVQAakJKnKlH+/PcOfMoFwIG/o4rElqLv/ycAFlx8ZlXUorCg==}
     engines: {node: '>=18.12.0'}
 
+  verkit@0.4.0:
+    resolution: {integrity: sha512-sXMwN6DMHeouPfCxkxWkKAmxphWKEenHYY5H1nIBzU3PmDsmJp6kBXJdshjVdpMZuWCmL9SH7KFRx29AylpP6g==}
+    engines: {node: '>=18.12.0'}
+
   vite@8.2.1:
     resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4744,8 +4753,14 @@ snapshots:
       tmcp: 1.20.0(typescript@6.0.3)
       valibot: 1.4.2(typescript@6.0.3)
 
-  '@tmcp/transport-stdio@0.4.3(tmcp@1.20.0(typescript@6.0.3))':
+  '@tmcp/session-manager@0.3.0(tmcp@1.20.0(typescript@6.0.3))':
     dependencies:
+      json-rpc-2.0: 1.7.1
+      tmcp: 1.20.0(typescript@6.0.3)
+
+  '@tmcp/transport-stdio@0.5.0(tmcp@1.20.0(typescript@6.0.3))':
+    dependencies:
+      '@tmcp/session-manager': 0.3.0(tmcp@1.20.0(typescript@6.0.3))
       tmcp: 1.20.0(typescript@6.0.3)
 
   '@turbo/darwin-64@2.10.10':
@@ -6620,6 +6635,8 @@ snapshots:
   vary@1.1.2: {}
 
   verkit@0.3.2: {}
+
+  verkit@0.4.0: {}
 
   vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.48.0)(yaml@2.9.0):
     dependencies:


### PR DESCRIPTION
## 🎯 Changes

Applies the subset of a pending dependency-update batch whose target versions already clear the repo's `minimumReleaseAge: 2880` (48h) supply-chain policy in `pnpm-workspace.yaml`, checked via `npm view <pkg>@<version> time` against the current time (2026-08-20T09:23Z):

Kept (published more than 48h ago):
- `verkit` 0.3.2 → 0.4.0 (published 2026-08-15T13:10Z)
- `@tmcp/transport-stdio` 0.4.3 → 0.5.0 (published 2026-08-14T12:53Z)

Reverted to their current versions (still inside the 48h window, left for a later pass):
- `@changesets/cli` 3.0.0 → 3.0.1 (published 2026-08-19T05:46Z)
- `turbo` 2.10.10 → 2.10.11 (published 2026-08-18T15:17Z)
- `rolldown` 1.2.4 → 1.2.5 (published 2026-08-19T13:33Z)
- `vite` 8.2.1 → 8.2.2 (published 2026-08-20T04:14Z)
- catalog: `@vitest/coverage-v8`, `@vitest/ui`, `vitest` 4.1.10 → 4.1.11 (published 2026-08-18T14:22–14:27Z)
- catalog: `oxfmt` 0.62.0 → 0.64.0, `oxlint` 1.78.0 → 1.79.0 (published 2026-08-18T15:10–15:12Z)

`@types/node`, `taze`, and `typescript` were left untouched, as requested.

No `--config.minimum-release-age=0` or other policy bypass was used; `pnpm install` ran with the default policy and succeeded.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`. (One pre-existing failure in `packages/mcp` — `generate.test.ts` — reproduces identically on the base branch before these changes; it stems from a missing built `@kubb/adapter-oas` dist artifact, unrelated to this dependency bump.)

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).


---
_Generated by [Claude Code](https://claude.ai/code/session_01151oXv1L7pdKCtVDVwyG6c)_