### PR TITLE
chore(deps): bump taze to 21.1.0 (major)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "bun-types": "^1.3.14",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",
-    "taze": "^20.0.2",
+    "taze": "^21.1.0",
     "tsdown": "catalog:",
     "turbo": "^2.10.10",
     "typescript": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: 'catalog:'
         version: 1.78.0
       taze:
-        specifier: ^20.0.2
-        version: 20.0.2
+        specifier: ^21.1.0
+        version: 21.1.0
       tsdown:
         specifier: 'catalog:'
         version: 0.22.14(typescript@6.0.3)
@@ -3068,8 +3068,8 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
-  pnpm-workspace-yaml@1.7.0:
-    resolution: {integrity: sha512-cgjaozHkjWL4H8oKZydEWE4mg31XydK3/1cLKjHvwnFAXutp45yAlMKljpOdZEq4TtLuzYAMvy9j05wRm3aoPw==}
+  pnpm-workspace-yaml@1.8.0:
+    resolution: {integrity: sha512-rqGldoFOzjalWzlPtzAi/RcjAyep+Pjl4QUKJ6/oEZXzhVAX79GS/i8gjhQT715g75kTkyfHjL9eBPGZ9Co++Q==}
 
   postcss@8.5.25:
     resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
@@ -3297,8 +3297,8 @@ packages:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
-  taze@20.0.2:
-    resolution: {integrity: sha512-OlY3OEHIeVq7kSfidnkpEPE8Gqn1DgDU05Q4kdVrjrvVN8OIWu4xci+hK9DXofprHyw29vkgBpaz7n8dEUcHng==}
+  taze@21.1.0:
+    resolution: {integrity: sha512-NkFkadmqqpaVZ9x3bV4cul1xQnUknhs1HzE3Q/VXHKS7np2Kg7ZNL7nNsEsBXKsafmgepa+aZNtzoegDgsymPw==}
     hasBin: true
 
   term-size@2.2.1:
@@ -6188,7 +6188,7 @@ snapshots:
       exsolve: 1.1.0
       pathe: 2.0.3
 
-  pnpm-workspace-yaml@1.7.0:
+  pnpm-workspace-yaml@1.8.0:
     dependencies:
       yaml: 2.9.0
 
@@ -6436,7 +6436,7 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  taze@20.0.2:
+  taze@21.1.0:
     dependencies:
       '@antfu/ni': 30.5.0
       '@henrygd/queue': 1.2.0
@@ -6445,7 +6445,7 @@ snapshots:
       ofetch: 1.5.1
       package-manager-detector: 1.8.0
       pathe: 2.0.3
-      pnpm-workspace-yaml: 1.7.0
+      pnpm-workspace-yaml: 1.8.0
       restore-cursor: 5.1.0
       tinyexec: 1.3.0
       tinyglobby: 0.2.17


### PR DESCRIPTION
Bumps `taze` 20.0.2 → 21.1.0, tracked in #3908.

`taze` is a standalone devDependency CLI used only via the `upgrade` script (`npx taze -r -w --exclude pnpm --maturity-period 3`) — it's never imported by any source file, so a major bump here carries no API-surface risk to the codebase itself.

This branch is off `main` before #3918 (round 2 patch/minor updates) merges, so the lockfile still shows the pre-#3918 turbo/vitest pins — unrelated to this change.

## Verification
- `pnpm install` — clean; version confirmed >48h past npm publish
- `npx taze --version` — resolves and runs (21.1.0)
- `pnpm run lint` — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01151oXv1L7pdKCtVDVwyG6c)_