### PR TITLE
refactor(studio): resolve PR feedback on the Studio CLI connect

### DIFF
--- a/.changeset/olive-parrots-shake.md
+++ b/.changeset/olive-parrots-shake.md
@@ -1,0 +1,10 @@
+---
+'@kubb/studio': minor
+---
+
+Every agent ↔ Studio WebSocket message is now named with the `kubb:` prefix the generation hooks
+already use: `kubb:command`, `kubb:connected`, `kubb:data`, `kubb:config-saved`, `kubb:ping`,
+`kubb:pong`, and `kubb:disconnect`. One namespace now covers the whole wire.
+
+This is a breaking protocol change. An agent and a Studio instance have to be on matching versions,
+so update both sides together.

--- a/.changeset/silver-jars-melt.md
+++ b/.changeset/silver-jars-melt.md
@@ -1,0 +1,10 @@
+---
+'@kubb/studio': patch
+---
+
+Studio's HTTP calls now go through `ofetch`. It handles JSON encoding and parsing, throws on a
+non-2xx status, and retries agent registration on its own, which replaces the package's own
+`HttpError` class and its hand-written retry loop.
+
+Registration now retries only what is worth retrying: a network failure or a 5xx, and no longer a
+403, which cannot succeed on a second try with the same machine token.

--- a/packages/cli/src/runners/studio/credentials.ts
+++ b/packages/cli/src/runners/studio/credentials.ts
@@ -12,7 +12,14 @@ export function getKubbHome(): string {
   return process.env.KUBB_HOME ?? path.join(homedir(), '.kubb')
 }
 
-const credentialsPath = () => path.join(getKubbHome(), 'credentials.json')
+const CREDENTIALS_FILENAME = 'credentials.json'
+
+/**
+ * Absolute path of the stored credential, so callers can name it in output without rebuilding it.
+ */
+export function getCredentialsPath(): string {
+  return path.join(getKubbHome(), CREDENTIALS_FILENAME)
+}
 
 export type Credentials = {
   /**
@@ -38,7 +45,7 @@ export type Credentials = {
  * overwrite it rather than the CLI dying on it.
  */
 export async function readCredentials(): Promise<Credentials | null> {
-  const raw = await read(credentialsPath()).catch(() => null)
+  const raw = await read(getCredentialsPath()).catch(() => null)
   if (!raw) {
     return null
   }
@@ -55,7 +62,7 @@ export async function readCredentials(): Promise<Credentials | null> {
  * is set explicitly rather than left to the process umask.
  */
 export async function writeCredentials(credentials: Credentials): Promise<void> {
-  const file = credentialsPath()
+  const file = getCredentialsPath()
 
   await mkdir(path.dirname(file), { recursive: true, mode: 0o700 })
   await write(file, JSON.stringify(credentials, null, 2))
@@ -68,5 +75,5 @@ export async function writeCredentials(credentials: Credentials): Promise<void> 
  * Forgets the stored credential. Succeeds when there was nothing to forget.
  */
 export async function clearCredentials(): Promise<void> {
-  await clean(credentialsPath())
+  await clean(getCredentialsPath())
 }

--- a/packages/cli/src/runners/studio/run.test.ts
+++ b/packages/cli/src/runners/studio/run.test.ts
@@ -53,14 +53,12 @@ describe('resolvePermissions', () => {
 
     // The project path is machine-specific, so it is stood in for rather than snapshotted.
     const questions = confirm.mock.calls.map(([call]) => call?.message?.replace(process.cwd(), '<project>'))
-    expect(questions).toMatchInlineSnapshot(`
-      [
-        "Let Kubb Studio write generated files into <project>?",
-        "Let Kubb Studio change plugin options in kubb.config.ts?",
-        "Let Kubb Studio generate from an OpenAPI spec it sends, instead of the one on disk?",
-        "Let Kubb Studio run the formatter, the linter, and output.postGenerate?",
-      ]
-    `)
+    expect(questions).toStrictEqual([
+      'Let Kubb Studio write generated files into <project>?',
+      'Let Kubb Studio change plugin options in kubb.config.ts?',
+      'Let Kubb Studio generate from an OpenAPI spec it sends, instead of the one on disk?',
+      'Let Kubb Studio run the formatter, the linter, and output.postGenerate?',
+    ])
   })
 
   it('names the config the project actually has, not the default', async () => {
@@ -68,8 +66,8 @@ describe('resolvePermissions', () => {
 
     await resolvePermissions(options, credentials, 'configs/kubb.config.mjs')
 
-    expect(confirm.mock.calls.map(([call]) => call?.message).find((message) => message?.includes('plugin options'))).toMatchInlineSnapshot(
-      `"Let Kubb Studio change plugin options in configs/kubb.config.mjs?"`,
+    expect(confirm.mock.calls.map(([call]) => call?.message).find((message) => message?.includes('plugin options'))).toBe(
+      'Let Kubb Studio change plugin options in configs/kubb.config.mjs?',
     )
   })
 
@@ -107,8 +105,8 @@ describe('resolvePermissions', () => {
 
 describe('formatPermissionSummary', () => {
   it('lists every permission', () => {
-    expect(formatPermissionSummary({ allowWrite: true, allowConfigEdit: false, allowInput: true, allowExec: false })).toMatchInlineSnapshot(
-      `"write generated files: yes, edit kubb.config.ts: no, use a Studio spec: yes, run formatter, linter, postGenerate: no"`,
+    expect(formatPermissionSummary({ allowWrite: true, allowConfigEdit: false, allowInput: true, allowExec: false })).toBe(
+      'write generated files: yes, edit kubb.config.ts: no, use a Studio spec: yes, run formatter, linter, postGenerate: no',
     )
   })
 })

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -14,7 +14,7 @@ import { version } from '../../../package.json'
 import type { definition } from '../../commands/studio.ts'
 import { canUseTTY, isCIEnvironment } from '../../utils/env.ts'
 import { getConfigs } from '../generate/utils.ts'
-import { clearCredentials, type Credentials, getKubbHome, readCredentials, writeCredentials } from './credentials.ts'
+import { clearCredentials, type Credentials, getCredentialsPath, getKubbHome, readCredentials, writeCredentials } from './credentials.ts'
 
 const ACTIONS = ['connect', 'login', 'logout', 'status'] as const
 
@@ -89,7 +89,7 @@ async function login({ studioUrl, autoOpen }: StudioOptions): Promise<Credential
     const credentials: Credentials = { studioUrl, token, agentId: agent.id, agentSlug: agent.slug }
     await writeCredentials(credentials)
 
-    console.log(`Credentials stored in ${path.join(getKubbHome(), 'credentials.json')}`)
+    console.log(`Credentials stored in ${getCredentialsPath()}`)
 
     return credentials
   } catch (error) {

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -67,6 +67,7 @@
   "dependencies": {
     "@kubb/core": "workspace:*",
     "magicast": "^0.5.3",
+    "ofetch": "^1.5.1",
     "remeda": "^2.42.0",
     "tinyexec": "catalog:",
     "unstorage": "^1.17.5",

--- a/packages/studio/src/api.test.ts
+++ b/packages/studio/src/api.test.ts
@@ -1,12 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { spyOnConsole } from './console.mock.ts'
-import { createAgentSession, disconnect, HttpError, InvalidAgentTokenError, registerAgent } from './api.ts'
+import { createAgentSession, disconnect, InvalidAgentTokenError, registerAgent } from './api.ts'
 
 const consoleSpy = spyOnConsole()
-
-vi.mock('node:timers/promises', () => ({
-  setTimeout: vi.fn(async () => {}),
-}))
 
 // Partial: `api.ts` only wants the machine token stubbed, and a full factory would also replace
 // the storage accessors that the rest of the package shares.
@@ -15,11 +11,7 @@ vi.mock('./machine.ts', async (importOriginal) => ({
   getMachineToken: vi.fn(async () => 'machine-token-hash'),
 }))
 
-const createMockResponse = (data: unknown, ok = true, status = 200) => ({
-  ok,
-  status,
-  json: vi.fn(async () => data),
-})
+const createMockResponse = (data: unknown, status = 200) => new Response(JSON.stringify(data), { status, headers: { 'Content-Type': 'application/json' } })
 
 const fetchMock = vi.fn()
 
@@ -30,10 +22,6 @@ const session = {
   expiresAt: new Date().toISOString(),
   revokedAt: null,
   isSandbox: false,
-}
-
-function unauthorizedError(): Error {
-  return new HttpError('invalid_agent_token', 401)
 }
 
 beforeEach(() => {
@@ -48,7 +36,7 @@ afterEach(() => {
 
 describe('registerAgent', () => {
   it('throws instead of retrying when Studio rejects the token, so a deleted agent stops the loop', async () => {
-    fetchMock.mockRejectedValue(unauthorizedError())
+    fetchMock.mockResolvedValue(createMockResponse({ message: 'invalid_agent_token' }, 401))
 
     await expect(registerAgent({ token: 'agent-token', studioUrl: 'http://localhost:3000' })).rejects.toBeInstanceOf(InvalidAgentTokenError)
     expect(fetchMock).toHaveBeenCalledTimes(1)
@@ -62,13 +50,11 @@ describe('registerAgent', () => {
 
     await expect(promise).resolves.toBe(true)
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    expect(fetchMock).toHaveBeenCalledWith(
-      'http://studio/api/agent/connect',
-      expect.objectContaining({
-        method: 'POST',
-        headers: expect.objectContaining({ Authorization: 'Bearer tok' }),
-      }),
-    )
+
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe('http://studio/api/agent/connect')
+    expect(init.method).toBe('POST')
+    expect(new Headers(init.headers).get('Authorization')).toBe('Bearer tok')
   })
 
   it('retries with backoff and returns true once an attempt succeeds', async () => {
@@ -101,7 +87,7 @@ describe('createAgentSession', () => {
   })
 
   it('throws on a non-403 error without re-registering', async () => {
-    fetchMock.mockResolvedValueOnce(createMockResponse({ message: 'Bad Gateway' }, false, 502))
+    fetchMock.mockResolvedValueOnce(createMockResponse({ message: 'Bad Gateway' }, 502))
 
     await expect(createAgentSession({ token: 'tok', studioUrl: 'http://studio' })).rejects.toThrow('Failed to get agent session from Kubb Studio: Bad Gateway')
     expect(fetchMock).toHaveBeenCalledTimes(1)
@@ -110,7 +96,7 @@ describe('createAgentSession', () => {
   it('re-registers and retries once when Studio rejects the machine token', async () => {
     // 1: session create → 403, 2: register → ok, 3: session create retry → ok
     fetchMock
-      .mockResolvedValueOnce(createMockResponse({ message: 'machine token mismatch' }, false, 403))
+      .mockResolvedValueOnce(createMockResponse({ message: 'machine token mismatch' }, 403))
       .mockResolvedValueOnce(createMockResponse({}))
       .mockResolvedValueOnce(createMockResponse(session))
 
@@ -123,22 +109,23 @@ describe('createAgentSession', () => {
   })
 
   it('throws when re-registration fails after a machine token rejection', async () => {
-    fetchMock.mockResolvedValue(createMockResponse({ message: 'Forbidden' }, false, 403))
+    fetchMock.mockResolvedValue(createMockResponse({ message: 'Forbidden' }, 403))
 
     const promise = createAgentSession({ token: 'tok', studioUrl: 'http://studio' })
     promise.catch(() => {})
     await vi.runAllTimersAsync()
 
     await expect(promise).rejects.toThrow('Failed to get agent session from Kubb Studio: Forbidden')
-    // 1 session create + 4 register attempts
-    expect(fetchMock).toHaveBeenCalledTimes(5)
+    // 1 session create + 1 register. A 403 is not retried: the machine token was refused, and
+    // asking again with the same one cannot change that.
+    expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
   it('throws InvalidAgentTokenError when the retry after re-register still gets a 401', async () => {
     fetchMock
-      .mockResolvedValueOnce(createMockResponse({ message: 'machine token mismatch' }, false, 403))
+      .mockResolvedValueOnce(createMockResponse({ message: 'machine token mismatch' }, 403))
       .mockResolvedValueOnce(createMockResponse({}))
-      .mockResolvedValueOnce(createMockResponse({ message: 'revoked' }, false, 401))
+      .mockResolvedValueOnce(createMockResponse({ message: 'revoked' }, 401))
 
     const promise = createAgentSession({ token: 'tok', studioUrl: 'http://studio' })
     promise.catch(() => {})
@@ -166,7 +153,7 @@ describe('disconnect', () => {
   })
 
   it('warns instead of throwing when Studio cannot be notified', async () => {
-    fetchMock.mockResolvedValueOnce(createMockResponse({ message: 'gone' }, false, 500))
+    fetchMock.mockResolvedValueOnce(createMockResponse({ message: 'gone' }, 500))
 
     await expect(disconnect({ sessionId: 'session-abc', token: 'tok', studioUrl: 'http://studio', slug: 'brave-otter' })).resolves.toBeUndefined()
 

--- a/packages/studio/src/api.ts
+++ b/packages/studio/src/api.ts
@@ -1,12 +1,11 @@
-import { setTimeout as delay } from 'node:timers/promises'
 import { styleText } from 'node:util'
 import { getErrorMessage } from '@internals/utils'
+import { FetchError, ofetch, type FetchOptions } from 'ofetch'
 import type { AgentConnectResponse } from './protocol/index.ts'
 import { getMachineToken } from './machine.ts'
 
-type PostJsonOptions = {
+type PostJsonOptions = Pick<FetchOptions, 'retry' | 'retryDelay' | 'body'> & {
   headers?: Record<string, string>
-  body?: unknown
   /**
    * Studio's device-token polling endpoint returns a body worth reading on 4xx too
    * (`authorization_pending`, `slow_down`, `access_denied`, ...), so set `allowErrorResponse` to
@@ -16,21 +15,9 @@ type PostJsonOptions = {
 }
 
 /**
- * An HTTP failure from Studio. Carries `statusCode` so callers can branch on 401 vs 403 without
- * duck-typing a plain `Error`.
- */
-export class HttpError extends Error {
-  statusCode: number
-
-  constructor(message: string, statusCode: number, options?: ErrorOptions) {
-    super(message, options)
-    this.name = 'HttpError'
-    this.statusCode = statusCode
-  }
-}
-
-/**
- * Reads a human-readable message from a Studio JSON error body, when it has one.
+ * Reads a human-readable message from a Studio JSON error body, when it has one. `FetchError`'s own
+ * message stops at the status line, so the detail Studio sends with a failure (an agent limit, a
+ * revoked token) would otherwise never reach the user.
  */
 function responseMessage(data: unknown): string | undefined {
   if (!data || typeof data !== 'object') {
@@ -48,30 +35,17 @@ function responseMessage(data: unknown): string | undefined {
 }
 
 /**
- * Posts JSON to Studio and parses the JSON response. Throws {@link HttpError} on a non-2xx status,
- * unless `allowErrorResponse` is set.
+ * Posts JSON to Studio and parses the JSON response. Throws ofetch's `FetchError` on a non-2xx
+ * status, unless `allowErrorResponse` is set.
  */
-export async function postJson<T>(url: string, { headers, body, allowErrorResponse }: PostJsonOptions = {}): Promise<T> {
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...headers },
-    body: body === undefined ? undefined : JSON.stringify(body),
-  })
-
-  const data = (await response.json().catch(() => undefined)) as T
-
-  if (!response.ok && !allowErrorResponse) {
-    const detail = responseMessage(data)
-    throw new HttpError(detail ?? `Request to ${url} failed with status ${response.status}`, response.status)
-  }
-
-  return data
+export function postJson<T>(url: string, { headers, body, allowErrorResponse, retry, retryDelay }: PostJsonOptions = {}): Promise<T> {
+  return ofetch<T>(url, { method: 'POST', headers, body, ignoreResponseError: allowErrorResponse, retry, retryDelay })
 }
 
 /**
- * Delay before each registration attempt; the first attempt runs immediately.
+ * Retries after the first registration attempt, each backing off twice as far as the last.
  */
-const REGISTER_RETRY_DELAYS_MS = [0, 2_000, 4_000, 8_000]
+const REGISTER_RETRIES = 3
 
 /**
  * Shared in-flight registration so concurrent pool sessions trigger one purge, not N.
@@ -96,8 +70,8 @@ export class InvalidAgentTokenError extends Error {
 }
 
 /**
- * Whether a thrown value carries `statusCode`. Not narrowed to {@link HttpError}: a `fetch` layer
- * or a host wrapper can throw its own error shape with the same field.
+ * Whether a thrown value carries `statusCode`. Not narrowed to `FetchError`: a host wrapper can
+ * throw its own error shape with the same field.
  *
  * A 401 means the agent token itself was rejected. A 403 from the session create endpoint means
  * the machine token stored in Studio no longer matches this agent (missing or mismatched).
@@ -107,7 +81,7 @@ function rejectedWith(error: unknown, statusCode: number): boolean {
 }
 
 function sessionError(cause: unknown): Error {
-  const detail = getErrorMessage(cause)
+  const detail = (cause instanceof FetchError ? responseMessage(cause.data) : undefined) ?? getErrorMessage(cause)
   return new Error(detail ? `Failed to get agent session from Kubb Studio: ${detail}` : 'Failed to get agent session from Kubb Studio', { cause })
 }
 
@@ -186,34 +160,29 @@ export function registerAgent(props: RegisterProps): Promise<boolean> {
 }
 
 async function runRegistration({ token, studioUrl, poolSize }: RegisterProps): Promise<boolean> {
-  const url = `${studioUrl}/api/agent/connect`
   const machineToken = await getMachineToken()
 
-  for (const delayMs of REGISTER_RETRY_DELAYS_MS) {
-    if (delayMs > 0) {
-      await delay(delayMs)
+  try {
+    await postJson(`${studioUrl}/api/agent/connect`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      body: { machineToken, poolSize },
+      retry: REGISTER_RETRIES,
+      // 2s, 4s, then 8s. `retry` counts down, so the first retry is the one with the most left.
+      retryDelay: ({ options }) => 2_000 * 2 ** (REGISTER_RETRIES - Number(options.retry)),
+    })
+
+    return true
+  } catch (error) {
+    if (rejectedWith(error, 401)) {
+      throw new InvalidAgentTokenError(studioUrl, { cause: error })
     }
 
-    try {
-      await postJson(url, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-        body: { machineToken, poolSize },
-      })
-      return true
-    } catch (error) {
-      if (rejectedWith(error, 401)) {
-        throw new InvalidAgentTokenError(studioUrl, { cause: error })
-      }
+    console.error(styleText('red', `Failed to register agent with Studio after ${REGISTER_RETRIES + 1} attempts`))
 
-      console.warn(styleText('yellow', `Failed to register agent with Studio, retrying: ${getErrorMessage(error)}`))
-    }
+    return false
   }
-
-  console.error(styleText('red', `Failed to register agent with Studio after ${REGISTER_RETRY_DELAYS_MS.length} attempts`))
-
-  return false
 }
 
 type DisconnectProps = {

--- a/packages/studio/src/api.ts
+++ b/packages/studio/src/api.ts
@@ -1,18 +1,8 @@
 import { styleText } from 'node:util'
 import { getErrorMessage } from '@internals/utils'
-import { FetchError, ofetch, type FetchOptions } from 'ofetch'
+import { FetchError, ofetch } from 'ofetch'
 import type { AgentConnectResponse } from './protocol/index.ts'
 import { getMachineToken } from './machine.ts'
-
-type PostJsonOptions = Pick<FetchOptions, 'retry' | 'retryDelay' | 'body'> & {
-  headers?: Record<string, string>
-  /**
-   * Studio's device-token polling endpoint returns a body worth reading on 4xx too
-   * (`authorization_pending`, `slow_down`, `access_denied`, ...), so set `allowErrorResponse` to
-   * read the response instead of throwing.
-   */
-  allowErrorResponse?: boolean
-}
 
 /**
  * Reads a human-readable message from a Studio JSON error body, when it has one. `FetchError`'s own
@@ -32,14 +22,6 @@ function responseMessage(data: unknown): string | undefined {
   }
 
   return undefined
-}
-
-/**
- * Posts JSON to Studio and parses the JSON response. Throws ofetch's `FetchError` on a non-2xx
- * status, unless `allowErrorResponse` is set.
- */
-export function postJson<T>(url: string, { headers, body, allowErrorResponse, retry, retryDelay }: PostJsonOptions = {}): Promise<T> {
-  return ofetch<T>(url, { method: 'POST', headers, body, ignoreResponseError: allowErrorResponse, retry, retryDelay })
 }
 
 /**
@@ -91,7 +73,8 @@ function sessionError(cause: unknown): Error {
 async function requestAgentSession({ token, studioUrl }: ConnectProps): Promise<AgentConnectResponse> {
   const url = `${studioUrl}/api/agent/sessions`
 
-  const data = await postJson<AgentConnectResponse>(url, {
+  const data = await ofetch<AgentConnectResponse>(url, {
+    method: 'POST',
     headers: { Authorization: `Bearer ${token}` },
     body: { machineToken: await getMachineToken() },
   })
@@ -163,7 +146,8 @@ async function runRegistration({ token, studioUrl, poolSize }: RegisterProps): P
   const machineToken = await getMachineToken()
 
   try {
-    await postJson(`${studioUrl}/api/agent/connect`, {
+    await ofetch(`${studioUrl}/api/agent/connect`, {
+      method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,
       },
@@ -202,7 +186,8 @@ export async function disconnect({ sessionId, token, studioUrl, slug }: Disconne
   const tag = slug ?? 'agent'
 
   try {
-    await postJson(url, {
+    await ofetch(url, {
+      method: 'POST',
       headers: {
         Authorization: `Bearer ${token}`,
       },

--- a/packages/studio/src/client.e2e.test.ts
+++ b/packages/studio/src/client.e2e.test.ts
@@ -134,9 +134,9 @@ function projectConfig(): Config {
   } as unknown as Config
 }
 
-const isConnected = (message: AgentMessage): message is ConnectedMessage => message.type === 'connected'
-const isEnd = (message: AgentMessage): message is DataMessage => message.type === 'data' && message.payload.type === 'kubb:generation:end'
-const isError = (message: AgentMessage): message is DataMessage => message.type === 'data' && message.payload.type === 'kubb:error'
+const isConnected = (message: AgentMessage): message is ConnectedMessage => message.type === 'kubb:connected'
+const isEnd = (message: AgentMessage): message is DataMessage => message.type === 'kubb:data' && message.payload.type === 'kubb:generation:end'
+const isError = (message: AgentMessage): message is DataMessage => message.type === 'kubb:data' && message.payload.type === 'kubb:error'
 
 describe('createClient against a Studio instance', () => {
   let studio: ReturnType<typeof createFakeStudio>
@@ -197,11 +197,11 @@ describe('createClient against a Studio instance', () => {
   it('runs a generation and streams it back to Studio', async () => {
     await connect()
 
-    studio.send({ type: 'command', command: 'generate', payload: { plugins: [] } })
+    studio.send({ type: 'kubb:command', command: 'generate', payload: { plugins: [] } })
 
     await studio.waitFor(isEnd)
 
-    const types = studio.received.filter((message) => message.type === 'data').map((message) => (message as DataMessage).payload.type)
+    const types = studio.received.filter((message) => message.type === 'kubb:data').map((message) => (message as DataMessage).payload.type)
 
     expect(types).toContain('kubb:generation:start')
     expect(types).toContain('kubb:build:start')
@@ -214,7 +214,7 @@ describe('createClient against a Studio instance', () => {
   it('refuses a plugin the local config does not import, before importing it', async () => {
     await connect({ allowedPlugins: ['@kubb/plugin-ts'] })
 
-    studio.send({ type: 'command', command: 'generate', payload: { plugins: [{ name: 'evil-module', options: {} }] } })
+    studio.send({ type: 'kubb:command', command: 'generate', payload: { plugins: [{ name: 'evil-module', options: {} }] } })
 
     const error = await studio.waitFor(isError)
 
@@ -224,7 +224,7 @@ describe('createClient against a Studio instance', () => {
   it('reaches the import, and fails there, when no allow-list is set', async () => {
     await connect()
 
-    studio.send({ type: 'command', command: 'generate', payload: { plugins: [{ name: 'evil-module', options: {} }] } })
+    studio.send({ type: 'kubb:command', command: 'generate', payload: { plugins: [{ name: 'evil-module', options: {} }] } })
 
     const error = await studio.waitFor(isError)
 

--- a/packages/studio/src/configFile.test.ts
+++ b/packages/studio/src/configFile.test.ts
@@ -39,19 +39,17 @@ function apply(source: string, ...edits: Array<ConfigEdit>) {
 describe('readConfig', () => {
   it('lists every plugin in the advanced example with its package', () => {
     const view = readConfig(advanced)
-    expect(view.managed && view.configs[0]!.plugins.map((plugin) => `${plugin.importName} <- ${plugin.packageName}`)).toMatchInlineSnapshot(`
-      [
-        "pluginRedoc <- @kubb/plugin-redoc",
-        "pluginTs <- @kubb/plugin-ts",
-        "pluginZod <- @kubb/plugin-zod",
-        "pluginReactQuery <- @kubb/plugin-react-query",
-        "pluginAxios <- @kubb/plugin-axios",
-        "pluginMcp <- @kubb/plugin-mcp",
-        "pluginFaker <- @kubb/plugin-faker",
-        "pluginCypress <- @kubb/plugin-cypress",
-        "pluginMsw <- @kubb/plugin-msw",
-      ]
-    `)
+    expect(view.managed && view.configs[0]!.plugins.map((plugin) => `${plugin.importName} <- ${plugin.packageName}`)).toStrictEqual([
+      'pluginRedoc <- @kubb/plugin-redoc',
+      'pluginTs <- @kubb/plugin-ts',
+      'pluginZod <- @kubb/plugin-zod',
+      'pluginReactQuery <- @kubb/plugin-react-query',
+      'pluginAxios <- @kubb/plugin-axios',
+      'pluginMcp <- @kubb/plugin-mcp',
+      'pluginFaker <- @kubb/plugin-faker',
+      'pluginCypress <- @kubb/plugin-cypress',
+      'pluginMsw <- @kubb/plugin-msw',
+    ])
   })
 
   it('marks function-valued options as not literal', () => {
@@ -64,88 +62,82 @@ describe('readConfig', () => {
       'faker.resolver': byName.pluginFaker?.resolver,
       'faker.group': byName.pluginFaker?.group,
       'ts.override': byName.pluginTs?.override,
-    }).toMatchInlineSnapshot(`
-      {
-        "axios.baseURL": {
-          "literal": true,
-          "value": "https://petstore3.swagger.io/api/v3",
+    }).toStrictEqual({
+      'axios.baseURL': {
+        literal: true,
+        value: 'https://petstore3.swagger.io/api/v3',
+      },
+      'axios.group': {
+        literal: false,
+      },
+      'faker.group': {
+        literal: true,
+        value: {
+          type: 'tag',
         },
-        "axios.group": {
-          "literal": false,
-        },
-        "faker.group": {
-          "literal": true,
-          "value": {
-            "type": "tag",
-          },
-        },
-        "faker.macros": {
-          "literal": false,
-        },
-        "faker.resolver": {
-          "literal": false,
-        },
-        "ts.override": {
-          "literal": true,
-          "value": [
-            {
-              "options": {
-                "enum": {
-                  "constCasing": "camelCase",
-                  "keyCasing": "none",
-                  "type": "enum",
-                  "typeSuffix": "Key",
-                },
+      },
+      'faker.macros': {
+        literal: false,
+      },
+      'faker.resolver': {
+        literal: false,
+      },
+      'ts.override': {
+        literal: true,
+        value: [
+          {
+            options: {
+              enum: {
+                constCasing: 'camelCase',
+                keyCasing: 'none',
+                type: 'enum',
+                typeSuffix: 'Key',
               },
-              "pattern": "findPetsByStatus",
-              "type": "operationId",
             },
-          ],
-        },
-      }
-    `)
+            pattern: 'findPetsByStatus',
+            type: 'operationId',
+          },
+        ],
+      },
+    })
   })
 
   it('refuses a function returning an array', () => {
-    expect(readConfig(`export default defineConfig(() => schemas.map((s) => ({ name: s })))`)).toMatchInlineSnapshot(`
-      {
-        "managed": false,
-        "reason": "config is not an object literal",
-      }
-    `)
+    expect(readConfig(`export default defineConfig(() => schemas.map((s) => ({ name: s })))`)).toStrictEqual({
+      managed: false,
+      reason: 'config is not an object literal',
+    })
   })
 
   it('reads through a (cli) => ({...}) wrapper', () => {
     const source = `import { pluginTs } from '@kubb/plugin-ts'\nexport default defineConfig((cli) => ({ plugins: [pluginTs({ arrayType: 'generic' })] }))`
-    expect(readConfig(source)).toMatchInlineSnapshot(`
-      {
-        "configs": [
-          {
-            "name": undefined,
-            "plugins": [
-              {
-                "importName": "pluginTs",
-                "options": {
-                  "arrayType": {
-                    "literal": true,
-                    "value": "generic",
-                  },
+    expect(readConfig(source)).toStrictEqual({
+      configs: [
+        {
+          name: undefined,
+          plugins: [
+            {
+              importName: 'pluginTs',
+              options: {
+                arrayType: {
+                  literal: true,
+                  value: 'generic',
                 },
-                "packageName": "@kubb/plugin-ts",
               },
-            ],
-          },
-        ],
-        "managed": true,
-      }
-    `)
+              packageName: '@kubb/plugin-ts',
+            },
+          ],
+        },
+      ],
+      managed: true,
+    })
   })
 })
 
 describe('applyConfigEdits: set', () => {
   it('changes only the targeted value and leaves every other byte alone', () => {
     const result = apply(advanced, { operation: 'set', plugin: '@kubb/plugin-ts', path: ['enum', 'type'], value: 'enum' })
-    expect(changedSpan(advanced, result.source)).toMatchInlineSnapshot(`""asConst" -> "enum""`)
+    expect(changedSpan(advanced, result.source)).toBe('"asConst" -> "enum"')
   })
 
   it('adds a missing key to an existing options object', () => {
@@ -162,26 +154,18 @@ describe('applyConfigEdits: set', () => {
 
   it('refuses to overwrite an option customized in code', () => {
     const result = apply(advanced, { operation: 'set', plugin: '@kubb/plugin-axios', path: ['group', 'name'], value: 'x' })
-    expect({ changed: result.changed, outcomes: result.outcomes.map((outcome) => outcome.reason) }).toMatchInlineSnapshot(`
-      {
-        "changed": false,
-        "outcomes": [
-          "group.name is customized in code",
-        ],
-      }
-    `)
+    expect({ changed: result.changed, outcomes: result.outcomes.map((outcome) => outcome.reason) }).toStrictEqual({
+      changed: false,
+      outcomes: ['group.name is customized in code'],
+    })
   })
 
   it('refuses a plugin that is not in the file', () => {
     const result = apply(advanced, { operation: 'set', plugin: '@kubb/plugin-swr', path: ['hooks'], value: true })
-    expect({ changed: result.changed, outcomes: result.outcomes.map((outcome) => outcome.reason) }).toMatchInlineSnapshot(`
-      {
-        "changed": false,
-        "outcomes": [
-          "@kubb/plugin-swr is not in the plugins array",
-        ],
-      }
-    `)
+    expect({ changed: result.changed, outcomes: result.outcomes.map((outcome) => outcome.reason) }).toStrictEqual({
+      changed: false,
+      outcomes: ['@kubb/plugin-swr is not in the plugins array'],
+    })
   })
 
   it('applies the good edits in a batch and reports the bad ones', () => {
@@ -195,18 +179,11 @@ describe('applyConfigEdits: set', () => {
       applied: result.outcomes.filter((outcome) => outcome.applied).length,
       reasons: result.outcomes.filter((outcome) => !outcome.applied).map((outcome) => outcome.reason),
       changedLines: changedLines(advanced, result.source),
-    }).toMatchInlineSnapshot(`
-      {
-        "applied": 2,
-        "changedLines": [
-          "arrayType: 'generic', -> arrayType: 'array',",
-          "handlers: true, -> handlers: false,",
-        ],
-        "reasons": [
-          "group is customized in code",
-        ],
-      }
-    `)
+    }).toStrictEqual({
+      applied: 2,
+      changedLines: ["arrayType: 'generic', -> arrayType: 'array',", 'handlers: true, -> handlers: false,'],
+      reasons: ['group is customized in code'],
+    })
   })
 
   it('refuses a __proto__ path segment instead of throwing and taking the rest of the batch down', () => {
@@ -218,15 +195,10 @@ describe('applyConfigEdits: set', () => {
     expect({
       applied: result.outcomes.filter((outcome) => outcome.applied).length,
       reasons: result.outcomes.map((outcome) => outcome.reason),
-    }).toMatchInlineSnapshot(`
-      {
-        "applied": 1,
-        "reasons": [
-          "__proto__.polluted is not a valid option path",
-          undefined,
-        ],
-      }
-    `)
+    }).toStrictEqual({
+      applied: 1,
+      reasons: ['__proto__.polluted is not a valid option path', undefined],
+    })
   })
 })
 
@@ -240,22 +212,18 @@ describe('applyConfigEdits: remove', () => {
 
   it('refuses to remove an option customized in code', () => {
     const result = apply(advanced, { operation: 'remove', plugin: '@kubb/plugin-faker', path: ['macros'] })
-    expect({ changed: result.changed, reason: result.outcomes[0]?.reason }).toMatchInlineSnapshot(`
-      {
-        "changed": false,
-        "reason": "macros is customized in code",
-      }
-    `)
+    expect({ changed: result.changed, reason: result.outcomes[0]?.reason }).toStrictEqual({
+      changed: false,
+      reason: 'macros is customized in code',
+    })
   })
 
   it('reports an option that was never set', () => {
     const result = apply(advanced, { operation: 'remove', plugin: '@kubb/plugin-zod', path: ['unset'] })
-    expect({ changed: result.changed, reason: result.outcomes[0]?.reason }).toMatchInlineSnapshot(`
-      {
-        "changed": false,
-        "reason": "unset is not set",
-      }
-    `)
+    expect({ changed: result.changed, reason: result.outcomes[0]?.reason }).toStrictEqual({
+      changed: false,
+      reason: 'unset is not set',
+    })
   })
 })
 
@@ -279,34 +247,28 @@ describe('applyConfigEdits: add-plugin', () => {
   it('leaves the result parseable, with the new plugin readable', () => {
     const result = apply(advanced, { operation: 'add-plugin', plugin: '@kubb/plugin-swr' })
     const view = readConfig(result.source)
-    expect(view.managed && view.configs[0]!.plugins.at(-1)).toMatchInlineSnapshot(`
-      {
-        "importName": "pluginSwr",
-        "options": {},
-        "packageName": "@kubb/plugin-swr",
-      }
-    `)
+    expect(view.managed && view.configs[0]!.plugins.at(-1)).toStrictEqual({
+      importName: 'pluginSwr',
+      options: {},
+      packageName: '@kubb/plugin-swr',
+    })
   })
 
   it('refuses a plugin that is already there', () => {
     const result = apply(advanced, { operation: 'add-plugin', plugin: '@kubb/plugin-ts' })
-    expect({ changed: result.changed, reason: result.outcomes[0]?.reason }).toMatchInlineSnapshot(`
-      {
-        "changed": false,
-        "reason": "@kubb/plugin-ts is already in the plugins array",
-      }
-    `)
+    expect({ changed: result.changed, reason: result.outcomes[0]?.reason }).toStrictEqual({
+      changed: false,
+      reason: '@kubb/plugin-ts is already in the plugins array',
+    })
   })
 
   it('refuses when the import name is taken by another package', () => {
     const source = `import { pluginTs } from './my-own-plugin-ts.ts'\n\nexport default defineConfig({ plugins: [pluginTs()] })\n`
     const result = apply(source, { operation: 'add-plugin', plugin: '@kubb/plugin-ts' })
-    expect({ changed: result.changed, reason: result.outcomes[0]?.reason }).toMatchInlineSnapshot(`
-      {
-        "changed": false,
-        "reason": "pluginTs is already imported from ./my-own-plugin-ts.ts",
-      }
-    `)
+    expect({ changed: result.changed, reason: result.outcomes[0]?.reason }).toStrictEqual({
+      changed: false,
+      reason: 'pluginTs is already imported from ./my-own-plugin-ts.ts',
+    })
   })
 
   it('fills an empty plugins array', () => {
@@ -388,26 +350,24 @@ describe('reading a config that does not look like the examples', () => {
   it('finds a plugin imported under an alias', () => {
     const source = `import { pluginTs as tsPlugin } from '@kubb/plugin-ts'\n\nexport default defineConfig({ plugins: [tsPlugin({ arrayType: 'generic' })] })\n`
     const view = readConfig(source)
-    expect(view.managed && view.configs[0]!.plugins).toMatchInlineSnapshot(`
-      [
-        {
-          "importName": "tsPlugin",
-          "options": {
-            "arrayType": {
-              "literal": true,
-              "value": "generic",
-            },
+    expect(view.managed && view.configs[0]!.plugins).toStrictEqual([
+      {
+        importName: 'tsPlugin',
+        options: {
+          arrayType: {
+            literal: true,
+            value: 'generic',
           },
-          "packageName": "@kubb/plugin-ts",
         },
-      ]
-    `)
+        packageName: '@kubb/plugin-ts',
+      },
+    ])
   })
 
   it('edits a plugin imported under an alias', () => {
     const source = `import { pluginTs as tsPlugin } from '@kubb/plugin-ts'\n\nexport default defineConfig({ plugins: [tsPlugin({ arrayType: 'generic' })] })\n`
     const result = applyConfigEdits(source, [{ operation: 'set', plugin: '@kubb/plugin-ts', path: ['arrayType'], value: 'array' }])
-    expect(changedSpan(source, result.source)).toMatchInlineSnapshot(`""generic" -> "array""`)
+    expect(changedSpan(source, result.source)).toBe('"generic" -> "array"')
   })
 
   // A string that happens to hold an import line used to convince the old whole-file cleanup pass
@@ -422,23 +382,19 @@ describe('reading a config that does not look like the examples', () => {
       ``,
     ].join('\n')
     const result = applyConfigEdits(source, [{ operation: 'add-plugin', plugin: '@kubb/plugin-zod' }])
-    expect(result.source.split('\n').filter((line) => line.startsWith('import'))).toMatchInlineSnapshot(`
-      [
-        "import { pluginTs } from '@kubb/plugin-ts'",
-        "import { pluginZod } from '@kubb/plugin-zod'",
-      ]
-    `)
+    expect(result.source.split('\n').filter((line) => line.startsWith('import'))).toStrictEqual([
+      "import { pluginTs } from '@kubb/plugin-ts'",
+      "import { pluginZod } from '@kubb/plugin-zod'",
+    ])
   })
 
   it('follows a config that does write semicolons', () => {
     const source = [`import { pluginTs } from '@kubb/plugin-ts';`, ``, `export default defineConfig({ plugins: [pluginTs()] });`, ``].join('\n')
     const result = applyConfigEdits(source, [{ operation: 'add-plugin', plugin: '@kubb/plugin-zod' }])
-    expect(result.source.split('\n').filter((line) => line.startsWith('import'))).toMatchInlineSnapshot(`
-      [
-        "import { pluginTs } from '@kubb/plugin-ts';",
-        "import { pluginZod } from '@kubb/plugin-zod';",
-      ]
-    `)
+    expect(result.source.split('\n').filter((line) => line.startsWith('import'))).toStrictEqual([
+      "import { pluginTs } from '@kubb/plugin-ts';",
+      "import { pluginZod } from '@kubb/plugin-zod';",
+    ])
   })
 
   it('puts a new import after the existing ones when a statement comes first', () => {
@@ -475,22 +431,10 @@ describe('applyConfigEdits: array configs', () => {
 
   it('reads one entry per element, in source order', () => {
     const view = readConfig(arraySource)
-    expect(view.managed && view.configs.map((config) => [config.name, config.plugins.map((plugin) => plugin.importName)])).toMatchInlineSnapshot(`
-      [
-        [
-          "public",
-          [
-            "pluginTs",
-          ],
-        ],
-        [
-          "internal",
-          [
-            "pluginZod",
-          ],
-        ],
-      ]
-    `)
+    expect(view.managed && view.configs.map((config) => [config.name, config.plugins.map((plugin) => plugin.importName)])).toStrictEqual([
+      ['public', ['pluginTs']],
+      ['internal', ['pluginZod']],
+    ])
   })
 
   it('targets an entry by index', () => {
@@ -500,22 +444,20 @@ describe('applyConfigEdits: array configs', () => {
 
   it('targets an entry by name', () => {
     const result = applyConfigEdits(arraySource, [{ operation: 'set', config: 'public', plugin: '@kubb/plugin-ts', path: ['arrayType'], value: 'array' }])
-    expect(changedSpan(arraySource, result.source)).toMatchInlineSnapshot(`""generic" -> "array""`)
+    expect(changedSpan(arraySource, result.source)).toBe('"generic" -> "array"')
   })
 
   it('defaults to the first entry when an edit names none', () => {
     const result = applyConfigEdits(arraySource, [{ operation: 'set', plugin: '@kubb/plugin-ts', path: ['arrayType'], value: 'array' }])
-    expect(changedSpan(arraySource, result.source)).toMatchInlineSnapshot(`""generic" -> "array""`)
+    expect(changedSpan(arraySource, result.source)).toBe('"generic" -> "array"')
   })
 
   it('refuses an edit naming a config entry that does not exist', () => {
     const result = applyConfigEdits(arraySource, [{ operation: 'set', config: 'missing', plugin: '@kubb/plugin-ts', path: ['arrayType'], value: 'array' }])
-    expect({ changed: result.changed, reason: result.outcomes[0]?.reason }).toMatchInlineSnapshot(`
-      {
-        "changed": false,
-        "reason": "no config entry found for "missing"",
-      }
-    `)
+    expect({ changed: result.changed, reason: result.outcomes[0]?.reason }).toStrictEqual({
+      changed: false,
+      reason: 'no config entry found for "missing"',
+    })
   })
 
   it('adds a plugin to one entry without touching the other', () => {
@@ -526,23 +468,10 @@ describe('applyConfigEdits: array configs', () => {
 
   it('reads every entry of a realistic multi-output array config', () => {
     const view = readConfig(arrayConfig)
-    expect(view.managed && view.configs.map((config) => [config.name, config.plugins.map((plugin) => plugin.importName)])).toMatchInlineSnapshot(`
-      [
-        [
-          "public",
-          [
-            "pluginTs",
-          ],
-        ],
-        [
-          "internal",
-          [
-            "pluginTs",
-            "pluginZod",
-          ],
-        ],
-      ]
-    `)
+    expect(view.managed && view.configs.map((config) => [config.name, config.plugins.map((plugin) => plugin.importName)])).toStrictEqual([
+      ['public', ['pluginTs']],
+      ['internal', ['pluginTs', 'pluginZod']],
+    ])
   })
 
   it('disables a plugin in one entry of the real fixture, leaving the other entry alone', () => {
@@ -579,14 +508,12 @@ describe('applyConfigEdits: disable-plugin and enable-plugin', () => {
   it('reports the plugin as disabled with no options', () => {
     const disabled = applyConfigEdits(source, [{ operation: 'disable-plugin', plugin: '@kubb/plugin-zod' }]).source
     const view = readConfig(disabled)
-    expect(view.managed && view.configs[0]!.plugins.find((plugin) => plugin.packageName === '@kubb/plugin-zod')).toMatchInlineSnapshot(`
-      {
-        "disabled": true,
-        "importName": "pluginZod",
-        "options": {},
-        "packageName": "@kubb/plugin-zod",
-      }
-    `)
+    expect(view.managed && view.configs[0]!.plugins.find((plugin) => plugin.packageName === '@kubb/plugin-zod')).toStrictEqual({
+      disabled: true,
+      importName: 'pluginZod',
+      options: {},
+      packageName: '@kubb/plugin-zod',
+    })
   })
 
   it('leaves a set on a sibling plugin untouched while one is disabled', () => {
@@ -594,7 +521,7 @@ describe('applyConfigEdits: disable-plugin and enable-plugin', () => {
     const result = applyConfigEdits(disabled, [{ operation: 'set', plugin: '@kubb/plugin-ts', path: ['arrayType'], value: 'array' }])
     expect(result.source).toContain('// kubb:disabled @kubb/plugin-zod')
     expect(result.source).toContain('//   inferred: true,')
-    expect(changedSpan(disabled, result.source)).toMatchInlineSnapshot(`""generic" -> "array""`)
+    expect(changedSpan(disabled, result.source)).toBe('"generic" -> "array"')
   })
 
   it('enabling returns the source byte-for-byte', () => {
@@ -619,32 +546,26 @@ describe('applyConfigEdits: disable-plugin and enable-plugin', () => {
   it('refuses to disable a plugin that shares its line with other code', () => {
     const inline = `import { pluginTs } from '@kubb/plugin-ts'\n\nexport default defineConfig({ plugins: [pluginTs({ arrayType: 'generic' })] })\n`
     const result = applyConfigEdits(inline, [{ operation: 'disable-plugin', plugin: '@kubb/plugin-ts' }])
-    expect({ changed: result.changed, reason: result.outcomes[0]?.reason }).toMatchInlineSnapshot(`
-      {
-        "changed": false,
-        "reason": "@kubb/plugin-ts shares a line with other code, so it cannot be commented out safely",
-      }
-    `)
+    expect({ changed: result.changed, reason: result.outcomes[0]?.reason }).toStrictEqual({
+      changed: false,
+      reason: '@kubb/plugin-ts shares a line with other code, so it cannot be commented out safely',
+    })
   })
 
   it('refuses to disable a plugin that is not in the file', () => {
     const result = applyConfigEdits(source, [{ operation: 'disable-plugin', plugin: '@kubb/plugin-msw' }])
-    expect({ changed: result.changed, reason: result.outcomes[0]?.reason }).toMatchInlineSnapshot(`
-      {
-        "changed": false,
-        "reason": "@kubb/plugin-msw is not in the plugins array",
-      }
-    `)
+    expect({ changed: result.changed, reason: result.outcomes[0]?.reason }).toStrictEqual({
+      changed: false,
+      reason: '@kubb/plugin-msw is not in the plugins array',
+    })
   })
 
   it('refuses to enable a plugin that is not disabled', () => {
     const result = applyConfigEdits(source, [{ operation: 'enable-plugin', plugin: '@kubb/plugin-zod' }])
-    expect({ changed: result.changed, reason: result.outcomes[0]?.reason }).toMatchInlineSnapshot(`
-      {
-        "changed": false,
-        "reason": "@kubb/plugin-zod is not disabled",
-      }
-    `)
+    expect({ changed: result.changed, reason: result.outcomes[0]?.reason }).toStrictEqual({
+      changed: false,
+      reason: '@kubb/plugin-zod is not disabled',
+    })
   })
 })
 
@@ -652,18 +573,16 @@ describe('readConfig: values magicast cannot proxy', () => {
   it('classifies a negative number and a template literal as literal without throwing', () => {
     const source = `import { pluginTs } from '@kubb/plugin-ts'\n\nexport default defineConfig({ plugins: [pluginTs({ n: -1, banner: \`static\` })] })\n`
     const view = readConfig(source)
-    expect(view.managed && view.configs[0]!.plugins[0]!.options).toMatchInlineSnapshot(`
-      {
-        "banner": {
-          "literal": true,
-          "value": "static",
-        },
-        "n": {
-          "literal": true,
-          "value": -1,
-        },
-      }
-    `)
+    expect(view.managed && view.configs[0]!.plugins[0]!.options).toStrictEqual({
+      banner: {
+        literal: true,
+        value: 'static',
+      },
+      n: {
+        literal: true,
+        value: -1,
+      },
+    })
   })
 })
 
@@ -733,23 +652,19 @@ describe('applyConfigEdits: values arriving from outside', () => {
 
   it('refuses a value that is not a literal', () => {
     const result = applyConfigEdits(base, [{ operation: 'set', plugin: '@kubb/plugin-ts', path: ['arrayType'], value: () => 'array' }])
-    expect({ changed: result.changed, reason: result.outcomes[0]?.reason }).toMatchInlineSnapshot(`
-      {
-        "changed": false,
-        "reason": "the value is not a literal that can be written to a config file",
-      }
-    `)
+    expect({ changed: result.changed, reason: result.outcomes[0]?.reason }).toStrictEqual({
+      changed: false,
+      reason: 'the value is not a literal that can be written to a config file',
+    })
   })
 
   it('refuses a __proto__ key instead of writing it into the file', () => {
     const value = JSON.parse('{"__proto__": {"polluted": true}}') as unknown
     const result = applyConfigEdits(base, [{ operation: 'set', plugin: '@kubb/plugin-ts', path: ['group'], value }])
-    expect({ changed: result.changed, reason: result.outcomes[0]?.reason }).toMatchInlineSnapshot(`
-      {
-        "changed": false,
-        "reason": "the value is not a literal that can be written to a config file",
-      }
-    `)
+    expect({ changed: result.changed, reason: result.outcomes[0]?.reason }).toStrictEqual({
+      changed: false,
+      reason: 'the value is not a literal that can be written to a config file',
+    })
   })
 
   it('escapes a string that would otherwise break out of the literal', () => {
@@ -765,11 +680,7 @@ describe('applyConfigEdits: values arriving from outside', () => {
     `)
     // The injected text must be inert: the plugin still has exactly the one option.
     const view = readConfig(result.source)
-    expect(view.managed && Object.keys(view.configs[0]!.plugins[0]!.options)).toMatchInlineSnapshot(`
-      [
-        "arrayType",
-      ]
-    `)
+    expect(view.managed && Object.keys(view.configs[0]!.plugins[0]!.options)).toStrictEqual(['arrayType'])
   })
 
   it('keeps a value with real newlines and quotes readable', () => {

--- a/packages/studio/src/connectStudio.test.ts
+++ b/packages/studio/src/connectStudio.test.ts
@@ -155,7 +155,7 @@ describe('connectToStudio', () => {
 
     await vi.advanceTimersByTimeAsync(30_000)
 
-    expect(sendAgentMessage).toHaveBeenCalledWith(mockWs, { type: 'ping' })
+    expect(sendAgentMessage).toHaveBeenCalledWith(mockWs, { type: 'kubb:ping' })
   })
 
   it('stops retrying once the signal aborts', async () => {
@@ -175,7 +175,7 @@ describe('connectToStudio', () => {
   it('accepts a pong without treating it as an unknown message', async () => {
     await connectToStudio(options)
 
-    await mockWs.trigger('message', { data: JSON.stringify({ type: 'pong' }) })
+    await mockWs.trigger('message', { data: JSON.stringify({ type: 'kubb:pong' }) })
 
     expect(consoleSpy.warn).not.toHaveBeenCalledWith(expect.stringContaining('Unknown message type'))
   })
@@ -199,7 +199,7 @@ describe('connectToStudio', () => {
 
     // onOpen sends the connected payload without awaiting it, and it now reads storage first,
     // so let the fire-and-forget send settle before asserting.
-    await vi.waitFor(() => expect(sendAgentMessage).toHaveBeenCalledWith(mockWs, expect.objectContaining({ type: 'connected' })))
+    await vi.waitFor(() => expect(sendAgentMessage).toHaveBeenCalledWith(mockWs, expect.objectContaining({ type: 'kubb:connected' })))
   })
 
   it('logs the slug when the WebSocket opens', async () => {
@@ -239,7 +239,7 @@ describe('connectToStudio', () => {
 
     for (const _ of Array.from({ length: 5 })) {
       await vi.advanceTimersByTimeAsync(1_000)
-      await mockWs.trigger('message', { data: JSON.stringify({ type: 'pong' }) })
+      await mockWs.trigger('message', { data: JSON.stringify({ type: 'kubb:pong' }) })
     }
 
     expect(mockWs.terminated).toBe(false)
@@ -264,13 +264,13 @@ describe('connectToStudio', () => {
     let configFile: string
 
     /**
-     * The `config-saved` reply the agent sent, if any.
+     * The `kubb:config-saved` reply the agent sent, if any.
      */
     const reply = () =>
       vi
         .mocked(sendAgentMessage)
         .mock.calls.map(([, message]) => message)
-        .find((message) => message.type === 'config-saved')
+        .find((message) => message.type === 'kubb:config-saved')
 
     beforeEach(() => {
       projectRoot = mkdtempSync(path.join(tmpdir(), 'kubb-studio-'))
@@ -283,7 +283,7 @@ describe('connectToStudio', () => {
       rmSync(projectRoot, { recursive: true, force: true })
     })
 
-    const write = async (edits: Array<unknown>) => mockWs.trigger('message', { data: JSON.stringify({ type: 'command', command: 'save', edits }) })
+    const write = async (edits: Array<unknown>) => mockWs.trigger('message', { data: JSON.stringify({ type: 'kubb:command', command: 'save', edits }) })
 
     it('writes a literal option and leaves the rest of the file alone', async () => {
       await connectToStudio({ ...options, allowConfigEdit: true })
@@ -351,7 +351,7 @@ describe('connectToStudio', () => {
       await write([{ operation: 'set', plugin: '@kubb/plugin-ts', path: ['group', 'name'], value: 'x' }])
 
       expect(readFileSync(configFile, 'utf-8')).toBe(original)
-      expect(reply()?.payload.outcomes[0]?.reason).toMatchInlineSnapshot(`"group.name is customized in code"`)
+      expect(reply()?.payload.outcomes[0]?.reason).toBe('group.name is customized in code')
     })
 
     // Studio only ever saw the file as it was on connect. Re-reading it right before the patch is
@@ -380,7 +380,7 @@ describe('connectToStudio', () => {
     it('still replies when the message carries no edits', async () => {
       await connectToStudio({ ...options, allowConfigEdit: true })
 
-      await mockWs.trigger('message', { data: JSON.stringify({ type: 'command', command: 'save' }) })
+      await mockWs.trigger('message', { data: JSON.stringify({ type: 'kubb:command', command: 'save' }) })
 
       expect(reply()?.payload).toMatchObject({ changed: false, outcomes: [] })
     })
@@ -388,40 +388,38 @@ describe('connectToStudio', () => {
     it('reports what the file holds on connect so Studio can disable the right controls', async () => {
       await connectToStudio({ ...options, allowConfigEdit: true })
 
-      await mockWs.trigger('message', { data: JSON.stringify({ type: 'command', command: 'connect' }) })
+      await mockWs.trigger('message', { data: JSON.stringify({ type: 'kubb:command', command: 'connect' }) })
 
       const connected = vi
         .mocked(sendAgentMessage)
         .mock.calls.map(([, message]) => message)
-        .find((message) => message.type === 'connected')
+        .find((message) => message.type === 'kubb:connected')
 
-      expect(connected?.type === 'connected' && connected.payload.configFile).toMatchInlineSnapshot(`
-        {
-          "configs": [
-            {
-              "name": undefined,
-              "plugins": [
-                {
-                  "importName": "pluginTs",
-                  "options": {
-                    "enum": {
-                      "literal": true,
-                      "value": {
-                        "type": "asConst",
-                      },
-                    },
-                    "group": {
-                      "literal": false,
+      expect(connected?.type === 'kubb:connected' && connected.payload.configFile).toStrictEqual({
+        configs: [
+          {
+            name: undefined,
+            plugins: [
+              {
+                importName: 'pluginTs',
+                options: {
+                  enum: {
+                    literal: true,
+                    value: {
+                      type: 'asConst',
                     },
                   },
-                  "packageName": "@kubb/plugin-ts",
+                  group: {
+                    literal: false,
+                  },
                 },
-              ],
-            },
-          ],
-          "managed": true,
-        }
-      `)
+                packageName: '@kubb/plugin-ts',
+              },
+            ],
+          },
+        ],
+        managed: true,
+      })
     })
   })
 
@@ -431,7 +429,7 @@ describe('connectToStudio', () => {
     await connectToStudio(options)
 
     await mockWs.trigger('message', {
-      data: JSON.stringify({ type: 'command', command: 'generate' }),
+      data: JSON.stringify({ type: 'kubb:command', command: 'generate' }),
     })
 
     expect(generate).toHaveBeenCalledWith(
@@ -447,7 +445,7 @@ describe('connectToStudio', () => {
     await connectToStudio(options)
 
     await mockWs.trigger('message', {
-      data: JSON.stringify({ type: 'command', command: 'generate', payload }),
+      data: JSON.stringify({ type: 'kubb:command', command: 'generate', payload }),
     })
 
     expect(generate).toHaveBeenCalledWith(
@@ -461,7 +459,7 @@ describe('connectToStudio', () => {
     await connectToStudio({ ...options, allowWrite: true })
 
     await mockWs.trigger('message', {
-      data: JSON.stringify({ type: 'command', command: 'generate' }),
+      data: JSON.stringify({ type: 'kubb:command', command: 'generate' }),
     })
 
     expect(generate).toHaveBeenCalledWith(
@@ -484,7 +482,7 @@ describe('connectToStudio', () => {
     await connectToStudio(options)
 
     await sandboxWs.trigger('message', {
-      data: JSON.stringify({ type: 'command', command: 'generate', payload }),
+      data: JSON.stringify({ type: 'kubb:command', command: 'generate', payload }),
     })
 
     expect(generate).toHaveBeenCalledWith(
@@ -502,7 +500,7 @@ describe('connectToStudio', () => {
     await connectToStudio(options) // allowInput: false
 
     await mockWs.trigger('message', {
-      data: JSON.stringify({ type: 'command', command: 'generate', payload }),
+      data: JSON.stringify({ type: 'kubb:command', command: 'generate', payload }),
     })
 
     // Without allowInput the spec stays the on-disk config.input
@@ -520,7 +518,7 @@ describe('connectToStudio', () => {
     await connectToStudio({ ...options, client: { kind: 'cli', version: '1.0.0', cwd: '/project', projectName: 'project' } }) // allowInput: false
 
     await mockWs.trigger('message', {
-      data: JSON.stringify({ type: 'command', command: 'generate', payload }),
+      data: JSON.stringify({ type: 'kubb:command', command: 'generate', payload }),
     })
 
     expect(consoleSpy.warn).toHaveBeenCalledWith(expect.stringContaining('--allowInput'))
@@ -533,7 +531,7 @@ describe('connectToStudio', () => {
     await connectToStudio({ ...options, allowInput: true })
 
     await mockWs.trigger('message', {
-      data: JSON.stringify({ type: 'command', command: 'generate', payload }),
+      data: JSON.stringify({ type: 'kubb:command', command: 'generate', payload }),
     })
 
     expect(generate).toHaveBeenCalledWith(
@@ -549,7 +547,7 @@ describe('connectToStudio', () => {
     await connectToStudio({ ...options, allowInput: true })
 
     await mockWs.trigger('message', {
-      data: JSON.stringify({ type: 'command', command: 'generate', payload }),
+      data: JSON.stringify({ type: 'kubb:command', command: 'generate', payload }),
     })
 
     expect(generate).toHaveBeenCalledWith(
@@ -565,7 +563,7 @@ describe('connectToStudio', () => {
     await connectToStudio({ ...options, allowExec: false })
 
     await mockWs.trigger('message', {
-      data: JSON.stringify({ type: 'command', command: 'generate', payload: { plugins: [] } }),
+      data: JSON.stringify({ type: 'kubb:command', command: 'generate', payload: { plugins: [] } }),
     })
 
     expect(generate).toHaveBeenCalledWith(
@@ -579,7 +577,7 @@ describe('connectToStudio', () => {
     await connectToStudio({ ...options, allowedPlugins: ['@kubb/plugin-ts'] })
 
     await mockWs.trigger('message', {
-      data: JSON.stringify({ type: 'command', command: 'generate', payload: { plugins: [{ name: 'evil-module', options: {} }] } }),
+      data: JSON.stringify({ type: 'kubb:command', command: 'generate', payload: { plugins: [{ name: 'evil-module', options: {} }] } }),
     })
 
     expect(generate).not.toHaveBeenCalled()
@@ -596,7 +594,7 @@ describe('connectToStudio', () => {
     await connectToStudio(options)
 
     await mockWs.trigger('message', {
-      data: JSON.stringify({ type: 'command', command: 'generate', payload }),
+      data: JSON.stringify({ type: 'kubb:command', command: 'generate', payload }),
     })
 
     const adapter = vi.mocked(generate).mock.calls[0]?.[0].config.adapter
@@ -613,7 +611,7 @@ describe('connectToStudio', () => {
     await connectToStudio(options)
 
     await mockWs.trigger('message', {
-      data: JSON.stringify({ type: 'command', command: 'generate', payload }),
+      data: JSON.stringify({ type: 'kubb:command', command: 'generate', payload }),
     })
 
     const call = vi.mocked(generate).mock.calls[0]?.[0]
@@ -632,7 +630,7 @@ describe('connectToStudio', () => {
     await connectToStudio(options)
 
     const first = mockWs.trigger('message', {
-      data: JSON.stringify({ type: 'command', command: 'generate' }),
+      data: JSON.stringify({ type: 'kubb:command', command: 'generate' }),
     })
 
     // Wait until `generate()` is actually in flight (loadConfig/mergePlugins/etc. resolve
@@ -641,7 +639,7 @@ describe('connectToStudio', () => {
     await vi.waitFor(() => expect(generate).toHaveBeenCalledTimes(1))
 
     const second = mockWs.trigger('message', {
-      data: JSON.stringify({ type: 'command', command: 'generate' }),
+      data: JSON.stringify({ type: 'kubb:command', command: 'generate' }),
     })
 
     resolveGenerate()
@@ -655,10 +653,10 @@ describe('connectToStudio', () => {
     await connectToStudio(options)
 
     await mockWs.trigger('message', {
-      data: JSON.stringify({ type: 'command', command: 'generate' }),
+      data: JSON.stringify({ type: 'kubb:command', command: 'generate' }),
     })
     await mockWs.trigger('message', {
-      data: JSON.stringify({ type: 'command', command: 'generate' }),
+      data: JSON.stringify({ type: 'kubb:command', command: 'generate' }),
     })
 
     expect(generate).toHaveBeenCalledTimes(2)
@@ -670,7 +668,7 @@ describe('connectToStudio', () => {
     await connectToStudio(options)
 
     await mockWs.trigger('message', {
-      data: JSON.stringify({ type: 'command', command: 'generate', payload: { plugins: [] } }),
+      data: JSON.stringify({ type: 'kubb:command', command: 'generate', payload: { plugins: [] } }),
     })
 
     const generationHooks = vi.mocked(setupEventsStream).mock.calls[0]?.[1]
@@ -686,13 +684,13 @@ describe('connectToStudio', () => {
     await connectToStudio(options)
 
     await mockWs.trigger('message', {
-      data: JSON.stringify({ type: 'command', command: 'connect' }),
+      data: JSON.stringify({ type: 'kubb:command', command: 'connect' }),
     })
 
     expect(sendAgentMessage).toHaveBeenCalledWith(
       mockWs,
       expect.objectContaining({
-        type: 'connected',
+        type: 'kubb:connected',
         payload: expect.objectContaining({
           versions: {
             kubb: '5.1.0-core-test',
@@ -709,7 +707,7 @@ describe('connectToStudio', () => {
     await connectToStudio({ ...options, allowWrite: true })
 
     await mockWs.trigger('message', {
-      data: JSON.stringify({ type: 'command', command: 'connect' }),
+      data: JSON.stringify({ type: 'kubb:command', command: 'connect' }),
     })
 
     expect(sendAgentMessage).toHaveBeenCalledWith(
@@ -731,7 +729,7 @@ describe('connectToStudio', () => {
     await connectToStudio({ ...options, allowInput: true })
 
     await mockWs.trigger('message', {
-      data: JSON.stringify({ type: 'command', command: 'connect' }),
+      data: JSON.stringify({ type: 'kubb:command', command: 'connect' }),
     })
 
     expect(sendAgentMessage).toHaveBeenCalledWith(
@@ -757,7 +755,7 @@ describe('connectToStudio', () => {
     await connectToStudio({ ...options, allowWrite: true })
 
     await sandboxWs.trigger('message', {
-      data: JSON.stringify({ type: 'command', command: 'connect' }),
+      data: JSON.stringify({ type: 'kubb:command', command: 'connect' }),
     })
 
     expect(sendAgentMessage).toHaveBeenCalledWith(
@@ -798,7 +796,7 @@ describe('connectToStudio', () => {
     await connectToStudio(options)
 
     await mockWs.trigger('message', {
-      data: JSON.stringify({ type: 'disconnect', reason: 'revoked' }),
+      data: JSON.stringify({ type: 'kubb:disconnect', reason: 'revoked' }),
     })
 
     expect(consoleSpy.warn).toHaveBeenCalledWith(expect.stringContaining('disconnected by Studio (revoked)'))
@@ -815,7 +813,7 @@ describe('connectToStudio', () => {
     await connectToStudio(options)
 
     await mockWs.trigger('message', {
-      data: JSON.stringify({ type: 'disconnect', reason: 'expired' }),
+      data: JSON.stringify({ type: 'kubb:disconnect', reason: 'expired' }),
     })
 
     expect(consoleSpy.warn).toHaveBeenCalledWith(expect.stringContaining('disconnected by Studio (expired)'))

--- a/packages/studio/src/connectStudio.ts
+++ b/packages/studio/src/connectStudio.ts
@@ -219,7 +219,7 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
       const config = await loadConfig()
 
       sendAgentMessage(ws, {
-        type: 'connected',
+        type: 'kubb:connected',
         payload: {
           versions: {
             kubb: kubbVersion,
@@ -308,7 +308,7 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
         return
       }
 
-      sendAgentMessage(ws, { type: 'ping' })
+      sendAgentMessage(ws, { type: 'kubb:ping' })
     }, heartbeatInterval)
 
     // Only `kubb:error` is ever fired on the connection emitter. Every generation event goes
@@ -425,13 +425,13 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
           }
 
           if (data.command === 'save') {
-            // Studio waits on a `config-saved` for every `save`, so every path out of this
+            // Studio waits on a `kubb:config-saved` for every `save`, so every path out of this
             // branch sends one. `edits` is checked before it is walked: the message crosses the same
             // trust boundary as the values inside it.
             if (!Array.isArray(data.edits)) {
               console.warn(styleText('yellow', `[${tag}] Ignored save from Studio: the message carried no edits`))
 
-              sendAgentMessage(ws, { type: 'config-saved', payload: { outcomes: [], changed: false } })
+              sendAgentMessage(ws, { type: 'kubb:config-saved', payload: { outcomes: [], changed: false } })
 
               return
             }
@@ -439,7 +439,7 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
             const edits = data.edits
             const refuse = (reason: string) =>
               sendAgentMessage(ws, {
-                type: 'config-saved',
+                type: 'kubb:config-saved',
                 payload: { outcomes: edits.map((edit) => ({ edit, applied: false, reason })), changed: false },
               })
 
@@ -472,7 +472,7 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
               }
 
               sendAgentMessage(ws, {
-                type: 'config-saved',
+                type: 'kubb:config-saved',
                 payload: { outcomes, changed, configFile: changed ? await readConfigFileView(patched) : undefined },
               })
 

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -1,5 +1,5 @@
-export { createClient, type Client, type ClientOptions } from './client.ts'
+export { createClient, type Client } from './client.ts'
 export { InvalidAgentTokenError } from './api.ts'
 export { defaultStudioUrl } from './constants.ts'
 export { createFileStorage, setStorage } from './machine.ts'
-export { pollForPairingToken, startPairing, type PairingResult, type PairingSession } from './pair.ts'
+export { pollForPairingToken, startPairing } from './pair.ts'

--- a/packages/studio/src/pair.test.ts
+++ b/packages/studio/src/pair.test.ts
@@ -24,11 +24,8 @@ const session: PairingSession = {
   interval: 1,
 }
 
-const createMockResponse = (data: unknown, ok = true, status = 200) => ({
-  ok,
-  status,
-  json: vi.fn(async () => data),
-})
+const createMockResponse = (data: unknown, status = 200) =>
+  new Response(data === undefined ? null : JSON.stringify(data), { status, headers: { 'Content-Type': 'application/json' } })
 
 beforeEach(() => {
   fetchMock.mockReset()
@@ -46,7 +43,7 @@ describe('pollForPairingToken', () => {
       token: 'agent-token',
       agent: { id: '1', slug: 'brave-otter', name: 'demo' },
     }
-    fetchMock.mockResolvedValueOnce(createMockResponse({ error: 'authorization_pending' }, false, 400)).mockResolvedValueOnce(createMockResponse(result))
+    fetchMock.mockResolvedValueOnce(createMockResponse({ error: 'authorization_pending' }, 400)).mockResolvedValueOnce(createMockResponse(result))
 
     const promise = pollForPairingToken({ studioUrl: 'http://studio', session })
     await vi.runAllTimersAsync()
@@ -55,7 +52,7 @@ describe('pollForPairingToken', () => {
   })
 
   it("surfaces Studio's error_description on access_denied", async () => {
-    fetchMock.mockResolvedValueOnce(createMockResponse({ error: 'access_denied', error_description: 'agent limit reached' }, false, 403))
+    fetchMock.mockResolvedValueOnce(createMockResponse({ error: 'access_denied', error_description: 'agent limit reached' }, 403))
 
     const promise = pollForPairingToken({ studioUrl: 'http://studio', session })
     promise.catch(() => {})
@@ -65,7 +62,7 @@ describe('pollForPairingToken', () => {
   })
 
   it('throws on an unexpected pairing error instead of spinning until expiry', async () => {
-    fetchMock.mockResolvedValueOnce(createMockResponse({ error: 'server_error', error_description: 'pairing store unavailable' }, false, 500))
+    fetchMock.mockResolvedValueOnce(createMockResponse({ error: 'server_error', error_description: 'pairing store unavailable' }, 500))
 
     const promise = pollForPairingToken({ studioUrl: 'http://studio', session })
     promise.catch(() => {})
@@ -75,7 +72,7 @@ describe('pollForPairingToken', () => {
   })
 
   it('throws when Studio returns an empty body', async () => {
-    fetchMock.mockResolvedValueOnce(createMockResponse(undefined, false, 500))
+    fetchMock.mockResolvedValueOnce(createMockResponse(undefined, 500))
 
     const promise = pollForPairingToken({ studioUrl: 'http://studio', session })
     promise.catch(() => {})

--- a/packages/studio/src/pair.ts
+++ b/packages/studio/src/pair.ts
@@ -1,8 +1,8 @@
 import { setTimeout as delay } from 'node:timers/promises'
 import { styleText } from 'node:util'
 import { getErrorMessage } from '@internals/utils'
+import { ofetch } from 'ofetch'
 import { agentDefaults } from './constants.ts'
-import { postJson } from './api.ts'
 import { getMachineToken } from './machine.ts'
 
 /**
@@ -76,7 +76,8 @@ export async function startPairing({
   clientId = CLIENT_ID,
   agentKind,
 }: StartPairingOptions): Promise<PairingSession> {
-  return postJson<PairingSession>(`${studioUrl}/api/auth/device/code`, {
+  return ofetch<PairingSession>(`${studioUrl}/api/auth/device/code`, {
+    method: 'POST',
     body: {
       client_id: clientId,
       name,
@@ -130,11 +131,12 @@ export async function pollForPairingToken({ studioUrl = agentDefaults.studioUrl,
 
     let response: PollResponse | undefined
     try {
-      response = await postJson<PollResponse | undefined>(`${studioUrl}/api/agent/token`, {
+      response = await ofetch<PollResponse | undefined>(`${studioUrl}/api/agent/token`, {
+        method: 'POST',
         body: { device_code: session.device_code },
         // A denial, an expiry, and "not yet" all come back as 4xx with a body the caller needs to
         // read, so let every response through and switch on `error` instead of catching.
-        allowErrorResponse: true,
+        ignoreResponseError: true,
       })
     } catch (error) {
       // Studio can go briefly unreachable (a deploy, a dropped connection) during the minutes the

--- a/packages/studio/src/protocol/index.test.ts
+++ b/packages/studio/src/protocol/index.test.ts
@@ -6,7 +6,7 @@ describe('agent protocol', () => {
   describe('message type guards', () => {
     it('identifies command messages', () => {
       const message: AgentMessage = {
-        type: 'command',
+        type: 'kubb:command',
         command: 'generate',
         payload: {},
       }
@@ -17,7 +17,7 @@ describe('agent protocol', () => {
 
     it('identifies data messages', () => {
       const message: AgentMessage = {
-        type: 'data',
+        type: 'kubb:data',
         payload: {
           type: 'kubb:info',
           data: [{ message: 'message' }],
@@ -34,7 +34,7 @@ describe('agent protocol', () => {
     })
 
     it('identifies a disconnect message and carries its reason', () => {
-      const message: AgentMessage = { type: 'disconnect', reason: 'revoked' }
+      const message: AgentMessage = { type: 'kubb:disconnect', reason: 'revoked' }
 
       expect(isDisconnectMessage(message)).toBe(true)
       expect(isCommandMessage(message)).toBe(false)

--- a/packages/studio/src/protocol/index.ts
+++ b/packages/studio/src/protocol/index.ts
@@ -1,8 +1,9 @@
 /**
- * WebSocket message types for the agent ↔ Studio protocol.
+ * WebSocket message types for the agent ↔ Studio protocol. Every message name is `kubb:`-prefixed,
+ * matching the generation hooks in {@link KubbHooks}, so one namespace covers the whole wire.
  *
- * - Studio → agent: `command` (generate, connect, save), `pong`, `disconnect`
- * - Agent → Studio: `connected`, `data`, `ping`, `config-saved`
+ * - Studio → agent: `kubb:command` (generate, connect, save), `kubb:pong`, `kubb:disconnect`
+ * - Agent → Studio: `kubb:connected`, `kubb:data`, `kubb:ping`, `kubb:config-saved`
  * - Either way: `kubb:error`
  */
 
@@ -219,17 +220,17 @@ export type CommandMessage =
   /**
    * Run a generation with the given config. `payload` is the merged config Studio wants generated.
    */
-  | { type: 'command'; command: 'generate'; payload: JSONKubbConfig }
+  | { type: 'kubb:command'; command: 'generate'; payload: JSONKubbConfig }
   /**
-   * Ask the agent to send a fresh `connected` payload. Permissions are fixed when the host starts
+   * Ask the agent to send a fresh `kubb:connected` payload. Permissions are fixed when the host starts
    * the agent; this message only triggers another read of disk config and saved Studio state.
    */
-  | { type: 'command'; command: 'connect' }
+  | { type: 'kubb:command'; command: 'connect' }
   /**
    * Change plugin options in the user's `kubb.config.ts`. Applied only when the agent was granted
    * `allowConfigEdit`; otherwise every edit comes back refused.
    */
-  | { type: 'command'; command: 'save'; edits: Array<ConfigEdit> }
+  | { type: 'kubb:command'; command: 'save'; edits: Array<ConfigEdit> }
 
 /**
  * Identifies the host running the Kubb runtime, so Studio can badge the connection and show the
@@ -255,7 +256,7 @@ export type ClientInfo = {
 }
 
 /**
- * Payload of the `connected` handshake the agent sends when it attaches to a session. Carries the
+ * Payload of the `kubb:connected` handshake the agent sends when it attaches to a session. Carries the
  * agent's on-disk config baseline, granted permissions, reported versions, and workspace paths.
  */
 export type ConnectMessagePayload = {
@@ -329,7 +330,7 @@ export type ConnectMessagePayload = {
  * Carries the on-disk config baseline, granted permissions, and paths Studio needs to render the editor.
  */
 export type ConnectedMessage = {
-  type: 'connected'
+  type: 'kubb:connected'
   payload: ConnectMessagePayload
 }
 
@@ -337,7 +338,7 @@ export type ConnectedMessage = {
  * Reply to a `save` command: what the agent did to the file on disk.
  */
 export type ConfigSavedMessage = {
-  type: 'config-saved'
+  type: 'kubb:config-saved'
   payload: {
     /**
      * Per-edit result, in the order the edits were sent.
@@ -369,14 +370,14 @@ export type ErrorMessage = {
  * Heartbeat sent by the Agent to Studio so the connection is not treated as idle.
  */
 export type PingMessage = {
-  type: 'ping'
+  type: 'kubb:ping'
 }
 
 /**
- * Studio's reply to a `ping`, confirming the connection is still alive.
+ * Studio's reply to a `kubb:ping`, confirming the connection is still alive.
  */
 export type PongMessage = {
-  type: 'pong'
+  type: 'kubb:pong'
 }
 
 /**
@@ -384,12 +385,12 @@ export type PongMessage = {
  * The agent should close the connection without reconnecting.
  */
 export type DisconnectMessage = {
-  type: 'disconnect'
+  type: 'kubb:disconnect'
   reason: 'expired' | 'revoked'
 }
 
 /**
- * Payload of a `data` message: a single Kubb generation event forwarded to Studio in real time.
+ * Payload of a `kubb:data` message: a single Kubb generation event forwarded to Studio in real time.
  * Generic over the hook name so `data` is typed to that hook's context tuple.
  */
 export type DataMessagePayload<T extends KubbHook = KubbHook> = {
@@ -415,10 +416,10 @@ export type DataMessagePayload<T extends KubbHook = KubbHook> = {
 
 /**
  * Envelope for a single generation event streamed from Agent to Studio. Wraps a
- * {@link DataMessagePayload} so both sides can switch on `type: 'data'`.
+ * {@link DataMessagePayload} so both sides can switch on `type: 'kubb:data'`.
  */
 export type DataMessage<T extends KubbHook = KubbHook> = {
-  type: 'data'
+  type: 'kubb:data'
   payload: DataMessagePayload<T>
 }
 
@@ -459,7 +460,7 @@ export type AgentConnectResponse = {
 export type AgentMessage = CommandMessage | DataMessage | ConnectedMessage | ConfigSavedMessage | ErrorMessage | PingMessage | PongMessage | DisconnectMessage
 
 export function isCommandMessage(msg: AgentMessage): msg is CommandMessage {
-  return msg.type === 'command'
+  return msg.type === 'kubb:command'
 }
 
 /**
@@ -474,13 +475,13 @@ export function isCommandMessage(msg: AgentMessage): msg is CommandMessage {
  * ```
  */
 export function isDataMessage<T extends KubbHook>(msg: AgentMessage, type?: T): msg is DataMessage<T> {
-  return msg.type === 'data' && (type ? msg.payload.type === type : true)
+  return msg.type === 'kubb:data' && (type ? msg.payload.type === type : true)
 }
 
 export function isPongMessage(msg: AgentMessage): msg is PongMessage {
-  return msg.type === 'pong'
+  return msg.type === 'kubb:pong'
 }
 
 export function isDisconnectMessage(msg: AgentMessage): msg is DisconnectMessage {
-  return msg.type === 'disconnect'
+  return msg.type === 'kubb:disconnect'
 }

--- a/packages/studio/src/resolveConfig.test.ts
+++ b/packages/studio/src/resolveConfig.test.ts
@@ -369,30 +369,23 @@ describe('toExportName', () => {
       '@kubb/plugin-vue-query',
       '@kubb/plugin-zod',
     ]
-    expect(Object.fromEntries(packages.map((name) => [name, toExportName(name)]))).toMatchInlineSnapshot(`
-      {
-        "@kubb/plugin-axios": "pluginAxios",
-        "@kubb/plugin-cypress": "pluginCypress",
-        "@kubb/plugin-faker": "pluginFaker",
-        "@kubb/plugin-fetch": "pluginFetch",
-        "@kubb/plugin-mcp": "pluginMcp",
-        "@kubb/plugin-msw": "pluginMsw",
-        "@kubb/plugin-react-query": "pluginReactQuery",
-        "@kubb/plugin-redoc": "pluginRedoc",
-        "@kubb/plugin-swr": "pluginSwr",
-        "@kubb/plugin-ts": "pluginTs",
-        "@kubb/plugin-vue-query": "pluginVueQuery",
-        "@kubb/plugin-zod": "pluginZod",
-      }
-    `)
+    expect(Object.fromEntries(packages.map((name) => [name, toExportName(name)]))).toStrictEqual({
+      '@kubb/plugin-axios': 'pluginAxios',
+      '@kubb/plugin-cypress': 'pluginCypress',
+      '@kubb/plugin-faker': 'pluginFaker',
+      '@kubb/plugin-fetch': 'pluginFetch',
+      '@kubb/plugin-mcp': 'pluginMcp',
+      '@kubb/plugin-msw': 'pluginMsw',
+      '@kubb/plugin-react-query': 'pluginReactQuery',
+      '@kubb/plugin-redoc': 'pluginRedoc',
+      '@kubb/plugin-swr': 'pluginSwr',
+      '@kubb/plugin-ts': 'pluginTs',
+      '@kubb/plugin-vue-query': 'pluginVueQuery',
+      '@kubb/plugin-zod': 'pluginZod',
+    })
   })
 
   it('derives a name for a plugin outside the @kubb scope', () => {
-    expect(['@acme/plugin-solid-query', 'kubb-plugin-custom'].map(toExportName)).toMatchInlineSnapshot(`
-      [
-        "pluginSolidQuery",
-        "kubbPluginCustom",
-      ]
-    `)
+    expect(['@acme/plugin-solid-query', 'kubb-plugin-custom'].map(toExportName)).toStrictEqual(['pluginSolidQuery', 'kubbPluginCustom'])
   })
 })

--- a/packages/studio/src/ws.ts
+++ b/packages/studio/src/ws.ts
@@ -75,7 +75,7 @@ export function sendAgentMessage(ws: WebSocket, message: AgentMessage): void {
  */
 export function sendErrorMessage(ws: WebSocket, error: Error): void {
   sendAgentMessage(ws, {
-    type: 'data',
+    type: 'kubb:data',
     payload: { type: 'kubb:error', data: [{ message: error.message, stack: error.stack }], timestamp: Date.now(), seq: nextEventSeq(ws) },
   })
 }
@@ -86,7 +86,7 @@ export function sendErrorMessage(ws: WebSocket, error: Error): void {
 export function setupEventsStream(ws: WebSocket, hooks: Hookable<AgentHooks>): void {
   function sendDataMessage(payload: Omit<DataMessagePayload, 'seq' | 'timestamp'>) {
     sendAgentMessage(ws, {
-      type: 'data',
+      type: 'kubb:data',
       payload: { ...payload, timestamp: Date.now(), seq: nextEventSeq(ws) },
     })
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,6 +355,9 @@ importers:
       magicast:
         specifier: ^0.5.3
         version: 0.5.3
+      ofetch:
+        specifier: ^1.5.1
+        version: 1.5.1
       remeda:
         specifier: ^2.42.0
         version: 2.45.0


### PR DESCRIPTION
## 🎯 Changes

Resolves the open review threads on #3936. Targets `feature/kubb-studio-cli-connect` so merging it folds the fixes into that PR.

**`credentials.json` as a const** ([r3922374306](https://github.com/kubb-labs/kubb/pull/3936#discussion_r3922374306))
Lifted into `CREDENTIALS_FILENAME` and exposed `getCredentialsPath()`. `run.ts` now names the file through it instead of rebuilding the path, so the literal appears once.

**Smaller `@kubb/studio` entry point** ([r3922736600](https://github.com/kubb-labs/kubb/pull/3936#discussion_r3922736600))
Dropped `ClientOptions`, `PairingResult`, and `PairingSession`. Neither the CLI nor the Docker agent (`apps/agent/server/plugins/studio.ts`) imports them. `createFileStorage` stays: the CLI uses it.

**`kubb:` on every message** ([r3922630741](https://github.com/kubb-labs/kubb/pull/3936#discussion_r3922630741))
`command`, `connected`, `data`, `config-saved`, `ping`, `pong`, and `disconnect` are now `kubb:`-prefixed, matching the generation hooks. Breaking protocol change, synced in kubb-labs/platform#TBD. The agent `status` column keeps its own values; it is not a wire message.

**Explicit assertions over snapshots** ([r3922675815](https://github.com/kubb-labs/kubb/pull/3936#discussion_r3922675815))
Converted 41 inline snapshots to `toStrictEqual` / `toBe` across `configFile`, `connectStudio`, `resolveConfig`, and the CLI's `run` tests. The 12 that remain assert whole generated config files, which is what the testing rule reserves snapshots for.

**`ofetch` for HTTP** ([r3922727429](https://github.com/kubb-labs/kubb/pull/3936#discussion_r3922727429))
`ofetch` encodes and parses JSON, throws on a non-2xx status, and carries `statusCode` on its `FetchError`, which is what `rejectedWith` already reads. That removed the `HttpError` class, and its `retry` / `retryDelay` removed the hand-written registration loop.

One behavior change worth a look: registration now retries a network failure or a 5xx, and no longer a 403. A 403 means Studio refused the machine token, so a second try with the same token cannot succeed.

The pairing poll loop in `pair.ts` stays hand-written. It decides from the response body (`authorization_pending`, `slow_down`, `access_denied`) rather than from a thrown error, and the server moves the interval mid-flight with `slow_down`. `p-retry` and `async-retry` fix their schedule at call time and retry on throw; `p-wait-for` and `promise-poller` have no fatal path. `openid-client` does implement RFC 8628, but it needs a real OIDC issuer config and this endpoint returns an agent bearer token, not an OAuth token response.

Net −135 lines.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

`@kubb/studio` 181 tests, `@kubb/cli` studio runner 7 tests, and kubb.studio 649 + agent 29 in the platform repo all pass. `oxlint` and `tsc` are clean on both.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

Two changesets: a minor for the protocol rename and a patch for the `ofetch` switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ouPMe76zX3JLqfeTy7cux

---
_Generated by [Claude Code](https://claude.ai/code/session_016ouPMe76zX3JLqfeTy7cux)_