### PR TITLE
fix: types for module resolution bundler

### DIFF
--- a/.changeset/tidy-plums-invent.md
+++ b/.changeset/tidy-plums-invent.md
@@ -1,0 +1,16 @@
+---
+'@kubb/adapter-oas': patch
+'@kubb/parser-md': patch
+'@kubb/kit': patch
+'@kubb/plugin-barrel': patch
+'unplugin-kubb': patch
+'kubb': patch
+'@kubb/renderer-jsx': patch
+'@kubb/cli': patch
+'@kubb/ast': patch
+'@kubb/parser-ts': patch
+'@kubb/core': patch
+'@kubb/mcp': patch
+---
+
+Explicit `types` fields for each package.json `exports` entry, so that it works with tsconfig.json `moduleResolution: 'bundler'`

--- a/internals/shared/package.json
+++ b/internals/shared/package.json
@@ -32,6 +32,7 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },

--- a/internals/shared/tsdown.config.ts
+++ b/internals/shared/tsdown.config.ts
@@ -4,7 +4,6 @@ const shared: Partial<UserConfig> = {
   platform: 'node',
   sourcemap: true,
   shims: true,
-  exports: true,
   fixedExtension: false,
   deps: {
     neverBundle: [/^@kubb\//],

--- a/internals/utils/package.json
+++ b/internals/utils/package.json
@@ -32,6 +32,7 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },

--- a/internals/utils/tsdown.config.ts
+++ b/internals/utils/tsdown.config.ts
@@ -4,7 +4,6 @@ const shared: Partial<UserConfig> = {
   platform: 'node',
   sourcemap: true,
   shims: true,
-  exports: true,
   fixedExtension: false,
   deps: {
     neverBundle: [/^@kubb\//],

--- a/packages/adapter-oas/package.json
+++ b/packages/adapter-oas/package.json
@@ -43,6 +43,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },

--- a/packages/adapter-oas/tsdown.config.ts
+++ b/packages/adapter-oas/tsdown.config.ts
@@ -8,7 +8,6 @@ const shared: Partial<UserConfig> = {
   platform: 'node',
   sourcemap: true,
   shims: true,
-  exports: true,
   deps: {
     neverBundle: [/^@kubb\//],
     alwaysBundle: [/@internals/],

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -39,10 +39,12 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
     "./types": {
+      "types": "./dist/types.d.ts",
       "import": "./dist/types.js",
       "require": "./dist/types.cjs"
     },

--- a/packages/ast/tsdown.config.ts
+++ b/packages/ast/tsdown.config.ts
@@ -11,7 +11,6 @@ const shared: Partial<UserConfig> = {
   platform: 'node',
   sourcemap: true,
   shims: true,
-  exports: true,
   fixedExtension: false,
   outputOptions: {
     keepNames: true,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -6,7 +6,6 @@ const shared: Partial<UserConfig> = {
   platform: 'node',
   sourcemap: true,
   shims: true,
-  exports: true,
   deps: {
     neverBundle: [/^@kubb\//],
     alwaysBundle: [/@internals/],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,10 +52,12 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
     "./mocks": {
+      "types": "./dist/mocks.d.ts",
       "import": "./dist/mocks.js",
       "require": "./dist/mocks.cjs"
     },

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -9,7 +9,6 @@ const shared: Partial<UserConfig> = {
   platform: 'node',
   sourcemap: true,
   shims: true,
-  exports: true,
   deps: {
     neverBundle: [/^@kubb\//, 'vitest'],
     alwaysBundle: [/@internals/],

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -43,10 +43,12 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
     "./testing": {
+      "types": "./dist/testing.d.ts",
       "import": "./dist/testing.js",
       "require": "./dist/testing.cjs"
     },

--- a/packages/kit/tsdown.config.ts
+++ b/packages/kit/tsdown.config.ts
@@ -9,7 +9,6 @@ const shared: Partial<UserConfig> = {
   platform: 'node',
   sourcemap: true,
   shims: true,
-  exports: true,
   deps: {
     neverBundle: [/^@kubb\//],
     alwaysBundle: [/@internals/],

--- a/packages/kubb/package.json
+++ b/packages/kubb/package.json
@@ -50,66 +50,82 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
     "./astro": {
+      "types": "./dist/astro.d.ts",
       "import": "./dist/astro.js",
       "require": "./dist/astro.cjs"
     },
     "./config": {
+      "types": "./dist/config.d.ts",
       "import": "./dist/config.js",
       "require": "./dist/config.cjs"
     },
     "./esbuild": {
+      "types": "./dist/esbuild.d.ts",
       "import": "./dist/esbuild.js",
       "require": "./dist/esbuild.cjs"
     },
     "./farm": {
+      "types": "./dist/farm.d.ts",
       "import": "./dist/farm.js",
       "require": "./dist/farm.cjs"
     },
     "./jsx": {
+      "types": "./dist/jsx.d.ts",
       "import": "./dist/jsx.js",
       "require": "./dist/jsx.cjs"
     },
     "./jsx/jsx-dev-runtime": {
+      "types": "./dist/jsx/jsx-dev-runtime.d.ts",
       "import": "./dist/jsx/jsx-dev-runtime.js",
       "require": "./dist/jsx/jsx-dev-runtime.cjs"
     },
     "./jsx/jsx-runtime": {
+      "types": "./dist/jsx/jsx-runtime.d.ts",
       "import": "./dist/jsx/jsx-runtime.js",
       "require": "./dist/jsx/jsx-runtime.cjs"
     },
     "./kit": {
+      "types": "./dist/kit.d.ts",
       "import": "./dist/kit.js",
       "require": "./dist/kit.cjs"
     },
     "./kit/testing": {
+      "types": "./dist/kit/testing.d.ts",
       "import": "./dist/kit/testing.js",
       "require": "./dist/kit/testing.cjs"
     },
     "./nuxt": {
+      "types": "./dist/nuxt.d.ts",
       "import": "./dist/nuxt.js",
       "require": "./dist/nuxt.cjs"
     },
     "./rolldown": {
+      "types": "./dist/rolldown.d.ts",
       "import": "./dist/rolldown.js",
       "require": "./dist/rolldown.cjs"
     },
     "./rollup": {
+      "types": "./dist/rollup.d.ts",
       "import": "./dist/rollup.js",
       "require": "./dist/rollup.cjs"
     },
     "./rspack": {
+      "types": "./dist/rspack.d.ts",
       "import": "./dist/rspack.js",
       "require": "./dist/rspack.cjs"
     },
     "./vite": {
+      "types": "./dist/vite.d.ts",
       "import": "./dist/vite.js",
       "require": "./dist/vite.cjs"
     },
     "./webpack": {
+      "types": "./dist/webpack.d.ts",
       "import": "./dist/webpack.js",
       "require": "./dist/webpack.cjs"
     },

--- a/packages/kubb/tsdown.config.ts
+++ b/packages/kubb/tsdown.config.ts
@@ -23,7 +23,6 @@ const shared: Partial<UserConfig> = {
   platform: 'node',
   sourcemap: true,
   shims: true,
-  exports: true,
   deps: {
     neverBundle: [/^@kubb\//],
     alwaysBundle: [/@internals/],

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -47,6 +47,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },

--- a/packages/mcp/tsdown.config.ts
+++ b/packages/mcp/tsdown.config.ts
@@ -8,7 +8,6 @@ const shared: Partial<UserConfig> = {
   platform: 'node',
   sourcemap: true,
   shims: true,
-  exports: true,
   deps: {
     neverBundle: [/^@kubb\//],
     alwaysBundle: [/@internals/],

--- a/packages/parser-md/package.json
+++ b/packages/parser-md/package.json
@@ -42,6 +42,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },

--- a/packages/parser-md/tsdown.config.ts
+++ b/packages/parser-md/tsdown.config.ts
@@ -8,7 +8,6 @@ const shared: Partial<UserConfig> = {
   platform: 'node',
   sourcemap: true,
   shims: true,
-  exports: true,
   deps: {
     neverBundle: [/^@kubb\//],
     alwaysBundle: [/@internals/],

--- a/packages/parser-ts/package.json
+++ b/packages/parser-ts/package.json
@@ -41,6 +41,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },

--- a/packages/parser-ts/tsdown.config.ts
+++ b/packages/parser-ts/tsdown.config.ts
@@ -8,7 +8,6 @@ const shared: Partial<UserConfig> = {
   platform: 'node',
   sourcemap: true,
   shims: true,
-  exports: true,
   deps: {
     neverBundle: [/^@kubb\//],
     alwaysBundle: [/@internals/],

--- a/packages/plugin-barrel/package.json
+++ b/packages/plugin-barrel/package.json
@@ -43,6 +43,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },

--- a/packages/plugin-barrel/tsdown.config.ts
+++ b/packages/plugin-barrel/tsdown.config.ts
@@ -8,7 +8,6 @@ const shared: Partial<UserConfig> = {
   platform: 'node',
   sourcemap: true,
   shims: true,
-  exports: true,
   deps: {
     neverBundle: [/^@kubb\//],
     alwaysBundle: [/@internals/],

--- a/packages/renderer-jsx/package.json
+++ b/packages/renderer-jsx/package.json
@@ -57,18 +57,22 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
     "./jsx-dev-runtime": {
+      "types": "./dist/jsx-dev-runtime.d.ts",
       "import": "./dist/jsx-dev-runtime.js",
       "require": "./dist/jsx-dev-runtime.cjs"
     },
     "./jsx-runtime": {
+      "types": "./dist/jsx-runtime.d.ts",
       "import": "./dist/jsx-runtime.js",
       "require": "./dist/jsx-runtime.cjs"
     },
     "./types": {
+      "types": "./dist/types.d.ts",
       "import": "./dist/types.js",
       "require": "./dist/types.cjs"
     },

--- a/packages/renderer-jsx/tsdown.config.ts
+++ b/packages/renderer-jsx/tsdown.config.ts
@@ -11,7 +11,6 @@ const shared: Partial<UserConfig> = {
   platform: 'node',
   sourcemap: true,
   shims: true,
-  exports: true,
   fixedExtension: false,
   outputOptions: {
     keepNames: true,

--- a/packages/unplugin-kubb/package.json
+++ b/packages/unplugin-kubb/package.json
@@ -56,50 +56,62 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
     "./astro": {
+      "types": "./dist/astro.d.ts",
       "import": "./dist/astro.js",
       "require": "./dist/astro.cjs"
     },
     "./esbuild": {
+      "types": "./dist/esbuild.d.ts",
       "import": "./dist/esbuild.js",
       "require": "./dist/esbuild.cjs"
     },
     "./farm": {
+      "types": "./dist/farm.d.ts",
       "import": "./dist/farm.js",
       "require": "./dist/farm.cjs"
     },
     "./nuxt": {
+      "types": "./dist/nuxt.d.ts",
       "import": "./dist/nuxt.js",
       "require": "./dist/nuxt.cjs"
     },
     "./rolldown": {
+      "types": "./dist/rolldown.d.ts",
       "import": "./dist/rolldown.js",
       "require": "./dist/rolldown.cjs"
     },
     "./rollup": {
+      "types": "./dist/rollup.d.ts",
       "import": "./dist/rollup.js",
       "require": "./dist/rollup.cjs"
     },
     "./rspack": {
+      "types": "./dist/rspack.d.ts",
       "import": "./dist/rspack.js",
       "require": "./dist/rspack.cjs"
     },
     "./types": {
+      "types": "./dist/types.d.ts",
       "import": "./dist/types.js",
       "require": "./dist/types.cjs"
     },
     "./unpluginFactory": {
+      "types": "./dist/unpluginFactory.d.ts",
       "import": "./dist/unpluginFactory.js",
       "require": "./dist/unpluginFactory.cjs"
     },
     "./vite": {
+      "types": "./dist/vite.d.ts",
       "import": "./dist/vite.js",
       "require": "./dist/vite.cjs"
     },
     "./webpack": {
+      "types": "./dist/webpack.d.ts",
       "import": "./dist/webpack.js",
       "require": "./dist/webpack.cjs"
     },

--- a/packages/unplugin-kubb/tsdown.config.ts
+++ b/packages/unplugin-kubb/tsdown.config.ts
@@ -6,7 +6,6 @@ const shared: Partial<UserConfig> = {
   platform: 'node',
   sourcemap: true,
   shims: true,
-  exports: true,
   deps: {
     neverBundle: [/^@kubb\//],
     alwaysBundle: [/@internals/],


### PR DESCRIPTION
## 🎯 Changes

Same bug as [kubb-labs/plugins#835](https://github.com/kubb-labs/plugins/pull/835), fixed here in the core `kubb` packages.

Each package's `exports` field declares `import`/`require` conditions but no `types` condition. Under `moduleResolution: "bundler"` or `"nodenext"`, TypeScript resolves types through the `exports` map, not the legacy top-level `types` field. A CJS consumer (matching the `require` condition) had no matching `.d.ts` to resolve against, since tsdown emits one shared declaration file rather than a separate `.d.cts`, and got `TS7016: Could not find a declaration file for module`.

Reproduced this locally with a minimal `tsc` check before fixing: a `require`-only consumer under `moduleResolution: "bundler"` failed to find types until an explicit `"types"` condition was added.

Fixes:
- Add an explicit `"types"` entry (first key, as TypeScript requires) to every `exports` subpath across `packages/*` and `internals/*` that declares `import`/`require` conditions.
- Remove `exports: true` from each `tsdown.config.ts`, since it regenerates the `exports` block on every build and was stripping the `types` key back out.

Verified: `npx tsdown` in `internals/utils` keeps `"types"` in `package.json` after the build, where it was previously wiped.

`stijnvanhulle/template` uses the same tsdown setup but wasn't affected — its packages are ESM-only with a plain string `exports` target, so TypeScript's implicit `.d.ts` lookup already works there.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJ5SHC9nQtactNHkNuEpwM

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJ5SHC9nQtactNHkNuEpwM)_