### PR TITLE
feat: version the Claude Code plugin with Changesets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -16,5 +16,9 @@
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "onlyUpdatePeerDependentsWhenOutOfRange": true
   },
-  "ignore": ["@internals/*"]
+  "ignore": ["@internals/*"],
+  "privatePackages": {
+    "version": true,
+    "tag": false
+  }
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - '.changeset/**'
       - 'packages/**'
+      - 'tools/claude/**'
       - '.github/workflows/release.yml'
 
 permissions: {}
@@ -51,6 +52,9 @@ jobs:
         uses: kubb-labs/config/.github/actions/release@3f4c08f50e67174c9e0ba09290bc79199f50ddfb # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Keeps tools/claude/.claude-plugin/plugin.json's version in step with the
+          # @kubb/claude-plugin package.json that Changesets bumps.
+          version-script: pnpm exec changeset version && pnpm run sync:plugin-version
 
       # Canary skips staging on purpose, so it stays automatic on every push.
       - name: Publish canary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Release
         id: release
-        uses: kubb-labs/config/.github/actions/release@3f4c08f50e67174c9e0ba09290bc79199f50ddfb # main
+        uses: kubb-labs/config/.github/actions/release@c285a5f640a8133ee6648bc4446cd953c32555df # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Keeps tools/claude/.claude-plugin/plugin.json's version in step with the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,12 @@ pnpm changeset
 
 Pick the packages you changed, choose the bump (patch for fixes, minor for features, major for breaking changes), and write a short summary aimed at users. Commit the generated file under `.changeset/`. Docs-only or internal changes that touch no published package do not need one.
 
+The Claude Code plugin under `tools/claude/` (commands, agents, skills, hooks) is versioned the
+same way as `"@kubb/claude-plugin"`, a private workspace package that sits in the same `fixed`
+group as every other `@kubb/*` package. Add a changeset when you change its content; release
+syncs the bumped version into `tools/claude/.claude-plugin/plugin.json` automatically, so never
+edit that file's `version` field by hand.
+
 ## Releasing
 
 Maintainers only, once a changeset merges. Merging a changeset queues or updates the automatic "Version Packages" PR. Merging that PR runs the release job, which stages every changed package with `pnpm stage publish` (npm's staged publishing). Nothing is installable until a maintainer approves it.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lint": "oxlint -c oxlint.config.ts ./packages",
     "lint:fix": "oxlint -c oxlint.config.ts --fix ./packages",
     "start": "turbo run start --filter=./packages/*",
+    "sync:plugin-version": "node scripts/sync-plugin-version.mjs",
     "test": "vitest run --config ./configs/vitest.config.ts",
     "test:bench": "NODE_OPTIONS='--max_old_space_size=4096' vitest bench --config ./configs/vitest.bench.config.ts",
     "test:watch": "vitest --config ./configs/vitest.config.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -387,6 +387,8 @@ importers:
         specifier: ^5.110.1
         version: 5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)
 
+  tools/claude: {}
+
 packages:
 
   '@antfu/ni@30.5.0':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
 packages:
   - packages/*
   - internals/*
+  - tools/*
 allowBuilds:
   "@parcel/watcher": true
   core-js: true

--- a/scripts/sync-plugin-version.mjs
+++ b/scripts/sync-plugin-version.mjs
@@ -1,0 +1,23 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const root = fileURLToPath(new URL('..', import.meta.url))
+const packageJsonPath = `${root}tools/claude/package.json`
+const pluginJsonPath = `${root}tools/claude/.claude-plugin/plugin.json`
+
+const { version } = JSON.parse(readFileSync(packageJsonPath, 'utf-8'))
+const pluginJsonText = readFileSync(pluginJsonPath, 'utf-8')
+const currentVersion = JSON.parse(pluginJsonText).version
+
+if (currentVersion === version) {
+  console.log(`tools/claude/.claude-plugin/plugin.json is already at ${version}`)
+} else {
+  // A targeted replace keeps the file's existing formatting (single-line arrays, key
+  // order) intact instead of re-serializing the whole document.
+  const updated = pluginJsonText.replace(
+    /"version":\s*"[^"]*"/,
+    `"version": "${version}"`,
+  )
+  writeFileSync(pluginJsonPath, updated)
+  console.log(`Synced tools/claude/.claude-plugin/plugin.json to ${version}`)
+}

--- a/scripts/sync-plugin-version.mjs
+++ b/scripts/sync-plugin-version.mjs
@@ -1,9 +1,10 @@
 import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const root = fileURLToPath(new URL('..', import.meta.url))
-const packageJsonPath = `${root}tools/claude/package.json`
-const pluginJsonPath = `${root}tools/claude/.claude-plugin/plugin.json`
+const packageJsonPath = join(root, 'tools/claude/package.json')
+const pluginJsonPath = join(root, 'tools/claude/.claude-plugin/plugin.json')
 
 const { version } = JSON.parse(readFileSync(packageJsonPath, 'utf-8'))
 const pluginJsonText = readFileSync(pluginJsonPath, 'utf-8')

--- a/tools/claude/package.json
+++ b/tools/claude/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@kubb/claude-plugin",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Kubb Claude Code plugin (commands, agents, skills, hooks).",
+  "license": "MIT"
+}


### PR DESCRIPTION
## 🎯 Changes

`tools/claude/.claude-plugin/plugin.json` (the distributable Claude Code plugin) carried a hand-typed `version` with no link to the release pipeline. This wires it into the existing Changesets flow instead:

- Add `tools/claude/package.json` as a private `@kubb/claude-plugin` workspace package. It matches the existing `fixed: ["@kubb/*", "kubb"]` group, so it bumps in lockstep with every other `@kubb/*` package.
- Add `tools/*` to `pnpm-workspace.yaml`. The root `build`/`lint`/`typecheck` scripts stay scoped to `./packages/*`, so this doesn't pull the plugin into those pipelines.
- Add `"privatePackages": { "version": true, "tag": false }` to `.changeset/config.json` so Changesets versions private packages (off by default). `private: true` already keeps it out of `changeset publish`.
- Add `scripts/sync-plugin-version.mjs` and a `sync:plugin-version` script that copies the bumped `package.json` version into `plugin.json`'s `version` field with a targeted string replace, preserving the file's existing formatting.
- Pass `version-script: pnpm exec changeset version && pnpm run sync:plugin-version` to the release action (needs kubb-labs/config#31 to add that input) and add `tools/claude/**` to the release workflow's trigger paths.
- Document the flow in `CONTRIBUTING.md`: add a changeset when the plugin's content changes, never hand-edit `plugin.json`'s version.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).

No changeset needed for this PR: it only wires up the versioning mechanism, it doesn't change the plugin's own content or version.

## Test plan

- [x] `pnpm install` — `@kubb/claude-plugin` resolves as a workspace package.
- [x] `pnpm exec changeset status` with a throwaway changeset — `@kubb/claude-plugin` correctly joins the `@kubb/*` fixed bump group.
- [x] Ran `scripts/sync-plugin-version.mjs` against a bumped test version — confirmed it updates only the `version` field in `plugin.json` and leaves formatting untouched.
- [ ] End-to-end on a real release once kubb-labs/config#31 merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WLr4jmn9i3sqZwe9372Xr5)_