### PR TITLE
refactor(studio): drop else if chain in generate step loop

### DIFF
--- a/packages/studio/src/generate.ts
+++ b/packages/studio/src/generate.ts
@@ -155,7 +155,9 @@ export async function generate({ config, hooks }: GenerateProps): Promise<void> 
 
     if (!tool) {
       await hooks.callHook('kubb:warn', { message: `No ${step.kind}ter found (${step.detect.join(', ')}). Skipping ${step.kind}ting.` })
-    } else if (setting === 'auto') {
+    }
+
+    if (tool && setting === 'auto') {
       await hooks.callHook('kubb:info', { message: `Auto-detected ${step.kind}ter: ${styleText('dim', tool)}` })
     }
 


### PR DESCRIPTION
## Summary
- Replaces the `else if` in the generate step loop with two separate `if` statements, per this repo's "avoid else if chains" style rule.

## Test plan
- [x] `pnpm --filter @kubb/studio typecheck`