### PR TITLE
fix(ci): skip changeset format job for fork pull requests

### DIFF
--- a/.github/workflows/changeset-format.yml
+++ b/.github/workflows/changeset-format.yml
@@ -15,6 +15,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## 🎯 Changes

The "Format Changeset PR" job checks out `github.head_ref` from `origin` and pushes formatting fixes back to the PR branch. Both steps only work when the branch lives in `kubb-labs/kubb`. On a fork PR (an external maintainer's contribution), the branch doesn't exist in `origin`, so `actions/checkout` fails right away — see [this failed run](https://github.com/kubb-labs/kubb/actions/runs/33007124858/job/98329234096).

`autofix.yml` and `pr.yml` already guard their write-back jobs with `if: github.event.pull_request.head.repo.full_name == github.repository`. This PR adds the same guard to `changeset-format.yml` so the job is skipped for fork PRs instead of failing.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`. (Not applicable: this is a one-line workflow YAML condition, not application code covered by the test suite.)

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).