### PR TITLE
Rename write-config command to save

### DIFF
--- a/.changeset/shaggy-moons-repeat.md
+++ b/.changeset/shaggy-moons-repeat.md
@@ -4,7 +4,7 @@
 
 Let Studio change plugin options in a project's `kubb.config.ts`.
 
-A new `write-config` command carries a list of edits, each one a `set`, `remove`, or `add-plugin`
+A new `save` command carries a list of edits, each one a `set`, `remove`, or `add-plugin`
 `operation`. The agent patches the file's AST rather than regenerating it, so only the values an
 edit names get rewritten. Comments, formatting, and the code you wrote around the config keep their
 own text.

--- a/packages/studio/src/connectStudio.test.ts
+++ b/packages/studio/src/connectStudio.test.ts
@@ -246,9 +246,9 @@ describe('connectToStudio', () => {
     expect(mockWs.terminated).toBe(false)
   })
 
-  // write-config command
+  // save command
 
-  describe('write-config', () => {
+  describe('save', () => {
     const original = [
       `import { defineConfig } from 'kubb/config'`,
       `import { pluginTs } from '@kubb/plugin-ts'`,
@@ -265,13 +265,13 @@ describe('connectToStudio', () => {
     let configFile: string
 
     /**
-     * The `config-written` reply the agent sent, if any.
+     * The `config-saved` reply the agent sent, if any.
      */
     const reply = () =>
       vi
         .mocked(sendAgentMessage)
         .mock.calls.map(([, message]) => message)
-        .find((message) => message.type === 'config-written')
+        .find((message) => message.type === 'config-saved')
 
     beforeEach(() => {
       projectRoot = mkdtempSync(path.join(tmpdir(), 'kubb-studio-'))
@@ -284,7 +284,7 @@ describe('connectToStudio', () => {
       rmSync(projectRoot, { recursive: true, force: true })
     })
 
-    const write = async (edits: Array<unknown>) => mockWs.trigger('message', { data: JSON.stringify({ type: 'command', command: 'write-config', edits }) })
+    const write = async (edits: Array<unknown>) => mockWs.trigger('message', { data: JSON.stringify({ type: 'command', command: 'save', edits }) })
 
     it('writes a literal option and leaves the rest of the file alone', async () => {
       await connectToStudio({ ...options, allowConfigEdit: true })
@@ -349,7 +349,7 @@ describe('connectToStudio', () => {
     it('still replies when the message carries no edits', async () => {
       await connectToStudio({ ...options, allowConfigEdit: true })
 
-      await mockWs.trigger('message', { data: JSON.stringify({ type: 'command', command: 'write-config' }) })
+      await mockWs.trigger('message', { data: JSON.stringify({ type: 'command', command: 'save' }) })
 
       expect(reply()?.payload).toMatchObject({ changed: false, outcomes: [] })
     })

--- a/packages/studio/src/connectStudio.ts
+++ b/packages/studio/src/connectStudio.ts
@@ -410,14 +410,14 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
             return
           }
 
-          if (data.command === 'write-config') {
-            // Studio waits on a `config-written` for every `write-config`, so every path out of this
+          if (data.command === 'save') {
+            // Studio waits on a `config-saved` for every `save`, so every path out of this
             // branch sends one. `edits` is checked before it is walked: the message crosses the same
             // trust boundary as the values inside it.
             if (!Array.isArray(data.edits)) {
-              logger.warn(tag, 'Ignored "write-config" from Studio: the message carried no edits')
+              logger.warn(tag, 'Ignored "save" from Studio: the message carried no edits')
 
-              sendAgentMessage(ws, { type: 'config-written', payload: { outcomes: [], changed: false } })
+              sendAgentMessage(ws, { type: 'config-saved', payload: { outcomes: [], changed: false } })
 
               return
             }
@@ -425,12 +425,12 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
             const edits = data.edits
             const refuse = (reason: string) =>
               sendAgentMessage(ws, {
-                type: 'config-written',
+                type: 'config-saved',
                 payload: { outcomes: edits.map((edit) => ({ edit, applied: false, reason })), changed: false },
               })
 
             if (!effectiveConfigEdit) {
-              logger.warn(tag, 'Ignored "write-config" from Studio: editing kubb.config.ts was not granted')
+              logger.warn(tag, 'Ignored "save" from Studio: editing kubb.config.ts was not granted')
 
               refuse('the agent was not granted permission to edit kubb.config.ts')
 
@@ -458,7 +458,7 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
               }
 
               sendAgentMessage(ws, {
-                type: 'config-written',
+                type: 'config-saved',
                 payload: { outcomes, changed, configFile: changed ? await readConfigFileView(patched) : undefined },
               })
 

--- a/packages/studio/src/protocol/index.ts
+++ b/packages/studio/src/protocol/index.ts
@@ -1,8 +1,8 @@
 /**
  * WebSocket message types for the agent ↔ Studio protocol.
  *
- * - Studio → agent: `command` (generate, connect, write-config), `pong`, `disconnect`
- * - Agent → Studio: `connected`, `data`, `ping`, `config-written`
+ * - Studio → agent: `command` (generate, connect, save), `pong`, `disconnect`
+ * - Agent → Studio: `connected`, `data`, `ping`, `config-saved`
  * - Either way: `kubb:error`
  */
 
@@ -176,7 +176,7 @@ export type KubbHooks = {
 export type KubbHook = keyof KubbHooks
 
 /**
- * Command sent from Studio to Agent: `generate`, `connect`, or `write-config`.
+ * Command sent from Studio to Agent: `generate`, `connect`, or `save`.
  */
 export type CommandMessage =
   /**
@@ -192,7 +192,7 @@ export type CommandMessage =
    * Change plugin options in the user's `kubb.config.ts`. Applied only when the agent was granted
    * `allowConfigEdit`; otherwise every edit comes back refused.
    */
-  | { type: 'command'; command: 'write-config'; edits: Array<ConfigEdit> }
+  | { type: 'command'; command: 'save'; edits: Array<ConfigEdit> }
 
 /**
  * Identifies the host running the Kubb runtime, so Studio can badge the connection and show the
@@ -297,10 +297,10 @@ export type ConnectedMessage = {
 }
 
 /**
- * Reply to a `write-config` command: what the agent did to the file on disk.
+ * Reply to a `save` command: what the agent did to the file on disk.
  */
-export type ConfigWrittenMessage = {
-  type: 'config-written'
+export type ConfigSavedMessage = {
+  type: 'config-saved'
   payload: {
     /**
      * Per-edit result, in the order the edits were sent.
@@ -419,7 +419,7 @@ export type AgentConnectResponse = {
  * Every message that can cross the agent WebSocket, in either direction. Narrow it with the
  * `is*Message` guards below before reading a variant's fields.
  */
-export type AgentMessage = CommandMessage | DataMessage | ConnectedMessage | ConfigWrittenMessage | ErrorMessage | PingMessage | PongMessage | DisconnectMessage
+export type AgentMessage = CommandMessage | DataMessage | ConnectedMessage | ConfigSavedMessage | ErrorMessage | PingMessage | PongMessage | DisconnectMessage
 
 // Helper type guards
 export function isCommandMessage(msg: AgentMessage): msg is CommandMessage {


### PR DESCRIPTION
## 🎯 Changes

Rename the agent WebSocket protocol command from `write-config` to `save` for persisting plugin options to `kubb.config.ts`. Also rename the corresponding response type from `config-written` to `config-saved` for consistency.

This makes the command name more intuitive and aligns with common UI terminology for save operations.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a changeset.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AjXzYHoHC2s61dRFzfrVJU)_