### PR TITLE
fix(release): link unplugin-kubb back into the fixed version group

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,7 +7,7 @@
     }
   ],
   "commit": false,
-  "fixed": [["@kubb/*", "kubb"]],
+  "fixed": [["@kubb/*", "kubb", "unplugin-kubb"]],
   "linked": [],
   "access": "restricted",
   "baseBranch": "main",

--- a/packages/unplugin-kubb/package.json
+++ b/packages/unplugin-kubb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unplugin-kubb",
-  "version": "5.0.35",
+  "version": "5.1.0",
   "description": "Integration of Kubb for Vite, Webpack, Rollup, esbuild, Rspack, Nuxt, and Astro.",
   "keywords": [
     "astro",


### PR DESCRIPTION
## 🎯 Changes

`unplugin-kubb` was pulled out of the `@kubb/*` / `kubb` fixed release group in #3940 to clear a range of squatted, pre-monorepo npm versions. Since then it has released on its own version track (5.0.31 → 5.0.35) while the rest of the group moved on to 5.1.0.

This PR:
- Adds `unplugin-kubb` back to the `fixed` group in `.changeset/config.json`.
- Bumps `packages/unplugin-kubb/package.json` from `5.0.35` to `5.1.0` to align its baseline with the rest of the group.

Once merged, the next release publishes `unplugin-kubb@5.1.0` alongside `kubb` and `@kubb/*`, and it stays in lockstep with them going forward.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

No changeset is included on purpose: the version bump is a direct baseline correction, not a semver-driven change. Adding a changeset here would force a synchronized patch release across the whole fixed group (e.g. 5.1.0 → 5.1.1) as a side effect of this fix. `changeset publish` picks up the manual `5.1.0` bump on `unplugin-kubb` and publishes it directly since it now exceeds the version on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wqSZp5UgGc9vYZGmnMTVP


---
_Generated by [Claude Code](https://claude.ai/code/session_017wqSZp5UgGc9vYZGmnMTVP)_