### PR TITLE
fix(cli): add --dryRun and record the AI agent in telemetry

### DIFF
--- a/.changeset/gunshi-features.md
+++ b/.changeset/gunshi-features.md
@@ -2,4 +2,4 @@
 '@kubb/cli': minor
 ---
 
-Adds `--dryRun` to `generate` and `init` to preview a run without writing files, installing packages, formatting, linting, or running post-generate commands. Anonymous telemetry now records the name of the AI coding agent that ran the command, when one is detected.
+Adds `--dryRun` to `generate` and `init` to preview a run without writing files, installing packages, formatting, linting, or running post-generate commands. When an AI coding agent runs the CLI, `generate` now uses the plain logger instead of the interactive one, and anonymous telemetry records the agent's name.

--- a/.changeset/gunshi-features.md
+++ b/.changeset/gunshi-features.md
@@ -1,5 +1,5 @@
 ---
-'@kubb/cli': minor
+'@kubb/cli': patch
 ---
 
 Adds `--dryRun` to `generate` and `init` to preview a run without writing files, installing packages, formatting, linting, or running post-generate commands. When an AI coding agent runs the CLI, `generate` now uses the plain logger instead of the interactive one, and anonymous telemetry records the agent's name.

--- a/.changeset/gunshi-features.md
+++ b/.changeset/gunshi-features.md
@@ -1,0 +1,5 @@
+---
+'@kubb/cli': minor
+---
+
+Adds `--dryRun` to `generate` and `init` to preview a run without writing files, installing packages, formatting, linting, or running post-generate commands. Anonymous telemetry now records the name of the AI coding agent that ran the command, when one is detected.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -66,6 +66,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.7.0",
+    "@gunshi/plugin-dryrun": "^0.37.1",
     "@kubb/core": "workspace:*",
     "chokidar": "^5.0.0",
     "gunshi": "^0.37.1",

--- a/packages/cli/src/Telemetry.test.ts
+++ b/packages/cli/src/Telemetry.test.ts
@@ -85,6 +85,47 @@ describe('buildTelemetryEvent', () => {
 })
 
 describe('buildOtlpPayload', () => {
+  it('should include the kubb.agent attribute when the event has an agent', () => {
+    const event: ReturnType<typeof buildTelemetryEvent> = {
+      command: 'generate',
+      kubbVersion: '4.0.0',
+      nodeVersion: '20',
+      runtime: 'node',
+      runtimeVersion: '20',
+      platform: 'linux',
+      ci: false,
+      agent: 'claude',
+      plugins: [],
+      duration: 1000,
+      filesCreated: 5,
+      status: 'success',
+    }
+
+    const payload = buildOtlpPayload(event)
+    const span = payload.resourceSpans[0]!.scopeSpans[0]!.spans[0]!
+    expect(span.attributes).toContainEqual({ key: 'kubb.agent', value: { stringValue: 'claude' } })
+  })
+
+  it('should omit the kubb.agent attribute when the event has no agent', () => {
+    const event: ReturnType<typeof buildTelemetryEvent> = {
+      command: 'generate',
+      kubbVersion: '4.0.0',
+      nodeVersion: '20',
+      runtime: 'node',
+      runtimeVersion: '20',
+      platform: 'linux',
+      ci: false,
+      plugins: [],
+      duration: 1000,
+      filesCreated: 5,
+      status: 'success',
+    }
+
+    const payload = buildOtlpPayload(event)
+    const span = payload.resourceSpans[0]!.scopeSpans[0]!.spans[0]!
+    expect(span.attributes.find((a) => a.key === 'kubb.agent')).toBeUndefined()
+  })
+
   it('should build a valid OTLP trace payload', () => {
     const event: ReturnType<typeof buildTelemetryEvent> = {
       command: 'generate',

--- a/packages/cli/src/Telemetry.ts
+++ b/packages/cli/src/Telemetry.ts
@@ -2,6 +2,7 @@ import { randomBytes } from 'node:crypto'
 import os from 'node:os'
 import process from 'node:process'
 import { isCIEnvironment, runtime } from '@internals/utils'
+import { getAgentProfile } from 'gunshi/agent'
 import { OTLP_ENDPOINT } from './constants.ts'
 
 type OtlpKeyValue = {
@@ -69,6 +70,11 @@ export type TelemetryEvent = {
   runtimeVersion: string
   platform: string
   ci: boolean
+  /**
+   * Name of the detected AI coding agent (e.g. `'claude'`, `'cursor'`), when the CLI is invoked
+   * by one. `undefined` when run by a human or an unrecognized caller.
+   */
+  agent?: string
   plugins: Array<TelemetryPlugin>
   duration: number
   filesCreated: number
@@ -100,6 +106,7 @@ export function buildTelemetryEvent(options: {
 }): TelemetryEvent {
   const [seconds, nanoseconds] = process.hrtime(options.hrStart)
   const duration = Math.round(seconds * 1000 + nanoseconds / 1e6)
+  const agentProfile = getAgentProfile()
 
   return {
     command: options.command,
@@ -109,6 +116,7 @@ export function buildTelemetryEvent(options: {
     runtimeVersion: runtime.version.split('.')[0] as string,
     platform: os.platform(),
     ci: isCIEnvironment(),
+    agent: agentProfile.isAgent ? agentProfile.name : undefined,
     plugins: options.plugins ?? [],
     duration,
     filesCreated: options.filesCreated ?? 0,
@@ -135,6 +143,7 @@ export function buildOtlpPayload(event: TelemetryEvent): OtlpExportTraceServiceR
     { key: 'kubb.runtime_version', value: { stringValue: event.runtimeVersion } },
     { key: 'kubb.platform', value: { stringValue: event.platform } },
     { key: 'kubb.ci', value: { boolValue: event.ci } },
+    ...(event.agent ? [{ key: 'kubb.agent', value: { stringValue: event.agent } }] : []),
     { key: 'kubb.files_created', value: { intValue: event.filesCreated } },
     { key: 'kubb.status', value: { stringValue: event.status } },
     {

--- a/packages/cli/src/Telemetry.ts
+++ b/packages/cli/src/Telemetry.ts
@@ -2,7 +2,7 @@ import { randomBytes } from 'node:crypto'
 import os from 'node:os'
 import process from 'node:process'
 import { isCIEnvironment, runtime } from '@internals/utils'
-import { getAgentProfile } from 'gunshi/agent'
+import { getAgentName } from './agent.ts'
 import { OTLP_ENDPOINT } from './constants.ts'
 
 type OtlpKeyValue = {
@@ -106,7 +106,6 @@ export function buildTelemetryEvent(options: {
 }): TelemetryEvent {
   const [seconds, nanoseconds] = process.hrtime(options.hrStart)
   const duration = Math.round(seconds * 1000 + nanoseconds / 1e6)
-  const agentProfile = getAgentProfile()
 
   return {
     command: options.command,
@@ -116,7 +115,7 @@ export function buildTelemetryEvent(options: {
     runtimeVersion: runtime.version.split('.')[0] as string,
     platform: os.platform(),
     ci: isCIEnvironment(),
-    agent: agentProfile.isAgent ? agentProfile.name : undefined,
+    agent: getAgentName(),
     plugins: options.plugins ?? [],
     duration,
     filesCreated: options.filesCreated ?? 0,

--- a/packages/cli/src/agent.ts
+++ b/packages/cli/src/agent.ts
@@ -1,0 +1,10 @@
+import { getAgentProfile } from 'gunshi/agent'
+
+/**
+ * Name of the AI coding agent driving this process, when one is detected (e.g. `'claude'`,
+ * `'cursor'`). `undefined` when run by a human or an unrecognized caller.
+ */
+export function getAgentName(): string | undefined {
+  const profile = getAgentProfile()
+  return profile.isAgent ? profile.name : undefined
+}

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -40,13 +40,9 @@ export const command = defineWithTypes<{
   name: 'generate',
   description:
     'Generate TypeScript types, API clients, React Query hooks, Zod schemas, and more from an OpenAPI specification. Reads kubb.config.ts by default. Pass an OpenAPI file path as the first argument to override the input without editing the config.',
-  examples: [
-    'kubb generate',
-    'kubb generate ./openapi.yaml',
-    'kubb generate --config kubb.config.ts',
-    'kubb generate --watch',
-    'kubb generate --dryRun',
-  ].join('\n'),
+  examples: ['kubb generate', 'kubb generate ./openapi.yaml', 'kubb generate --config kubb.config.ts', 'kubb generate --watch', 'kubb generate --dryRun'].join(
+    '\n',
+  ),
   args: {
     input: {
       type: 'positional',

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,4 +1,6 @@
-import { define } from 'gunshi'
+import { pluginId as dryRunId } from '@gunshi/plugin-dryrun'
+import type { DryRunExtension } from '@gunshi/plugin-dryrun'
+import { defineWithTypes } from 'gunshi'
 import type { ReporterName } from '@kubb/core'
 
 const REPORTER_NAMES: Array<ReporterName> = ['cli', 'json', 'file']
@@ -30,11 +32,21 @@ function resolveLogLevel({ verbose, silent, logLevel }: { verbose: boolean; sile
   return logLevel
 }
 
-export const command = define({
+export const command = defineWithTypes<{
+  extensions: {
+    [dryRunId]: DryRunExtension
+  }
+}>()({
   name: 'generate',
   description:
     'Generate TypeScript types, API clients, React Query hooks, Zod schemas, and more from an OpenAPI specification. Reads kubb.config.ts by default. Pass an OpenAPI file path as the first argument to override the input without editing the config.',
-  examples: ['kubb generate', 'kubb generate ./openapi.yaml', 'kubb generate --config kubb.config.ts', 'kubb generate --watch'].join('\n'),
+  examples: [
+    'kubb generate',
+    'kubb generate ./openapi.yaml',
+    'kubb generate --config kubb.config.ts',
+    'kubb generate --watch',
+    'kubb generate --dryRun',
+  ].join('\n'),
   args: {
     input: {
       type: 'positional',
@@ -77,7 +89,8 @@ export const command = define({
       parse: parseReporters,
     },
   },
-  async run({ values }) {
+  async run(ctx) {
+    const { values } = ctx
     const logLevel = resolveLogLevel(values)
     const { run } = await import('../runners/generate/run.ts')
 
@@ -87,6 +100,7 @@ export const command = define({
       logLevel,
       watch: values.watch,
       reporters: values.reporter,
+      dryRun: ctx.extensions[dryRunId].enabled,
     })
   },
 })

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -1,7 +1,7 @@
-import { pluginId as dryRunId } from '@gunshi/plugin-dryrun'
-import type { DryRunExtension } from '@gunshi/plugin-dryrun'
 import { defineWithTypes } from 'gunshi'
 import type { ReporterName } from '@kubb/core'
+import { dryRunId } from '../gunshiDryRun.ts'
+import type { DryRunExtensions } from '../gunshiDryRun.ts'
 
 const REPORTER_NAMES: Array<ReporterName> = ['cli', 'json', 'file']
 
@@ -32,11 +32,7 @@ function resolveLogLevel({ verbose, silent, logLevel }: { verbose: boolean; sile
   return logLevel
 }
 
-export const command = defineWithTypes<{
-  extensions: {
-    [dryRunId]: DryRunExtension
-  }
-}>()({
+export const command = defineWithTypes<{ extensions: DryRunExtensions }>()({
   name: 'generate',
   description:
     'Generate TypeScript types, API clients, React Query hooks, Zod schemas, and more from an OpenAPI specification. Reads kubb.config.ts by default. Pass an OpenAPI file path as the first argument to override the input without editing the config.',

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,13 +1,9 @@
-import { pluginId as dryRunId } from '@gunshi/plugin-dryrun'
-import type { DryRunExtension } from '@gunshi/plugin-dryrun'
 import { defineWithTypes } from 'gunshi'
+import { dryRunId } from '../gunshiDryRun.ts'
+import type { DryRunExtensions } from '../gunshiDryRun.ts'
 import { version } from '../../package.json'
 
-export const command = defineWithTypes<{
-  extensions: {
-    [dryRunId]: DryRunExtension
-  }
-}>()({
+export const command = defineWithTypes<{ extensions: DryRunExtensions }>()({
   name: 'init',
   description:
     'Scaffold a kubb.config.ts and install plugins for code generation from an OpenAPI spec. Run without flags for interactive setup, or pass --input, --output, and --plugins to skip the prompts.',

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,7 +1,13 @@
-import { define } from 'gunshi'
+import { pluginId as dryRunId } from '@gunshi/plugin-dryrun'
+import type { DryRunExtension } from '@gunshi/plugin-dryrun'
+import { defineWithTypes } from 'gunshi'
 import { version } from '../../package.json'
 
-export const command = define({
+export const command = defineWithTypes<{
+  extensions: {
+    [dryRunId]: DryRunExtension
+  }
+}>()({
   name: 'init',
   description:
     'Scaffold a kubb.config.ts and install plugins for code generation from an OpenAPI spec. Run without flags for interactive setup, or pass --input, --output, and --plugins to skip the prompts.',
@@ -10,6 +16,7 @@ export const command = define({
     'kubb init --yes',
     'kubb init --input ./openapi.yaml --output ./src/gen --plugins plugin-ts,plugin-zod',
     'kubb init --plugins plugin-ts,plugin-axios,plugin-react-query',
+    'kubb init --yes --dryRun',
   ].join('\n'),
   args: {
     yes: {
@@ -37,7 +44,8 @@ export const command = define({
       metavar: 'plugin-ts,plugin-zod,...',
     },
   },
-  async run({ values }) {
+  async run(ctx) {
+    const { values } = ctx
     const { run } = await import('../runners/init/run.ts')
 
     await run({
@@ -46,6 +54,7 @@ export const command = define({
       input: values.input,
       output: values.output,
       plugins: values.plugins,
+      dryRun: ctx.extensions[dryRunId],
     })
   },
 })

--- a/packages/cli/src/gunshiDryRun.ts
+++ b/packages/cli/src/gunshiDryRun.ts
@@ -1,0 +1,12 @@
+import { pluginId as dryRunId } from '@gunshi/plugin-dryrun'
+import type { DryRunExtension } from '@gunshi/plugin-dryrun'
+
+export { dryRunId }
+
+/**
+ * Extension shape gunshi's command context carries once the `@gunshi/plugin-dryrun` plugin is
+ * installed. Pass it as the `extensions` type parameter to `defineWithTypes`.
+ */
+export type DryRunExtensions = {
+  [dryRunId]: DryRunExtension
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,4 +1,5 @@
 import { styleText } from 'node:util'
+import dryrun from '@gunshi/plugin-dryrun'
 import { cli } from 'gunshi'
 import { isDisabled as isTelemetryDisabled } from './Telemetry.ts'
 import { version } from '../package.json'
@@ -45,6 +46,7 @@ export async function run(argv: Array<string> = process.argv): Promise<void> {
     },
     fallbackToEntry: true,
     strict: true,
+    plugins: [dryrun()],
     onErrorCommand: async (_ctx, error) => {
       process.exitCode = 1
       console.error(error)

--- a/packages/cli/src/loggers/reporters.test.ts
+++ b/packages/cli/src/loggers/reporters.test.ts
@@ -1,6 +1,10 @@
+import * as internalsUtils from '@internals/utils'
 import { Hookable, cliReporter, type Config, fileReporter, jsonReporter, type KubbHooks, logLevel, type Storage } from '@kubb/core'
 import { describe, expect, it, vi } from 'vitest'
 import setupReporters, { installReporter } from './utils.ts'
+
+const { getAgentProfile } = vi.hoisted(() => ({ getAgentProfile: vi.fn((): { isAgent: boolean; name?: string } => ({ isAgent: false })) }))
+vi.mock('gunshi/agent', () => ({ getAgentProfile }))
 
 describe('jsonReporter', () => {
   it('writes one JSON array for every config on lifecycle end', async () => {
@@ -101,5 +105,26 @@ describe('setupReporters', () => {
     await setupReporters(context, { logLevel: logLevel.info, reporters: [fileReporter] })
 
     expect(context.listenerCount('kubb:generation:end')).toBeGreaterThan(0)
+  })
+
+  it('installs the plain logger instead of the interactive one when an AI agent is detected', async () => {
+    using _tty = vi.spyOn(internalsUtils, 'canUseTTY').mockReturnValue(true)
+    getAgentProfile.mockReturnValue({ isAgent: true, name: 'claude' })
+    const context = new Hookable<KubbHooks>()
+
+    await setupReporters(context, { logLevel: logLevel.info, reporters: [cliReporter] })
+
+    // Only the clack logger streams hook output through `kubb:hook:line`.
+    expect(context.listenerCount('kubb:hook:line')).toBe(0)
+  })
+
+  it('installs the interactive logger when no AI agent is detected and a TTY is available', async () => {
+    using _tty = vi.spyOn(internalsUtils, 'canUseTTY').mockReturnValue(true)
+    getAgentProfile.mockReturnValue({ isAgent: false })
+    const context = new Hookable<KubbHooks>()
+
+    await setupReporters(context, { logLevel: logLevel.info, reporters: [cliReporter] })
+
+    expect(context.listenerCount('kubb:hook:line')).toBeGreaterThan(0)
   })
 })

--- a/packages/cli/src/loggers/reporters.test.ts
+++ b/packages/cli/src/loggers/reporters.test.ts
@@ -1,10 +1,8 @@
 import * as internalsUtils from '@internals/utils'
 import { Hookable, cliReporter, type Config, fileReporter, jsonReporter, type KubbHooks, logLevel, type Storage } from '@kubb/core'
 import { describe, expect, it, vi } from 'vitest'
+import * as agent from '../agent.ts'
 import setupReporters, { installReporter } from './utils.ts'
-
-const { getAgentProfile } = vi.hoisted(() => ({ getAgentProfile: vi.fn((): { isAgent: boolean; name?: string } => ({ isAgent: false })) }))
-vi.mock('gunshi/agent', () => ({ getAgentProfile }))
 
 describe('jsonReporter', () => {
   it('writes one JSON array for every config on lifecycle end', async () => {
@@ -109,7 +107,7 @@ describe('setupReporters', () => {
 
   it('installs the plain logger instead of the interactive one when an AI agent is detected', async () => {
     using _tty = vi.spyOn(internalsUtils, 'canUseTTY').mockReturnValue(true)
-    getAgentProfile.mockReturnValue({ isAgent: true, name: 'claude' })
+    using _agent = vi.spyOn(agent, 'getAgentName').mockReturnValue('claude')
     const context = new Hookable<KubbHooks>()
 
     await setupReporters(context, { logLevel: logLevel.info, reporters: [cliReporter] })
@@ -120,7 +118,7 @@ describe('setupReporters', () => {
 
   it('installs the interactive logger when no AI agent is detected and a TTY is available', async () => {
     using _tty = vi.spyOn(internalsUtils, 'canUseTTY').mockReturnValue(true)
-    getAgentProfile.mockReturnValue({ isAgent: false })
+    using _agent = vi.spyOn(agent, 'getAgentName').mockReturnValue(undefined)
     const context = new Hookable<KubbHooks>()
 
     await setupReporters(context, { logLevel: logLevel.info, reporters: [cliReporter] })

--- a/packages/cli/src/loggers/utils.ts
+++ b/packages/cli/src/loggers/utils.ts
@@ -3,6 +3,7 @@ import { styleText } from 'node:util'
 import { canUseTTY, formatMs, getElapsedMs, toCause } from '@internals/utils'
 import type { Config, Reporter, ReporterContext } from '@kubb/core'
 import { logLevel as logLevelMap } from '@kubb/core'
+import { getAgentProfile } from 'gunshi/agent'
 import type { LoggerContext, LoggerOptions } from './defineLogger.ts'
 import { clackLogger } from './clackLogger.ts'
 import { plainLogger } from './plainLogger.ts'
@@ -233,7 +234,8 @@ async function setupReporters(context: LoggerContext, { logLevel, reporters }: L
       if (hasJson) {
         continue
       }
-      const logger = canUseTTY() ? clackLogger : plainLogger
+      // Spinners and cursor-movement escapes are hard for an AI coding agent to parse, even over a pseudo-TTY.
+      const logger = canUseTTY() && !getAgentProfile().isAgent ? clackLogger : plainLogger
       await logger.install(context, { logLevel })
     }
 

--- a/packages/cli/src/loggers/utils.ts
+++ b/packages/cli/src/loggers/utils.ts
@@ -3,7 +3,7 @@ import { styleText } from 'node:util'
 import { canUseTTY, formatMs, getElapsedMs, toCause } from '@internals/utils'
 import type { Config, Reporter, ReporterContext } from '@kubb/core'
 import { logLevel as logLevelMap } from '@kubb/core'
-import { getAgentProfile } from 'gunshi/agent'
+import { getAgentName } from '../agent.ts'
 import type { LoggerContext, LoggerOptions } from './defineLogger.ts'
 import { clackLogger } from './clackLogger.ts'
 import { plainLogger } from './plainLogger.ts'
@@ -235,7 +235,7 @@ async function setupReporters(context: LoggerContext, { logLevel, reporters }: L
         continue
       }
       // Spinners and cursor-movement escapes are hard for an AI coding agent to parse, even over a pseudo-TTY.
-      const logger = canUseTTY() && !getAgentProfile().isAgent ? clackLogger : plainLogger
+      const logger = canUseTTY() && !getAgentName() ? clackLogger : plainLogger
       await logger.install(context, { logLevel })
     }
 

--- a/packages/cli/src/runners/generate/run.ts
+++ b/packages/cli/src/runners/generate/run.ts
@@ -16,6 +16,7 @@ import {
   getInputKind,
   type KubbHooks,
   logLevel as logLevelMap,
+  memoryStorage,
   type ProblemDiagnostic,
   type ReporterName,
 } from '@kubb/core'
@@ -31,6 +32,11 @@ type GenerateProps = {
   config: Config
   hooks: Hookable<KubbHooks>
   logLevel: number
+  /**
+   * When `true`, generates in memory instead of writing to disk, and skips formatting, linting,
+   * and post-generate commands.
+   */
+  dryRun?: boolean
 }
 
 type ToolMap = typeof formatters | typeof linters
@@ -116,7 +122,7 @@ async function runToolPass({ toolValue, tool, outputPath, logLevel, hooks, onSta
 }
 
 async function generate(options: GenerateProps): Promise<boolean> {
-  const { input, hooks, logLevel } = options
+  const { input, hooks, logLevel, dryRun = false } = options
 
   const hrStart = process.hrtime()
   const inputPath = input ?? (typeof options.config.input === 'string' ? options.config.input : undefined)
@@ -124,6 +130,8 @@ async function generate(options: GenerateProps): Promise<boolean> {
   const config: Config = {
     ...options.config,
     input: input ?? options.config.input,
+    // Dry-run never touches disk, regardless of the config's own storage driver.
+    storage: dryRun ? memoryStorage() : options.config.storage,
   }
 
   // The formatter, linter, and post-generate commands run after a successful build. Collect their
@@ -168,7 +176,7 @@ async function generate(options: GenerateProps): Promise<boolean> {
     ]
 
     for (const pass of toolPasses) {
-      if (!pass.value) continue
+      if (!pass.value || dryRun) continue
       const error = await runToolPass({
         toolValue: pass.value,
         tool: pass.tool,
@@ -181,7 +189,7 @@ async function generate(options: GenerateProps): Promise<boolean> {
       if (error) await reportOutputFailure(pass.code, pass.tool.label, error)
     }
 
-    if (resolvedConfig.output.postGenerate?.length) {
+    if (resolvedConfig.output.postGenerate?.length && !dryRun) {
       await hooks.callHook('kubb:hooks:start')
       const hookResults = await runPostGenerate({ commands: resolvedConfig.output.postGenerate, hooks })
       for (const hookResult of hookResults) {
@@ -200,6 +208,10 @@ async function generate(options: GenerateProps): Promise<boolean> {
 
   const kubb = createKubb(config, { hooks })
   const result = await kubb.generate({ processOutput })
+
+  if (dryRun) {
+    await hooks.callHook('kubb:info', { message: 'Dry run: no files were written', info: `${result.files.length} file(s) would be generated` })
+  }
 
   const telemetryPlugins = Array.from(kubb.driver.plugins.values(), (p) => ({ name: p.name, options: p.options as Record<string, unknown> }))
   await sendTelemetry(
@@ -237,6 +249,7 @@ type GenerateCommandOptions = {
   logLevel: string
   watch: boolean
   reporters?: Array<ReporterName>
+  dryRun?: boolean
 }
 
 async function checkForUpdate(hooks: Hookable<KubbHooks>): Promise<void> {
@@ -256,7 +269,7 @@ async function checkForUpdate(hooks: Hookable<KubbHooks>): Promise<void> {
  * Loads configs, sets up the reporters (CLI `--reporter` picks which of `config.reporters` to trigger),
  * checks for a newer version, and calls `generate` for each config entry.
  */
-export async function run({ input, configPath, logLevel: logLevelKey, watch, reporters: cliReporters }: GenerateCommandOptions): Promise<void> {
+export async function run({ input, configPath, logLevel: logLevelKey, watch, reporters: cliReporters, dryRun }: GenerateCommandOptions): Promise<void> {
   const logLevel = logLevelMap[logLevelKey as keyof typeof logLevelMap] ?? logLevelMap.info
   const hooks = new Hookable<KubbHooks>()
 
@@ -306,7 +319,7 @@ export async function run({ input, configPath, logLevel: logLevelKey, watch, rep
         // listeners. Plugin listeners are already disposed by safeBuild's dispose()
         // in its finally block, so re-running generate() on the same hooks emitter is safe.
         const build = async (paths: Array<string>) => {
-          await generate({ input, config, logLevel, hooks })
+          await generate({ input, config, logLevel, hooks, dryRun })
           clack.log.step(styleText('yellow', `Watching for changes in ${paths.join(' and ')}`))
         }
 
@@ -321,7 +334,7 @@ export async function run({ input, configPath, logLevel: logLevelKey, watch, rep
         await startWatcher(watchedPaths, build, { info: (msg) => clack.log.info(msg), error: (msg) => clack.log.error(msg) })
       } else {
         try {
-          const succeeded = await generate({ input, config, logLevel, hooks })
+          const succeeded = await generate({ input, config, logLevel, hooks, dryRun })
           if (!succeeded) anyFailed = true
         } catch (configError) {
           await hooks.callHook('kubb:error', { error: toError(configError) })

--- a/packages/cli/src/runners/generate/run.ts
+++ b/packages/cli/src/runners/generate/run.ts
@@ -137,6 +137,8 @@ async function generate(options: GenerateProps): Promise<boolean> {
   // The formatter, linter, and post-generate commands run after a successful build. Collect their
   // failures as coded diagnostics so they reach the summary, the json report, and the exit code.
   const processOutput = async ({ config: resolvedConfig, outputPath }: { config: Config; outputPath: string }): Promise<Array<Diagnostic>> => {
+    if (dryRun) return []
+
     const outputDiagnostics: Array<Diagnostic> = []
     const reportOutputFailure = async (code: ProblemDiagnostic['code'], label: string, error: Error) => {
       const diagnostic = outputDiagnostic(code, label, error)
@@ -176,7 +178,7 @@ async function generate(options: GenerateProps): Promise<boolean> {
     ]
 
     for (const pass of toolPasses) {
-      if (!pass.value || dryRun) continue
+      if (!pass.value) continue
       const error = await runToolPass({
         toolValue: pass.value,
         tool: pass.tool,
@@ -189,7 +191,7 @@ async function generate(options: GenerateProps): Promise<boolean> {
       if (error) await reportOutputFailure(pass.code, pass.tool.label, error)
     }
 
-    if (resolvedConfig.output.postGenerate?.length && !dryRun) {
+    if (resolvedConfig.output.postGenerate?.length) {
       await hooks.callHook('kubb:hooks:start')
       const hookResults = await runPostGenerate({ commands: resolvedConfig.output.postGenerate, hooks })
       for (const hookResult of hookResults) {

--- a/packages/cli/src/runners/init/run.ts
+++ b/packages/cli/src/runners/init/run.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import process from 'node:process'
 import { styleText } from 'node:util'
 import * as clack from '@clack/prompts'
+import type { DryRunExtension } from '@gunshi/plugin-dryrun'
 import {
   availablePlugins,
   generateConfigFile,
@@ -42,6 +43,11 @@ type InitOptions = {
    * Comma-separated plugin list from `--plugins`, e.g. `'plugin-ts,plugin-zod'`. When provided, skips the plugin selection prompt.
    */
   plugins?: string
+  /**
+   * Dry-run extension from `@gunshi/plugin-dryrun`. When enabled, package installation and the
+   * config file write are skipped.
+   */
+  dryRun: DryRunExtension
 }
 
 /**
@@ -49,7 +55,7 @@ type InitOptions = {
  * Detects the package manager, prompts for input/output paths and plugins, installs packages, and writes `kubb.config.ts`.
  * Pass `yes: true` to skip all prompts and use defaults.
  */
-export async function run({ yes, version, input: inputFlag, output: outputFlag, plugins: pluginsFlag }: InitOptions): Promise<void> {
+export async function run({ yes, version, input: inputFlag, output: outputFlag, plugins: pluginsFlag, dryRun }: InitOptions): Promise<void> {
   const cwd = process.cwd()
 
   clack.intro(styleText('bgCyan', styleText('black', ' Kubb Init ')))
@@ -157,7 +163,9 @@ export async function run({ yes, version, input: inputFlag, output: outputFlag, 
     spinner.start(`Installing ${packagesToInstall.length} packages with ${packageManager.name}`)
 
     try {
-      await installPackages(packagesToInstall, packageManager, cwd)
+      await dryRun.run(() => installPackages(packagesToInstall, packageManager, cwd), {
+        message: `install ${packagesToInstall.length} packages with ${packageManager.name}`,
+      })
       spinner.stop(`Installed ${packagesToInstall.length} packages`)
     } catch (error) {
       spinner.stop('Installation failed')
@@ -188,7 +196,7 @@ export async function run({ yes, version, input: inputFlag, output: outputFlag, 
       configSpinner.start(`Overwriting ${KUBB_CONFIG_FILENAME}`)
     }
 
-    await fs.promises.writeFile(configPath, configContent, 'utf-8')
+    await dryRun.run(() => fs.promises.writeFile(configPath, configContent, 'utf-8'), { message: `write ${KUBB_CONFIG_FILENAME}` })
 
     configSpinner.stop(`Created ${KUBB_CONFIG_FILENAME}`)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       '@clack/prompts':
         specifier: ^1.7.0
         version: 1.7.0
+      '@gunshi/plugin-dryrun':
+        specifier: ^0.37.1
+        version: 0.37.1
       '@kubb/core':
         specifier: workspace:*
         version: link:../core
@@ -800,6 +803,14 @@ packages:
 
   '@farmfe/utils@0.1.0':
     resolution: {integrity: sha512-neNJQGqV7XL4XifG1uHOBFSFLy2yx1/DVZNRA7nfeEAXEksVZTwWA+fZrYEaI0w7Sw6K/9NYn9Jgpn+NAT0mcg==}
+
+  '@gunshi/plugin-dryrun@0.37.1':
+    resolution: {integrity: sha512-9Up4UJdO2/zP8pjvDv4JHgJaT1lLCxqE6rUdOeurfSlKZzrbhEyTdX+s4G5akAAFhO41E4q51PfsFf3a0WV9YA==}
+    engines: {node: '>= 22'}
+
+  '@gunshi/plugin@0.37.1':
+    resolution: {integrity: sha512-ljjBaL15jCwX6tEtWRdmAQ/y/svGcMZa5mVhMPgXFeQFQ++srK/x5dx8uchQFrE2MTqaFhMMjNK9AQowCyRv9A==}
+    engines: {node: '>= 22'}
 
   '@henrygd/queue@1.2.0':
     resolution: {integrity: sha512-jW/BLSTpcvExDhqJGxtIPgGr2O0IFF8XUNDwEbfCfhrXT8a4xztQ9Lv6U/vbYzYC0xVWn+3zv6YnLUh3bEFUKA==}
@@ -4332,6 +4343,12 @@ snapshots:
   '@farmfe/utils@0.0.1': {}
 
   '@farmfe/utils@0.1.0': {}
+
+  '@gunshi/plugin-dryrun@0.37.1':
+    dependencies:
+      '@gunshi/plugin': 0.37.1
+
+  '@gunshi/plugin@0.37.1': {}
 
   '@henrygd/queue@1.2.0': {}
 


### PR DESCRIPTION
## 🎯 Changes

Adds `--dryRun` to `generate` and `init` via `@gunshi/plugin-dryrun`. It previews a run without writing files, installing packages, formatting, linting, or running post-generate commands:
- `generate` swaps in `memoryStorage()` for the run, so nothing lands on disk, and skips the format/lint/post-generate passes.
- `init` wraps the package install and the `kubb.config.ts` write with the plugin's `run()` helper.

Telemetry now records the name of the AI coding agent that ran the command (via `gunshi/agent`'s `getAgentProfile()`), when one is detected, alongside the existing `ci` flag. This applies to all three commands that send telemetry (`generate`, `validate`, `mcp`) since it lives in the shared `buildTelemetryEvent()`.

I also evaluated `@gunshi/plugin-suggestion` for "did you mean" typo suggestions, since it was part of the same feature request. A reproduction confirmed its `isArgsValidationError`/`isCommandNotFoundError` checks never match errors thrown by `gunshi`'s own `cli()` in this version, because `gunshi` and `@gunshi/plugin` each bundle their own private copy of those error classes (a dual-package hazard), so `instanceof` fails across the package boundary and the plugin silently produces no suggestions. I left it unwired rather than shipping a plugin that looks functional but does nothing. Worth revisiting once upstream fixes this.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

## Test plan

- `pnpm --filter @kubb/cli typecheck`, `lint`, and `test` all pass (63 tests, including new `kubb.agent` telemetry coverage).
- Manually verified `kubb init --yes --dryRun` end to end: skips the real package install and `kubb.config.ts` write, prints `[dryrun] install ... ` / `[dryrun] write kubb.config.ts`, and leaves no file on disk.
- Manually verified `kubb generate --dryRun` end to end against a real config: pipeline runs, prints a "Dry run: no files were written" summary, and creates no output directory.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xjq8GsEgksyFANnVwokumD)_