### PR TITLE
chore: add context7.json pointing agents at the kubb.dev docs

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,14 +1,16 @@
 {
   "$schema": "https://context7.com/schema/context7.json",
+  "url": "https://context7.com/kubb-labs/kubb",
+  "public_key": "pk_E3UkJR9X5FvhME9wB1sCS",
   "projectTitle": "Kubb Core",
-  "description": "Core engine, CLI, authoring kit, OpenAPI adapter, parsers and renderers behind Kubb. The full Kubb documentation lives at https://kubb.dev and is indexed as /kubb-labs/docs.",
+  "description": "Core engine, CLI, authoring kit, OpenAPI adapter, parsers and renderers behind Kubb. The documentation is at https://kubb.dev, indexed on Context7 as /kubb-labs/docs.",
   "folders": ["packages"],
   "excludeFiles": ["AGENTS.md", "CLAUDE.md", "GEMINI.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "SECURITY.md"],
   "rules": [
-    "This repository holds the core packages only. For guides, configuration reference and plugin options, use https://kubb.dev or the /kubb-labs/docs library.",
+    "This repository holds the core packages, not the documentation. Guides, the configuration reference and plugin options are on https://kubb.dev, indexed on Context7 as /kubb-labs/docs.",
     "Import `defineConfig` from `kubb/config`, not from `kubb`.",
-    "Kubb v5 has no `pluginOas()`. The OpenAPI adapter is the top-level `adapter` key and defaults to `adapterOas()` from `@kubb/adapter-oas`, which ships with `kubb`. Set `adapter` only to pass options.",
-    "Each output format is its own `@kubb/plugin-*` package, listed in `plugins: []` and maintained in kubb-labs/plugins.",
-    "`@kubb/plugin-client` was removed in v5. Register `pluginAxios` or `pluginFetch` and point query and MCP plugins at it with `client: 'axios' | 'fetch'`."
+    "Kubb v5 has no `pluginOas()`. The OpenAPI adapter is a top-level `adapter` key that defaults to `adapterOas()` from `@kubb/adapter-oas`, which ships with `kubb`. Set it only when you need to pass options.",
+    "Each output format is its own `@kubb/plugin-*` package, listed in `plugins: []`. They are maintained in kubb-labs/plugins, not here.",
+    "`@kubb/plugin-client` was removed in v5. Register `pluginAxios` or `pluginFetch` instead, then point the query and MCP plugins at it with `client: 'axios' | 'fetch'`."
   ]
 }

--- a/context7.json
+++ b/context7.json
@@ -3,7 +3,7 @@
   "url": "https://context7.com/kubb-labs/kubb",
   "public_key": "pk_E3UkJR9X5FvhME9wB1sCS",
   "projectTitle": "Kubb Core",
-  "description": "Core engine, CLI, authoring kit, OpenAPI adapter, parsers and renderers behind Kubb. The documentation is at https://kubb.dev, indexed on Context7 as /kubb-labs/docs.",
+  "description": "The meta framework for code generation. Point Kubb at a schema and it generates types, clients, hooks, validators and mocks. This repository holds the core engine, CLI, authoring kit, OpenAPI adapter, parsers and renderers. The documentation is at https://kubb.dev, indexed on Context7 as /kubb-labs/docs.",
   "folders": ["packages"],
   "excludeFiles": ["AGENTS.md", "CLAUDE.md", "GEMINI.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "SECURITY.md"],
   "rules": [

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "Kubb Core",
+  "description": "Core engine, CLI, authoring kit, OpenAPI adapter, parsers and renderers behind Kubb. The full Kubb documentation lives at https://kubb.dev and is indexed as /kubb-labs/docs.",
+  "folders": ["packages"],
+  "excludeFiles": ["AGENTS.md", "CLAUDE.md", "GEMINI.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "SECURITY.md"],
+  "rules": [
+    "This repository holds the core packages only. For guides, configuration reference and plugin options, use https://kubb.dev or the /kubb-labs/docs library.",
+    "Import `defineConfig` from `kubb/config`, not from `kubb`.",
+    "Kubb v5 has no `pluginOas()`. The OpenAPI adapter is the top-level `adapter` key and defaults to `adapterOas()` from `@kubb/adapter-oas`, which ships with `kubb`. Set `adapter` only to pass options.",
+    "Each output format is its own `@kubb/plugin-*` package, listed in `plugins: []` and maintained in kubb-labs/plugins.",
+    "`@kubb/plugin-client` was removed in v5. Register `pluginAxios` or `pluginFetch` and point query and MCP plugins at it with `client: 'axios' | 'fetch'`."
+  ]
+}


### PR DESCRIPTION
## 🎯 Changes

`/kubb-labs/kubb` is the Context7 entry agents hit when they resolve "Kubb", and it is stale: querying it for a v5 config returns a `pluginOas()` + `pluginTs()` example attributed to `packages/mcp/README.md`. `pluginOas` does not appear anywhere in this repo any more.

`context7.json` has no redirect field — it only configures the parse of the repo it sits in — so this does the next best thing:

- `folders: ["packages"]` keeps the parse on the package READMEs. Context7 skips raw source when documentation is present, so this is README-level reference material rather than snippets reconstructed from source.
- `excludeFiles` drops `CHANGELOG.md` and the agent instruction files, which are always-included root markdown otherwise.
- `description` and the first `rules` entry send agents to kubb.dev and `/kubb-labs/docs` for guides, configuration reference and plugin options.
- The remaining rules pin the v5 facts stale indexes get wrong: `defineConfig` comes from `kubb/config`, the OpenAPI adapter is the top-level `adapter` key defaulting to `adapterOas()`, plugins are separate `@kubb/plugin-*` packages, and `@kubb/plugin-client` was removed in favor of `pluginAxios`/`pluginFetch`.

One deliberate tradeoff: `projectTitle` is set to "Kubb Core" rather than "Kubb". This entry is the core packages, and the documentation entry should be the one that wins when an agent resolves "Kubb". Context7 treats `projectTitle` as a suggestion used when its own inference is low-confidence, so the effect is soft either way — drop the field to keep the current title.

Companion PRs: kubb-labs/docs#184 (registers the docs repo as the documentation library) and the matching one in `kubb-labs/plugins`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

Not applicable: the file is a root config for an external service, outside the `packages internals configs` scope that lint, format and tests cover.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwPvg9GiHHk1Kbwap4DfHv)_