### PR TITLE
fix(kit): sanitize and dedupe MSW route param names in Url.toPath

### DIFF
--- a/.changeset/msw-path-param-collisions.md
+++ b/.changeset/msw-path-param-collisions.md
@@ -1,0 +1,8 @@
+---
+'@kubb/kit': patch
+---
+
+Fix `Url.toPath` producing route masks that `path-to-regexp` (used by MSW/Express) rejects or misparses:
+
+- A parameter name starting with a character outside `[A-Za-z0-9_]` (e.g. `{$id}`) now sanitizes to a safe capture name instead of keeping the disallowed character.
+- Distinct parameter names that normalize to the same identifier (e.g. `{group-id}` and `{group.id}`) are now deduplicated with an incrementing suffix (`groupId`, `groupId2`) instead of producing two identically named captures.

--- a/internals/utils/src/Url.test.ts
+++ b/internals/utils/src/Url.test.ts
@@ -40,6 +40,17 @@ describe('Url.toPath', () => {
     // so `:point-id` parses as param `point` followed by literal `-id`
     expect(Url.toPath('/point/{point-id}')).toBe('/point/:pointId')
   })
+
+  test('strips a leading `$` so path-to-regexp accepts the param name', () => {
+    expect(Url.toPath('/things/{$id}')).toBe('/things/:Id')
+  })
+
+  test('deduplicates param names that normalize to the same identifier', () => {
+    // `group-id` and `group.id` both camelCase to `groupId`; the second occurrence gets a
+    // counter suffix so path-to-regexp never sees two identically named captures, and the
+    // literal `.json` suffix is preserved
+    expect(Url.toPath('/groups/{group-id}/{group.id}.json')).toBe('/groups/:groupId/:groupId2.json')
+  })
 })
 
 describe('Url.toGroupedTemplateString', () => {

--- a/internals/utils/src/Url.ts
+++ b/internals/utils/src/Url.ts
@@ -44,6 +44,39 @@ function transformParam(raw: string): string {
 }
 
 /**
+ * `path-to-regexp` (used by MSW/Express) only accepts `[A-Za-z0-9_]` in a parameter name — it
+ * stops reading the name at the first other character (a hyphen, a dot, a `$`, ...), which either
+ * misparses the route or throws "Missing parameter name". This is a narrower check than
+ * {@link isValidVarName}: a `$`-prefixed name is a valid JS identifier but not a valid
+ * `path-to-regexp` name.
+ */
+function isPathToRegexpSafe(name: string): boolean {
+  return /^[A-Za-z0-9_]+$/.test(name)
+}
+
+/**
+ * Sanitizes a parameter name so it is safe to use as a `path-to-regexp` capture name, without
+ * routing through {@link camelCase} (which keeps a leading `$` since it is a valid JS identifier
+ * character). Runs of disallowed characters are treated as word boundaries; a boundary at the
+ * very start of the name (e.g. the `$` in `$id`) still capitalizes the word that follows it.
+ */
+function transformPathParam(raw: string): string {
+  if (isPathToRegexpSafe(raw)) {
+    return raw
+  }
+
+  const startsWithSafeChar = /^[A-Za-z_]/.test(raw)
+  const words = raw.split(/[^A-Za-z0-9]+/).filter(Boolean)
+
+  return words
+    .map((word, i) => {
+      const capitalize = !startsWithSafeChar || i > 0
+      return capitalize ? word.charAt(0).toUpperCase() + word.slice(1) : word.charAt(0).toLowerCase() + word.slice(1)
+    })
+    .join('')
+}
+
+/**
  * Renders how a grouped `path` object's member is accessed: dot access for a valid
  * identifier, bracket access with the raw name otherwise.
  */
@@ -70,14 +103,29 @@ export class Url {
   /**
    * Converts an OpenAPI/Swagger path to Express-style colon syntax.
    *
+   * Distinct parameter names that normalize to the same identifier (e.g. `{group-id}` and
+   * `{group.id}` both becoming `groupId`) are deduplicated with an incrementing suffix so
+   * `path-to-regexp` never sees two identically named captures.
+   *
    * @example
    * Url.toPath('/pet/{petId}') // '/pet/:petId'
    *
    * @example
    * Url.toPath('/point/{point-id}') // '/point/:pointId'
+   *
+   * @example
+   * Url.toPath('/groups/{group-id}/{group.id}.json') // '/groups/:groupId/:groupId2.json'
    */
   static toPath(path: string): string {
-    return path.replace(/\{([^}]+)\}/g, (_match, param: string) => `:${transformParam(param)}`)
+    const seen = new Map<string, number>()
+
+    return path.replace(/\{([^}]+)\}/g, (_match, param: string) => {
+      const base = transformPathParam(param)
+      const count = (seen.get(base) ?? 0) + 1
+      seen.set(base, count)
+
+      return count === 1 ? `:${base}` : `:${base}${count}`
+    })
   }
 
   /**


### PR DESCRIPTION
## 🎯 Changes

`@kubb/plugin-msw` builds its MSW route mask by calling `Url.toPath` (exported from `@kubb/kit`, in `internals/utils/src/Url.ts`) to turn an OpenAPI path's `{param}` placeholders into `path-to-regexp`/Express-style `:param` syntax.

`path-to-regexp` (v6, used by MSW) only accepts `[A-Za-z0-9_]` in a parameter name — it stops reading the name at the first other character, which either misparses the route or throws `"Missing parameter name"`. Two gaps caused invalid or colliding masks:

- A parameter name starting with a character outside that set (e.g. `{$id}`) was previously kept as-is because it's a *valid JS identifier* (`isValidVarName` allows a leading `$`), even though it isn't a valid `path-to-regexp` name. Added a dedicated `transformPathParam` sanitizer, used only by `Url.toPath`, that treats runs of disallowed characters as word boundaries (a boundary at the very start still capitalizes the word that follows), so `{$id}` → `:Id`.
- Distinct parameter names that normalize to the same identifier (e.g. `{group-id}` and `{group.id}`, both → `groupId`) produced two identically named captures. `Url.toPath` now tracks seen names and appends an incrementing suffix on collision, so `{group-id}/{group.id}.json` → `:groupId/:groupId2.json`.

`Url.toTemplateString` / `Url.toGroupedTemplateString` are unaffected — they interpolate a JS identifier (where `$id` is fine as-is), not a `path-to-regexp` capture name.

Closes #3921

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NiVPnA25c3vPBAR1h9Hoso)_