### PR TITLE
fix(adapter-oas): run multi-type array rule before format

### DIFF
--- a/.changeset/fix-oas31-multitype-format-precedence.md
+++ b/.changeset/fix-oas31-multitype-format-precedence.md
@@ -1,0 +1,5 @@
+---
+"@kubb/adapter-oas": patch
+---
+
+Fix an OpenAPI 3.1 multi-type array collapsing to a single type when combined with `format`. `type: ["null", "integer", "string"], format: "int32"` generated `integer | null`, dropping `string` entirely, because the `format` rule ran before the multi-type array had a chance to split into its per-type members. The multi-type rule now runs first, so each member (still carrying the original `format`) is parsed on its own and `int32 | null` correctly stays `integer | string | null` while other `format`-only schemas are unaffected.

--- a/.changeset/fix-oas31-multitype-format-precedence.md
+++ b/.changeset/fix-oas31-multitype-format-precedence.md
@@ -2,4 +2,4 @@
 "@kubb/adapter-oas": patch
 ---
 
-Fix an OpenAPI 3.1 multi-type array collapsing to a single type when combined with `format`. `type: ["null", "integer", "string"], format: "int32"` generated `integer | null`, dropping `string` entirely, because the `format` rule ran before the multi-type array had a chance to split into its per-type members. The multi-type rule now runs first, so each member (still carrying the original `format`) is parsed on its own and `int32 | null` correctly stays `integer | string | null` while other `format`-only schemas are unaffected.
+Fix an OpenAPI 3.1 multi-type array collapsing to one type when paired with `format`. `type: ["null", "integer", "string"], format: "int32"` generated `integer | null`, dropping `string`. The multi-type rule now runs before `format`, so each type parses on its own.

--- a/packages/adapter-oas/src/emit/parseSchema.ts
+++ b/packages/adapter-oas/src/emit/parseSchema.ts
@@ -71,8 +71,13 @@ export type SchemaRule = {
 
 /**
  * Ordered schema rule table. Order is significant: composition keywords (`$ref`, `allOf`,
- * `oneOf`/`anyOf`) take precedence over `const`/`format`, which take precedence over the plain
- * `type`. The first matching rule that produces a node wins. See {@link SchemaRule} for the
+ * `oneOf`/`anyOf`) take precedence over `const`, which takes precedence over a genuine OAS 3.1
+ * multi-type array (more than one non-`null` type), which takes precedence over `format`/`type`.
+ * A multi-type array must split into its per-type members before `format` runs, otherwise
+ * `format` collapses the whole schema to one type (e.g. `type: ['null', 'integer', 'string'],
+ * format: 'int32'` would drop `string` and emit just `integer`); each split-off member still
+ * carries the original `format` and re-enters this table, so `format` still applies per member.
+ * The first matching rule that produces a node wins. See {@link SchemaRule} for the
  * match/convert/fall-through contract.
  */
 export const schemaRules: Array<SchemaRule> = [
@@ -80,6 +85,7 @@ export const schemaRules: Array<SchemaRule> = [
   { match: ({ schema }) => !!schema.allOf?.length, convert: convertAllOf },
   { match: ({ schema }) => !!(schema.oneOf?.length || schema.anyOf?.length), convert: convertUnion },
   { match: ({ schema }) => 'const' in schema && schema.const !== undefined, convert: convertConst },
+  { match: ({ schema }) => Array.isArray(schema.type) && schema.type.filter((t) => t !== 'null').length > 1, convert: convertMultiType },
   {
     match: ({ schema, options }) => {
       if (!schema.format) return false
@@ -89,7 +95,6 @@ export const schemaRules: Array<SchemaRule> = [
     convert: convertFormat,
   },
   { match: ({ schema }) => isBinary(schema), convert: convertBinary },
-  { match: ({ schema }) => Array.isArray(schema.type) && schema.type.filter((t) => t !== 'null').length > 1, convert: convertMultiType },
   {
     match: ({ schema, type }) => !type && (schema.minLength !== undefined || schema.maxLength !== undefined || schema.pattern !== undefined),
     convert: convertString,

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -2770,6 +2770,19 @@ describe('parseSchema OAS 3.1 type array', () => {
     const members = narrowed?.members ?? []
     expect(members.every((m) => m.readOnly === true)).toBe(true)
   })
+
+  it('splits a multi-type array before a numeric format collapses it', () => {
+    const node = parseSchema(ctx, {
+      schema: { type: ['null', 'integer', 'string'], format: 'int32' },
+    })
+    const narrowed = ast.narrowSchema(node, 'union')
+
+    expect(node.type).toBe('union')
+    expect(node.nullable).toBe(true)
+    expect(narrowed?.members).toHaveLength(2)
+    expect(narrowed?.members?.[0]?.type).toBe('integer')
+    expect(narrowed?.members?.[1]?.type).toBe('string')
+  })
 })
 
 describe('parseSchema integer', () => {


### PR DESCRIPTION
## 🎯 Changes

Closes the remaining gap in #3910 that #3912 left open. An OpenAPI 3.1 multi-type array combined with a numeric `format` still collapsed to a single type:

```yaml
status:
  type: ["null", "integer", "string"]
  format: int32
```

generated `integer | null`, dropping `string` entirely, because the `format` rule in the `schemaRules` table matched and converted the whole schema before the multi-type rule ever got a chance to split it into per-type members.

The fix moves the multi-type rule ahead of `format` (and `binary`) in `schemaRules`. It only fires when a type array has more than one non-`null` type, so ordinary single-type schemas with a `format` are unaffected. Each split-off member still carries the original `format` and re-enters the rule table on its own, so `format` keeps applying correctly per member: the `integer` member resolves through `format: int32` as before, and the `string` member falls back through the existing "numeric format on a string type" exception in `convertFormat`.

## 🧪 Tests

Added `splits a multi-type array before a numeric format collapses it` to the `parseSchema OAS 3.1 type array` suite in `packages/adapter-oas/src/parser.test.ts`, covering `type: ["null", "integer", "string"], format: "int32"` → union of `integer | string` with `nullable` set. It fails before the change (`integer` only, `string` dropped) and passes after.

Verified locally: full `adapter-oas` suite (526 tests) passes, `oxlint` clean, `oxfmt --check` clean, `tsc --noEmit` clean.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).


---
_Generated by [Claude Code](https://claude.ai/code/session_01C8bMmeYtf8wqzvSGE8rBid)_