### PR TITLE
chore: fix context7.json format for library claiming

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://context7.com/schema/context7.json",
   "url": "https://context7.com/kubb-labs/kubb",
   "public_key": "pk_E3UkJR9X5FvhME9wB1sCS",
   "projectTitle": "Kubb Core",


### PR DESCRIPTION
## 🎯 Changes

Context7 rejected the claim for `/kubb-labs/kubb` with "context7.json format is incorrect for claiming": the verifier requires `url` and `public_key` and accepts the documented config fields, but refuses anything else. `$schema` is a JSON Schema meta key, not one of those config fields, so it fails verification.

Dropped `"$schema"` from `context7.json`. Everything else (`url`, `public_key`, `projectTitle`, `description`, `folders`, `excludeFiles`, `rules`) is a documented config field and stays as-is.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dr25jAaVtFrWp6zuLN2F4U)_