### PR TITLE
chore: restore the context7.json parsing config

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,4 +1,16 @@
 {
+  "$schema": "https://context7.com/schema/context7.json",
   "url": "https://context7.com/kubb-labs/kubb",
-  "public_key": "pk_E3UkJR9X5FvhME9wB1sCS"
+  "public_key": "pk_E3UkJR9X5FvhME9wB1sCS",
+  "projectTitle": "Kubb Core",
+  "description": "The meta framework for code generation. Point Kubb at a schema and it generates types, clients, hooks, validators and mocks. This repository holds the core engine, CLI, authoring kit, OpenAPI adapter, parsers and renderers. The documentation is at https://kubb.dev, indexed on Context7 as /kubb-labs/docs.",
+  "folders": ["packages"],
+  "excludeFiles": ["AGENTS.md", "CLAUDE.md", "GEMINI.md", "CHANGELOG.md", "CODE_OF_CONDUCT.md", "SECURITY.md"],
+  "rules": [
+    "This repository holds the core packages, not the documentation. Guides, the configuration reference and plugin options are on https://kubb.dev, indexed on Context7 as /kubb-labs/docs.",
+    "Import `defineConfig` from `kubb/config`, not from `kubb`.",
+    "Kubb v5 has no `pluginOas()`. The OpenAPI adapter is a top-level `adapter` key that defaults to `adapterOas()` from `@kubb/adapter-oas`, which ships with `kubb`. Set it only when you need to pass options.",
+    "Each output format is its own `@kubb/plugin-*` package, listed in `plugins: []`. They are maintained in kubb-labs/plugins, not here.",
+    "`@kubb/plugin-client` was removed in v5. Register `pluginAxios` or `pluginFetch` instead, then point the query and MCP plugins at it with `client: 'axios' | 'fetch'`."
+  ]
 }


### PR DESCRIPTION
## 🎯 Changes

Follow-up to the claiming change. `context7.json` on `main` is currently just `url` and `public_key`; this brings back the parsing config that tells Context7 what to index and what to tell agents:

- `projectTitle` and `description`
- `folders` (`packages`) and `excludeFiles`
- the five `rules` about `kubb/config`, the `adapter` key, the `@kubb/plugin-*` packages, and the removal of `@kubb/plugin-client`

`$schema` is re-added too, for autocomplete and validation in the editor.

**Merge this only after the library is claimed on [context7.com/kubb-labs/kubb/admin](https://context7.com/kubb-labs/kubb/admin)** — the claim verifier reads the default branch, and the extra fields are what it objected to.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dr25jAaVtFrWp6zuLN2F4U)_