### PR TITLE
docs: require ISO 24495-1 plain language for agent output

### DIFF
--- a/.claude/output-styles/house.md
+++ b/.claude/output-styles/house.md
@@ -14,6 +14,4 @@ Everything you write for a person, not just markdown files, follows
 - Sentence-case headings, no emoji, no marketing words such as powerful, seamless, or robust. Be
   specific instead.
 - Cut filler and AI vocabulary: "in order to", "it is worth noting", utilize, leverage.
-- Everyday words, one idea per sentence, active voice. Keep file paths, commands, and
-  identifiers exact.
 - After a change, state what changed and the command to verify it.

--- a/.claude/output-styles/house.md
+++ b/.claude/output-styles/house.md
@@ -4,12 +4,9 @@ description: Concise, direct replies in the repo's house voice, held to the ISO 
 keep-coding-instructions: true
 ---
 
-Everything you write for a person follows
+Everything you write for a person, not just markdown files, follows
 [ISO 24495-1:2023](https://www.iso.org/standard/78907.html), the plain language standard. The
-reader gets what they need, finds it easily, understands it on the first read, and can act on
-it. That covers chat replies and any prose or comments you generate, not just markdown files.
-The `plain-language` rule carries the detail, and the `humanizer` skill is the full voice
-reference.
+`plain-language` rule carries the detail. The `humanizer` skill is the full voice reference.
 
 - Be concise and direct. Lead with the answer or the change, then a short reason.
 - No dashes as punctuation (em, en, or a spaced hyphen) and no clause-joining semicolons. Use a

--- a/.claude/output-styles/house.md
+++ b/.claude/output-styles/house.md
@@ -8,10 +8,9 @@ Everything you write for a person, not just markdown files, follows
 [ISO 24495-1:2023](https://www.iso.org/standard/78907.html), the plain language standard. The
 `plain-language` rule carries the detail. The `humanizer` skill is the full voice reference.
 
-- Be concise and direct. Lead with the answer or the change, then a short reason.
+- Be concise and direct.
 - No dashes as punctuation (em, en, or a spaced hyphen) and no clause-joining semicolons. Use a
   comma, parentheses, or a separate sentence. Hyphenated compounds and CLI flags are fine.
-- Sentence-case headings, no emoji, no marketing words such as powerful, seamless, or robust. Be
-  specific instead.
+- Sentence-case headings, no marketing words such as powerful, seamless, or robust. Be specific
+  instead. No emoji, except the `changelog` skill's section headings.
 - Cut filler and AI vocabulary: "in order to", "it is worth noting", utilize, leverage.
-- After a change, state what changed and the command to verify it.

--- a/.claude/output-styles/house.md
+++ b/.claude/output-styles/house.md
@@ -1,11 +1,15 @@
 ---
 name: house
-description: Concise, direct replies and clean prose in the repo's house voice, while keeping normal coding behavior
+description: Concise, direct replies in the repo's house voice, held to the ISO 24495-1 plain language standard, while keeping normal coding behavior
 keep-coding-instructions: true
 ---
 
-Write in the repo's house voice in chat replies and in any prose or comments you generate, not
-just markdown files. The `humanizer` skill is the full reference.
+Everything you write for a person follows
+[ISO 24495-1:2023](https://www.iso.org/standard/78907.html), the plain language standard. The
+reader gets what they need, finds it easily, understands it on the first read, and can act on
+it. That covers chat replies and any prose or comments you generate, not just markdown files.
+The `plain-language` rule carries the detail, and the `humanizer` skill is the full voice
+reference.
 
 - Be concise and direct. Lead with the answer or the change, then a short reason.
 - No dashes as punctuation (em, en, or a spaced hyphen) and no clause-joining semicolons. Use a
@@ -13,4 +17,6 @@ just markdown files. The `humanizer` skill is the full reference.
 - Sentence-case headings, no emoji, no marketing words such as powerful, seamless, or robust. Be
   specific instead.
 - Cut filler and AI vocabulary: "in order to", "it is worth noting", utilize, leverage.
+- Everyday words, one idea per sentence, active voice. Keep file paths, commands, and
+  identifiers exact.
 - After a change, state what changed and the command to verify it.

--- a/.claude/rules/plain-language.md
+++ b/.claude/rules/plain-language.md
@@ -1,0 +1,31 @@
+# Plain language
+
+Every response an agent gives a person follows
+[ISO 24495-1:2023](https://www.iso.org/standard/78907.html), the plain language standard. That
+covers chat replies, task summaries, commit messages, PR titles and bodies, changesets, review
+comments, and any error or CLI text an agent writes for a reader.
+
+The standard sets four outcomes. The reader gets what they need, finds it easily, understands it
+on the first read, and can act on it. The `humanizer` skill catches the writing tells. This rule
+sets the bar the output has to clear.
+
+## Relevant
+
+Answer what was asked, for the person who asked it. Leave out background the reader already has,
+options you ruled out, and any restatement of the request.
+
+## Findable
+
+Lead with the answer or the change, then the reason. Put the sentence that matters first. Reach
+for a heading or a list only when there is more than one item to separate.
+
+## Understandable
+
+Use everyday words and the shortest sentence that stays accurate. One idea per sentence, active
+voice ("the build fails", not "a failure is produced"). Explain a term the first time it appears
+when the reader may not know it. Keep file paths, commands, and identifiers exact.
+
+## Usable
+
+State what changed and the command that verifies it. When work is blocked, name what blocks it
+and what you need to continue. Point at the file and line the reader has to open.

--- a/.claude/rules/plain-language.md
+++ b/.claude/rules/plain-language.md
@@ -1,31 +1,15 @@
 # Plain language
 
-Every response an agent gives a person follows
+Everything an agent writes for a person follows
 [ISO 24495-1:2023](https://www.iso.org/standard/78907.html), the plain language standard. That
-covers chat replies, task summaries, commit messages, PR titles and bodies, changesets, review
-comments, and any error or CLI text an agent writes for a reader.
+covers chat replies, task summaries, commit messages, PR titles and bodies, review comments, and
+any error or CLI text.
 
 The standard sets four outcomes. The reader gets what they need, finds it easily, understands it
-on the first read, and can act on it. The `humanizer` skill catches the writing tells. This rule
-sets the bar the output has to clear.
+on the first read, and can act on it. In practice:
 
-## Relevant
-
-Answer what was asked, for the person who asked it. Leave out background the reader already has,
-options you ruled out, and any restatement of the request.
-
-## Findable
-
-Lead with the answer or the change, then the reason. Put the sentence that matters first. Reach
-for a heading or a list only when there is more than one item to separate.
-
-## Understandable
-
-Use everyday words and the shortest sentence that stays accurate. One idea per sentence, active
-voice ("the build fails", not "a failure is produced"). Explain a term the first time it appears
-when the reader may not know it. Keep file paths, commands, and identifiers exact.
-
-## Usable
-
-State what changed and the command that verifies it. When work is blocked, name what blocks it
-and what you need to continue. Point at the file and line the reader has to open.
+- Answer what was asked. Cut background the reader has, options you ruled out, and restatements
+  of the request.
+- Lead with the answer or the change, then the reason.
+- One idea per sentence. Everyday words, active voice, exact paths and commands.
+- Say what changed and how to verify it. When blocked, name the blocker and what you need.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,8 +61,8 @@ rtk proxy <cmd>       # Run raw without filtering but still track usage
 `AGENTS.md` is the canonical instruction file. `CLAUDE.md`, `GEMINI.md`, and
 `.github/copilot-instructions.md` symlink to it. Skills live in `.agents/skills/` (open
 `SKILL.md` format, cross-provider). Always-on conventions live in `.claude/rules/`
-(`code-style`, `jsdoc`, `markdown`, `testing`, `security`, `usa-english`), and `.claude/` also holds commands,
-subagents, output styles, and hooks.
+(`code-style`, `jsdoc`, `markdown`, `plain-language`, `testing`, `security`, `usa-english`),
+and `.claude/` also holds commands, subagents, output styles, and hooks.
 
 <skills>
 


### PR DESCRIPTION
## 🎯 Changes

Agents in this repo had a house voice (the `house` output style and the `humanizer` skill) but no named standard behind it. This adds one.

New always-on rule at `.claude/rules/plain-language.md`. It points at [ISO 24495-1:2023](https://www.iso.org/standard/78907.html), the plain language standard, and applies it to everything an agent writes for a person: chat replies, task summaries, commit messages, PR titles and bodies, changesets, review comments, and CLI or error text. It sets four outcomes: answer what was asked without restating the request, lead with the answer before the reason, use everyday words and active voice, and say what changed and the command that verifies it.

The rule has no `paths` frontmatter, so it loads always-on next to `security` and `usa-english`. `AGENTS.md` lists it with the other conventions. `.claude/output-styles/house.md` now names the same standard.

The same change is going into the other repos that carry these conventions.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`. Markdown only, no code touched, so the suite was not run.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).