### PR TITLE
feat(adapter-oas): let dateType set date-time, date, and time independently

### DIFF
--- a/.changeset/wide-days-heal.md
+++ b/.changeset/wide-days-heal.md
@@ -1,0 +1,19 @@
+---
+'@kubb/adapter-oas': minor
+---
+
+Let `dateType` set `date-time`, `date`, and `time` independently, instead of one value driving all three
+
+Pass an object to represent timestamps as a JS `Date` while keeping date-only and time-only fields as strings, since `Date` cannot round-trip those without inventing a timezone.
+
+```ts
+adapterOas({
+  dateType: {
+    dateTime: 'date',
+    date: 'string',
+    time: 'string',
+  },
+})
+```
+
+The scalar form (`dateType: 'date'`) still applies one value to all three formats.

--- a/packages/adapter-oas/src/emit/parseSchema.ts
+++ b/packages/adapter-oas/src/emit/parseSchema.ts
@@ -5,7 +5,7 @@ import type { Document, SchemaObject } from '../types.ts'
 import { convertAllOf, convertMultiType, convertRef, convertUnion } from './converters/composition.ts'
 import { convertBinary, convertBoolean, convertConst, convertEnum, convertFormat, convertNumeric, convertString, createNullNode } from './converters/scalar.ts'
 import { convertArray, convertObject, convertTuple } from './converters/structural.ts'
-import { isHandledFormat } from './schemaShape.ts'
+import { isHandledFormat, resolveDateTypeValue } from './schemaShape.ts'
 
 /**
  * Pre-computed per-schema context passed to every schema converter.
@@ -89,7 +89,8 @@ export const schemaRules: Array<SchemaRule> = [
   {
     match: ({ schema, options }) => {
       if (!schema.format) return false
-      if (schema.format === 'date-time' || schema.format === 'date' || schema.format === 'time') return options.dateType !== false
+      if (schema.format === 'date-time' || schema.format === 'date' || schema.format === 'time')
+        return resolveDateTypeValue(options.dateType, schema.format) !== false
       return isHandledFormat(schema.format)
     },
     convert: convertFormat,

--- a/packages/adapter-oas/src/emit/schemaShape.test.ts
+++ b/packages/adapter-oas/src/emit/schemaShape.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { DEFAULT_PARSER_OPTIONS } from '../constants.ts'
-import { flattenSchema, getDateType, getPrimitiveType, getSchemaType } from './schemaShape.ts'
+import { flattenSchema, getDateType, getPrimitiveType, getSchemaType, resolveDateTypeValue } from './schemaShape.ts'
 
 describe('getSchemaType', () => {
   it('returns the SchemaType for a known format', () => {
@@ -83,6 +83,42 @@ describe('getDateType', () => {
       type: 'time',
       representation: 'date',
     })
+  })
+
+  it('resolves date-time and date independently through the object form', () => {
+    expect(getDateType({ ...base, dateType: { dateTime: 'date' } }, 'date-time')).toStrictEqual({
+      type: 'date',
+      representation: 'date',
+    })
+    expect(getDateType({ ...base, dateType: { dateTime: 'date' } }, 'date')).toStrictEqual({
+      type: 'date',
+      representation: 'string',
+    })
+    expect(getDateType({ ...base, dateType: { dateTime: 'date' } }, 'time')).toStrictEqual({
+      type: 'time',
+      representation: 'string',
+    })
+  })
+
+  it('returns null for a format the object form sets to false', () => {
+    expect(getDateType({ ...base, dateType: { date: false } }, 'date')).toBeNull()
+    expect(getDateType({ ...base, dateType: { date: false } }, 'date-time')).toStrictEqual({ type: 'datetime', offset: false })
+  })
+})
+
+describe('resolveDateTypeValue', () => {
+  it('applies a scalar dateType to every format', () => {
+    expect(resolveDateTypeValue('date', 'date-time')).toBe('date')
+    expect(resolveDateTypeValue('date', 'date')).toBe('date')
+    expect(resolveDateTypeValue('date', 'time')).toBe('date')
+    expect(resolveDateTypeValue(false, 'date-time')).toBe(false)
+  })
+
+  it('reads the matching key from the object form, defaulting an omitted key to string', () => {
+    expect(resolveDateTypeValue({ dateTime: 'date' }, 'date-time')).toBe('date')
+    expect(resolveDateTypeValue({ dateTime: 'date' }, 'date')).toBe('string')
+    expect(resolveDateTypeValue({ date: false, time: 'date' }, 'date')).toBe(false)
+    expect(resolveDateTypeValue({ date: false, time: 'date' }, 'time')).toBe('date')
   })
 })
 

--- a/packages/adapter-oas/src/emit/schemaShape.ts
+++ b/packages/adapter-oas/src/emit/schemaShape.ts
@@ -33,25 +33,44 @@ export function getPrimitiveType(type: string | undefined): ast.PrimitiveSchemaT
 }
 
 /**
+ * Resolves the `dateType` option down to the value for one format. The scalar form of
+ * `dateType` applies to every format; the object form picks `dateTime`/`date`/`time`
+ * individually and defaults an omitted key to `'string'`.
+ */
+export function resolveDateTypeValue(
+  dateType: ast.ParserOptions['dateType'],
+  format: 'date-time' | 'date' | 'time',
+): ast.DateTimeTypeValue | ast.DateOnlyTypeValue {
+  if (typeof dateType !== 'object' || dateType === null) {
+    return dateType
+  }
+
+  const key = format === 'date-time' ? 'dateTime' : format
+  return dateType[key] ?? 'string'
+}
+
+/**
  * Resolves the AST type descriptor for a date/time format, honoring the `dateType` option.
- * Returns `null` when `dateType: false`, so the format falls through to `string`.
+ * Returns `null` when the resolved value is `false`, so the format falls through to `string`.
  */
 export function getDateType(
   options: ast.ParserOptions,
   format: 'date-time' | 'date' | 'time',
 ): { type: 'datetime'; offset?: boolean; local?: boolean } | { type: 'date' | 'time'; representation: 'date' | 'string' } | null {
-  if (!options.dateType) {
+  const value = resolveDateTypeValue(options.dateType, format)
+
+  if (!value) {
     return null
   }
 
   if (format === 'date-time') {
-    if (options.dateType === 'date') {
+    if (value === 'date') {
       return { type: 'date', representation: 'date' }
     }
-    if (options.dateType === 'stringOffset') {
+    if (value === 'stringOffset') {
       return { type: 'datetime', offset: true }
     }
-    if (options.dateType === 'stringLocal') {
+    if (value === 'stringLocal') {
       return { type: 'datetime', local: true }
     }
     return { type: 'datetime', offset: false }
@@ -60,14 +79,14 @@ export function getDateType(
   if (format === 'date') {
     return {
       type: 'date',
-      representation: options.dateType === 'date' ? 'date' : 'string',
+      representation: value === 'date' ? 'date' : 'string',
     }
   }
 
   // time
   return {
     type: 'time',
-    representation: options.dateType === 'date' ? 'date' : 'string',
+    representation: value === 'date' ? 'date' : 'string',
   }
 }
 

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -3791,6 +3791,29 @@ describe('parser options', () => {
         expect(node.type).toBe('string')
       })
     })
+
+    describe('object form', () => {
+      it('represents date-time as Date while date and time stay strings', () => {
+        const ctx = { document: emptyDocument, refs: createRefs(emptyDocument) }
+        const dateTimeNode = parseSchema(ctx, { schema: { type: 'string', format: 'date-time' } }, { dateType: { dateTime: 'date' } })
+        const dateNode = parseSchema(ctx, { schema: { type: 'string', format: 'date' } }, { dateType: { dateTime: 'date' } })
+        const timeNode = parseSchema(ctx, { schema: { type: 'string', format: 'time' } }, { dateType: { dateTime: 'date' } })
+
+        expect(dateTimeNode.type).toBe('date')
+        expect(ast.narrowSchema(dateTimeNode, 'date')?.representation).toBe('date')
+        expect(dateNode.type).toBe('date')
+        expect(ast.narrowSchema(dateNode, 'date')?.representation).toBe('string')
+        expect(timeNode.type).toBe('time')
+        expect(ast.narrowSchema(timeNode, 'time')?.representation).toBe('string')
+      })
+
+      it('falls through to string when a format is set to false in the object form', () => {
+        const ctx = { document: emptyDocument, refs: createRefs(emptyDocument) }
+        const node = parseSchema(ctx, { schema: { type: 'string', format: 'date' } }, { dateType: { date: false, dateTime: 'date' } })
+
+        expect(node.type).toBe('string')
+      })
+    })
   })
 })
 

--- a/packages/ast/src/infer.ts
+++ b/packages/ast/src/infer.ts
@@ -16,18 +16,50 @@ import type {
 } from './nodes/index.ts'
 
 /**
+ * How `format: 'date-time'` schemas are represented downstream.
+ * - `false` falls through to a plain `string` (no validation).
+ * - `'string'` emits a datetime string node.
+ * - `'stringOffset'` emits a datetime node with timezone offset.
+ * - `'stringLocal'` emits a local datetime node.
+ * - `'date'` emits a `date` node (JavaScript `Date` object).
+ */
+export type DateTimeTypeValue = false | 'string' | 'stringOffset' | 'stringLocal' | 'date'
+
+/**
+ * How `format: 'date'` or `format: 'time'` schemas are represented downstream.
+ * - `false` falls through to a plain `string` (no validation).
+ * - `'string'` (default) emits a date or time string node.
+ * - `'date'` emits a `date`/`time` node (JavaScript `Date` object).
+ */
+export type DateOnlyTypeValue = false | 'string' | 'date'
+
+/**
+ * Per-format override of `dateType`, so `date-time`, `date`, and `time` schemas can each
+ * resolve to a different representation. A key left out defaults to `'string'`, the same
+ * default as the scalar form of `dateType`.
+ */
+export type DateTypeOptions = {
+  dateTime?: DateTimeTypeValue
+  date?: DateOnlyTypeValue
+  time?: DateOnlyTypeValue
+}
+
+/**
  * Options that control how the adapter parser maps source schemas to AST nodes.
  */
 export type ParserOptions = {
   /**
-   * How `format: 'date-time'` schemas are represented downstream.
-   * - `false` falls through to a plain `string` (no validation).
-   * - `'string'` emits a datetime string node.
-   * - `'stringOffset'` emits a datetime node with timezone offset.
-   * - `'stringLocal'` emits a local datetime node.
-   * - `'date'` emits a `date` node (JavaScript `Date` object).
+   * How `date-time`, `date`, and `time` formatted schemas are represented downstream.
+   * A scalar value ({@link DateTimeTypeValue}) applies to all three formats, matching
+   * the pre-5.1 behavior. Pass a {@link DateTypeOptions} object to set `dateTime`,
+   * `date`, and `time` independently.
+   *
+   * @example Represent `date-time` as a JS `Date`, keep `date` and `time` as strings
+   * ```ts
+   * dateType: { dateTime: 'date' }
+   * ```
    */
-  dateType: false | 'string' | 'stringOffset' | 'stringLocal' | 'date'
+  dateType: DateTimeTypeValue | DateTypeOptions
   /**
    * How `type: 'integer'` (and `format: 'int64'`) maps to TypeScript.
    * - `'bigint'` is exact for 64-bit IDs, but does not round-trip through JSON.

--- a/packages/ast/src/types.ts
+++ b/packages/ast/src/types.ts
@@ -1,5 +1,5 @@
 export type { DistributiveOmit, NodeDef } from './defineNode.ts'
-export type { InferSchemaNode, ParserOptions } from './infer.ts'
+export type { DateOnlyTypeValue, DateTimeTypeValue, DateTypeOptions, InferSchemaNode, ParserOptions } from './infer.ts'
 export type * from './nodes/index.ts'
 export type { ParentOf, Visitor, VisitorContext } from './visitor.ts'
 export type { Printer, PrinterFactoryOptions, PrinterPartial } from './createPrinter.ts'


### PR DESCRIPTION
## 🎯 Changes

Fixes #3956.

`dateType` used to be one value applied to `date-time`, `date`, and `time` alike. Setting `dateType: 'date'` to get a JS `Date` for timestamps also turned date-only and time-only fields into `Date`, which cannot represent them without inventing a timezone.

`dateType` now also accepts an object, so each format resolves independently. A key left out defaults to `'string'`:

```ts
adapterOas({
  dateType: {
    dateTime: 'date', // Date object for timestamps
    date: 'string', // plain string for date-only values
    time: 'string',
  },
})
```

The scalar form (`dateType: 'date'`) is unchanged and still applies to all three formats.

Changes:
- `packages/ast/src/infer.ts`: adds `DateTimeTypeValue`, `DateOnlyTypeValue`, and `DateTypeOptions`; widens `ParserOptions['dateType']` to accept either form.
- `packages/adapter-oas/src/emit/schemaShape.ts`: adds `resolveDateTypeValue` to resolve `dateType` down to the value for one format; `getDateType` now reads through it.
- `packages/adapter-oas/src/emit/parseSchema.ts`: the format match rule resolves per-format instead of checking `dateType !== false` globally.
- Tests added in `schemaShape.test.ts` and `parser.test.ts` for the object form.

No changes needed downstream: `plugin-ts`, `plugin-zod`, and `plugin-faker` already print off each node's own `representation`/`format`/`offset`/`local` fields rather than re-reading the `dateType` option, so they pick up the fix once this publishes.

Docs for `kubb-labs/docs` are in a companion PR.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUT9E7msBeSjET4FDrL7NW

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUT9E7msBeSjET4FDrL7NW)_