### PR TITLE
fix(ci): stop chaining commands in changesets/action version-script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Keeps tools/claude/.claude-plugin/plugin.json's version in step with the
           # @kubb/claude-plugin package.json that Changesets bumps.
-          version-script: pnpm exec changeset version && pnpm run sync:plugin-version
+          # changesets/action runs this without a shell, so `&&` can't chain
+          # commands here — pnpm run does its own shell chaining instead.
+          version-script: pnpm run release:version
 
       # Canary skips staging on purpose, so it stays automatic on every push.
       - name: Publish canary

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "graph": "npx nx graph ",
     "lint": "oxlint -c oxlint.config.ts ./packages",
     "lint:fix": "oxlint -c oxlint.config.ts --fix ./packages",
+    "release:version": "changeset version && pnpm run sync:plugin-version",
     "start": "turbo run start --filter=./packages/*",
     "sync:plugin-version": "node scripts/sync-plugin-version.mjs",
     "test": "vitest run --config ./configs/vitest.config.ts",


### PR DESCRIPTION
## 🎯 Changes

The Release workflow failed with `CACError: Unused args: &&, pnpm, run, sync:plugin-version`.

`changesets/action` runs `version-script` through `@actions/exec`, which does not spawn a shell. The workflow's `version-script: pnpm exec changeset version && pnpm run sync:plugin-version` was tokenized literally, so `&&` and the rest got passed as positional arguments to the `changeset version` CLI instead of chaining two commands.

Fix: move the chain into a new `release:version` pnpm script (`changeset version && pnpm run sync:plugin-version`), which pnpm runs through a real shell, and point `version-script` at `pnpm run release:version`.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).

Only CI config and the root `package.json` scripts changed; no published package changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSjgfZiACKnAwUKVwgDqzk

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSjgfZiACKnAwUKVwgDqzk)_