### PR TITLE
fix(adapter-oas): keep non-null types when null leads a 3.1 type array

### DIFF
--- a/.changeset/fix-oas31-null-first-type-array.md
+++ b/.changeset/fix-oas31-null-first-type-array.md
@@ -1,0 +1,5 @@
+---
+"@kubb/adapter-oas": patch
+---
+
+Fix an OpenAPI 3.1 multi-type array dropping every type when `null` came first. `type: ["null", "string"]` generated `null` instead of `string | null`, while the equivalent `type: ["string", "null"]` generated the right thing, so output depended on the order the types were written in. The normalized type now takes the first non-`null` entry, leaving `type: ["null"]` as a null schema.

--- a/.changeset/fix-oas31-null-first-type-array.md
+++ b/.changeset/fix-oas31-null-first-type-array.md
@@ -2,4 +2,4 @@
 "@kubb/adapter-oas": patch
 ---
 
-Fix an OpenAPI 3.1 multi-type array dropping every type when `null` came first. `type: ["null", "string"]` generated `null` instead of `string | null`, while the equivalent `type: ["string", "null"]` generated the right thing, so output depended on the order the types were written in. The normalized type now takes the first non-`null` entry, leaving `type: ["null"]` as a null schema.
+Fix an OpenAPI 3.1 multi-type array dropping its other types when `null` came first. `type: ["null", "string"]` generated `null` instead of `string | null`, while `type: ["string", "null"]` generated the right type, so the output depended on the order the types happened to be written in. The normalized type now takes the first non-`null` entry, and `type: ["null"]` stays a null schema.

--- a/packages/adapter-oas/src/emit/parseSchema.ts
+++ b/packages/adapter-oas/src/emit/parseSchema.ts
@@ -20,7 +20,8 @@ export type SchemaContext = {
   nullable: true | undefined
   defaultValue: unknown
   /**
-   * Normalized single type string (first element when OAS 3.1 multi-type array).
+   * Normalized single type string (first non-`null` element when OAS 3.1 multi-type array, so
+   * `['null', 'string']` and `['string', 'null']` both normalize to `string` with `nullable` set).
    */
   type: string | undefined
   rawOptions: Partial<ast.ParserOptions> | undefined

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -2719,6 +2719,28 @@ describe('parseSchema OAS 3.1 type array', () => {
     expect(node.nullable).toBe(true)
   })
 
+  it('sets nullable when null leads a single-non-null type array', () => {
+    const node = parseSchema(ctx, { schema: { type: ['null', 'string'] } })
+
+    expect(node.type).toBe('string')
+    expect(node.nullable).toBe(true)
+  })
+
+  it('sets nullable when null leads multiple types', () => {
+    const node = parseSchema(ctx, { schema: { type: ['null', 'string', 'integer'] } })
+    const narrowed = ast.narrowSchema(node, 'union')
+
+    expect(node.type).toBe('union')
+    expect(node.nullable).toBe(true)
+    expect(narrowed?.members).toHaveLength(2)
+  })
+
+  it('keeps a null-only type array as a null node', () => {
+    const node = parseSchema(ctx, { schema: { type: ['null'] } })
+
+    expect(node.type).toBe('null')
+  })
+
   it('handles type array with a single non-null entry', () => {
     const node = parseSchema(ctx, { schema: { type: ['integer'] } })
 

--- a/packages/adapter-oas/src/parser.ts
+++ b/packages/adapter-oas/src/parser.ts
@@ -60,7 +60,7 @@ export function createSchemaParser(ctx: OasParserContext) {
 
     const nullable = isNullable(schema) || undefined
     const defaultValue = schema.default === null && nullable ? undefined : schema.default
-    const type = Array.isArray(schema.type) ? schema.type[0] : schema.type
+    const type = Array.isArray(schema.type) ? (schema.type.find((t) => t !== 'null') ?? schema.type[0]) : schema.type
 
     const context: ConvertContext = {
       schema,


### PR DESCRIPTION
Fixes #3910.

## 🎯 Changes

An OpenAPI 3.1 schema written as `type: ["null", "string"]` generated `null`, dropping `string` entirely. Written the other way round, `type: ["string", "null"]` generated `string | null` correctly, so the output depended on the order the author happened to write the types in. OAS 3.1 gives that order no meaning.

This is a regression rather than a new bug. The same symptom was reported as #1690 against v3.10.4 and fixed by #1691 in April 2025. The v5 `adapter-oas` rewrite reintroduced it, and the reporter of #3910 spotted the connection.

The cause is one line in `packages/adapter-oas/src/parser.ts`:

```ts
const type = Array.isArray(schema.type) ? schema.type[0] : schema.type
```

`SchemaContext.type` unconditionally took the first element. For `["null", "string"]` that is `"null"`, which then matched the last entry in the `schemaRules` table (`type === 'null'`) and emitted a null node, discarding the rest. The multi-type rule earlier in the table only fires when more than one non-`null` type remains, so a single non-`null` type never reached it.

The fix takes the first non-`null` entry, falling back to the first element so a `type: ["null"]` schema stays a null schema:

```ts
const type = Array.isArray(schema.type) ? (schema.type.find((t) => t !== 'null') ?? schema.type[0]) : schema.type
```

Nullability needed no change. `isNullable()` already returns `true` when `null` appears anywhere in the array, which is why the null-last spelling worked. Both spellings now normalize to `string` with `nullable` set.

I also updated the `SchemaContext.type` doc comment, which still described the old "first element" behavior.

## 🧪 Tests

Three cases added to `parseSchema OAS 3.1 type array`. The suite already covered `["string", "null"]` but never the null-first spelling, which is how this got through.

- `["null", "string"]` to `string` with nullable set. This one fails before the change (`expected 'null' to be 'string'`) and passes after.
- `["null", "string", "integer"]` to a union of two with nullable set. It passed before and after, since the multi-type rule already caught it.
- `["null"]` to a null node, which guards the fallback.

Verified locally: 525 adapter-oas tests pass, `oxlint` clean, `oxfmt --check` clean, `tsc --noEmit` clean.

One unrelated failure shows up in the full-repo run. `packages/mcp/src/tools/generate.test.ts` cannot resolve `@kubb/adapter-oas/dist/index.cjs` because the workspace packages are not built in my environment. It fails identically with my changes stashed, so it predates this diff. CI, which builds first, runs it green.

## Known gap, not addressed here

Checking this against #1690's original reproduction showed that its `status` property is still not fully restored:

```yaml
status:
  type: ["null", "integer", "string"]
  format: int32
```

That still parses to `integer` (nullable) rather than `(number | string) | null`, because the `format` rule sits ahead of the multi-type rule in `schemaRules` and collapses the union before it can form. It is a separate defect from the one #3910 reports, and reordering those rules reaches further than this fix warrants, so I left it alone.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).