### PR TITLE
fix(studio): space out kubb studio log output

### DIFF
--- a/.changeset/quiet-lions-relax.md
+++ b/.changeset/quiet-lions-relax.md
@@ -1,0 +1,7 @@
+---
+'@kubb/studio': patch
+'@kubb/cli': patch
+---
+
+Space out `kubb studio` log output with blank lines between setup, connection, and each
+command round trip, so the terminal reads as separate blocks instead of one dense run.

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -277,6 +277,7 @@ async function connect(options: StudioOptions, retryPairing = true): Promise<voi
   }
 
   if (options.logLevel !== 'silent') {
+    console.log()
     console.log(styleText('dim', 'Connected. Press Ctrl+C to disconnect.'))
   }
 
@@ -344,6 +345,7 @@ async function run(options: StudioOptions): Promise<void> {
   try {
     if (options.logLevel !== 'silent') {
       console.warn(styleText('yellow', 'This feature is still under development, use with caution'))
+      console.log()
     }
 
     if (!ACTIONS.includes(options.action)) {

--- a/packages/studio/src/connectStudio.ts
+++ b/packages/studio/src/connectStudio.ts
@@ -247,6 +247,7 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
 
     const onOpen = () => {
       lastPongAt = Date.now()
+      console.log()
       console.log(styleText('green', `[${tag}] Connected to Kubb Studio`))
 
       // Announce readiness without waiting for a `connect` command. The command from the
@@ -342,6 +343,7 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
         }
 
         if (isCommandMessage(data)) {
+          console.log()
           console.info(styleText('dim', `[${tag}] Received ${data.command} from Studio`))
 
           if (data.command === 'generate') {


### PR DESCRIPTION
## 🎯 Changes

`kubb studio` logged the warning banner, the permission summary, the connection banner, and every command round trip as one dense block with no blank lines. This adds `console.log()` calls to group them:

- A blank line after the "still under development" warning, before the permission summary
- A blank line before "Connected. Press Ctrl+C to disconnect."
- A blank line before each `[tag] Connected to Kubb Studio` and before each `[tag] Received <command> from Studio`

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MjGx3ZbqGUUroQzhR7rJgd

---
_Generated by [Claude Code](https://claude.ai/code/session_01MjGx3ZbqGUUroQzhR7rJgd)_