### PR TITLE
feat(studio): add protocol and WebSocket client core

### DIFF
--- a/.changeset/studio-directional-protocol.md
+++ b/.changeset/studio-directional-protocol.md
@@ -1,0 +1,53 @@
+---
+'@kubb/studio': minor
+'@kubb/core': minor
+'@kubb/cli': patch
+---
+
+Name every Studio WebSocket message after the side that sends it
+
+The protocol had grown three ways to encode direction in a verb: `connect` was answered by
+`connected`, `save` by `config-saved`, and `ping` by `pong`. Now the name carries the sender, so the
+verb only carries the topic.
+
+| Before | After |
+| --- | --- |
+| `kubb:command` + `command: 'generate' \| 'connect' \| 'save'` | `studio:generate`, `studio:connect`, `studio:save` |
+| `kubb:connected` | `agent:connect` |
+| `kubb:config-saved` | `agent:save` |
+| `kubb:data` | `agent:data` |
+| `kubb:ping` | `agent:ping` |
+| `kubb:pong` | `studio:ping` |
+| `kubb:disconnect` | `studio:disconnect` |
+| `kubb:error` (envelope) | `studio:error` |
+
+`kubb:` now means one thing, generation lifecycle. The events relayed inside an `agent:data` payload
+keep their own names, so the envelope says who sent it and the payload says what happened.
+
+The three commands are their own message types, so a handler switches once instead of reading a
+`type` and then a nested `command` field. `isCommandMessage` still gates the whole branch.
+
+`agent:disconnect` is new, the mirror of `studio:disconnect`. The agent announces a shutdown so
+Studio drops the session instead of waiting out the heartbeat window. Only a shutdown sends it,
+since an expired or revoked session was Studio's own decision.
+
+Both sides now report a version. `studio:connect` carries Studio's, `agent:connect` always carries
+the runtime's and the host's, and the host prints both, so a mismatch is visible in the terminal
+rather than only in the UI.
+
+The connect payload is smaller. Everything about the config sits under one `config` key (`path`,
+`file`, `plugins`), and `client` is off the wire, which also stops sending the host's absolute
+working directory. `ClientInfo` stays as a local option that picks which remedy a refused-input
+warning suggests.
+
+For anyone embedding `@kubb/studio` rather than using the CLI, the runtime no longer writes to the
+console. Pass `installLogger` to `createClient` to render the session. It is called once for the
+session emitter and once per generation, so one function covers both. Session events arrive on the
+`studio:*` hooks now declared in `@kubb/core`, and never reach the wire.
+
+Two packaging fixes came out of this. `@kubb/studio` and `@kubb/core` had no `types` condition in
+their `exports` maps, so under `node16` or `nodenext` resolution a consumer got
+"Could not find a declaration file" for both the root entry and `@kubb/studio/protocol`.
+
+A Studio instance has to speak the new names, so update both sides together. There is no
+compatibility path for the old ones.

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -1,0 +1,84 @@
+{
+  "name": "@kubb/studio",
+  "version": "5.0.3",
+  "description": "Kubb Studio client runtime. Connects a Kubb project to Kubb Studio over WebSocket and streams code generation events, shared by the `kubb studio` CLI command and the Docker agent.",
+  "keywords": [
+    "agent",
+    "codegen",
+    "kubb",
+    "openapi",
+    "studio",
+    "typescript",
+    "websocket"
+  ],
+  "homepage": "https://kubb.dev",
+  "license": "MIT",
+  "author": "stijnvanhulle",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kubb-labs/kubb.git",
+    "directory": "packages/studio"
+  },
+  "funding": [
+    {
+      "type": "github",
+      "url": "https://github.com/sponsors/stijnvanhulle"
+    },
+    {
+      "type": "opencollective",
+      "url": "https://opencollective.com/kubb"
+    }
+  ],
+  "files": [
+    "dist",
+    "!/**/**.test.**",
+    "!/**/__tests__/**",
+    "!/**/__snapshots__/**"
+  ],
+  "type": "module",
+  "sideEffects": false,
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./protocol": {
+      "import": "./dist/protocol.js",
+      "require": "./dist/protocol.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "clean": "node -e \"require('node:fs').rmSync('./dist', {recursive:true,force:true})\"",
+    "lint": "oxlint .",
+    "lint:fix": "oxlint --fix .",
+    "start": "tsdown --watch",
+    "test": "vitest --passWithNoTests",
+    "typecheck": "tsc -p ./tsconfig.json --noEmit --emitDeclarationOnly false"
+  },
+  "dependencies": {
+    "@kubb/core": "workspace:*",
+    "magicast": "^0.5.4",
+    "ofetch": "^1.5.1",
+    "remeda": "^2.45.0",
+    "tinyexec": "catalog:",
+    "unstorage": "^1.17.5",
+    "ws": "^8.21.3"
+  },
+  "devDependencies": {
+    "@internals/utils": "workspace:*",
+    "@kubb/adapter-oas": "workspace:*",
+    "@types/ws": "^8.18.1"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/studio/src/console.mock.ts
+++ b/packages/studio/src/console.mock.ts
@@ -1,0 +1,17 @@
+import { vi } from 'vitest'
+
+/**
+ * Studio writes to the console, so the console is what tests observe. Spying beats mocking the
+ * internal module: it asserts the output a person actually sees, and cannot silently stop applying
+ * when the module moves.
+ */
+export function spyOnConsole() {
+  return {
+    debug: vi.spyOn(console, 'debug').mockImplementation(() => {}),
+    info: vi.spyOn(console, 'info').mockImplementation(() => {}),
+    log: vi.spyOn(console, 'log').mockImplementation(() => {}),
+    warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+    error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+    table: vi.spyOn(console, 'table').mockImplementation(() => {}),
+  }
+}

--- a/packages/studio/src/constants.ts
+++ b/packages/studio/src/constants.ts
@@ -1,0 +1,20 @@
+/**
+ * Hosted Kubb Studio URL. Exported so credential stores can bind tokens to the resolved instance,
+ * not whatever default the client would pick on its own.
+ */
+export const defaultStudioUrl = 'https://kubb.studio'
+
+/**
+ * Defaults the Studio client uses when a host passes nothing.
+ * Config path is left out on purpose: each host discovers that itself.
+ */
+export const agentDefaults = {
+  studioUrl: defaultStudioUrl,
+  retryIntervalMs: 30_000,
+  /**
+   * Maximum heartbeat interval. Studio drops agents from the active list after ~90s without a ping,
+   * so a slower override would make a healthy agent look dead.
+   */
+  heartbeatIntervalMs: 30_000,
+  poolSize: 1,
+} as const

--- a/packages/studio/src/hooks.test.ts
+++ b/packages/studio/src/hooks.test.ts
@@ -1,0 +1,126 @@
+import { Hookable } from '@kubb/core'
+import type { AgentHooks } from './hooks.ts'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setupHookListener } from './hooks.ts'
+
+vi.mock('tinyexec', () => ({
+  x: vi.fn(),
+}))
+
+import { x } from 'tinyexec'
+
+type FakeProcOptions = {
+  lines?: Array<string>
+  exitCode?: number
+  stdout?: string
+  stderr?: string
+}
+
+/**
+ * Builds a stand-in for tinyexec's `Result`: an object that is both async-iterable over
+ * stdout lines and awaitable to the final `{ stdout, stderr, exitCode }` output.
+ */
+function fakeProc({ lines = [], exitCode = 0, stdout = '', stderr = '' }: FakeProcOptions = {}) {
+  return {
+    async *[Symbol.asyncIterator]() {
+      for (const line of lines) {
+        yield line
+      }
+    },
+    then(onFulfilled: (value: { stdout: string; stderr: string; exitCode: number }) => unknown) {
+      return Promise.resolve({ stdout, stderr, exitCode }).then(onFulfilled)
+    },
+  }
+}
+
+describe('setupHookListener', () => {
+  let hooks: Hookable<AgentHooks>
+
+  beforeEach(() => {
+    hooks = new Hookable<AgentHooks>()
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    hooks.removeAllHooks()
+  })
+
+  it('skips execution when hook:start fires without an id', async () => {
+    setupHookListener(hooks, '/root')
+
+    await hooks.callHook('kubb:hook:start', { id: undefined as any, command: 'echo', args: [] })
+
+    expect(x).not.toHaveBeenCalled()
+  })
+
+  it('emits hook:end with success when command exits zero', async () => {
+    vi.mocked(x).mockReturnValue(fakeProc({ lines: ['output'], exitCode: 0 }) as any)
+
+    setupHookListener(hooks, '/root')
+
+    const hookEndSpy = vi.fn()
+    hooks.hook('kubb:hook:end', hookEndSpy)
+
+    await hooks.callHook('kubb:hook:start', { id: 'test-id', command: 'echo', args: ['hello'] })
+
+    expect(hookEndSpy).toHaveBeenCalledWith(expect.objectContaining({ id: 'test-id', command: 'echo', args: ['hello'], success: true, error: null }))
+  })
+
+  it('streams each stdout line as a hook:line event', async () => {
+    vi.mocked(x).mockReturnValue(fakeProc({ lines: ['first', 'second'], exitCode: 0 }) as any)
+
+    setupHookListener(hooks, '/root')
+
+    const lineSpy = vi.fn()
+    hooks.hook('kubb:hook:line', lineSpy)
+
+    await hooks.callHook('kubb:hook:start', { id: 'stream-id', command: 'oxlint', args: [] })
+
+    expect(lineSpy).toHaveBeenNthCalledWith(1, { id: 'stream-id', line: 'first' })
+    expect(lineSpy).toHaveBeenNthCalledWith(2, { id: 'stream-id', line: 'second' })
+  })
+
+  it('emits hook:end failure and an error on non-zero exit', async () => {
+    vi.mocked(x).mockReturnValue(fakeProc({ lines: ['boom'], exitCode: 1, stdout: 'boom', stderr: 'parse error' }) as any)
+
+    setupHookListener(hooks, '/root')
+
+    const hookEndSpy = vi.fn()
+    const errorSpy = vi.fn()
+    hooks.hook('kubb:hook:end', hookEndSpy)
+    hooks.hook('kubb:error', errorSpy)
+
+    await hooks.callHook('kubb:hook:start', { id: 'fail-id', command: 'oxlint', args: ['--fix'] })
+
+    expect(hookEndSpy).toHaveBeenCalledWith(expect.objectContaining({ id: 'fail-id', success: false, error: expect.any(Error) }))
+    expect(errorSpy).toHaveBeenCalledWith(expect.objectContaining({ error: expect.objectContaining({ message: 'Hook execute failed: oxlint --fix' }) }))
+  })
+
+  it('emits hook:end failure and error when spawning throws', async () => {
+    vi.mocked(x).mockImplementation(() => {
+      throw new Error('command not found')
+    })
+
+    setupHookListener(hooks, '/root')
+
+    const hookEndSpy = vi.fn()
+    const errorSpy = vi.fn()
+    hooks.hook('kubb:hook:end', hookEndSpy)
+    hooks.hook('kubb:error', errorSpy)
+
+    await hooks.callHook('kubb:hook:start', { id: 'throw-id', command: 'nonexistent', args: [] })
+
+    expect(hookEndSpy).toHaveBeenCalledWith(expect.objectContaining({ id: 'throw-id', success: false, error: expect.any(Error) }))
+    expect(errorSpy).toHaveBeenCalledWith(expect.objectContaining({ error: expect.objectContaining({ message: 'Hook execute failed: nonexistent' }) }))
+  })
+
+  it('passes the root as cwd to tinyexec', async () => {
+    vi.mocked(x).mockReturnValue(fakeProc({ exitCode: 0 }) as any)
+
+    setupHookListener(hooks, '/my/project/root')
+
+    await hooks.callHook('kubb:hook:start', { id: 'cwd-id', command: 'npm', args: ['run', 'lint'] })
+
+    expect(x).toHaveBeenCalledWith('npm', ['run', 'lint'], expect.objectContaining({ nodeOptions: expect.objectContaining({ cwd: '/my/project/root' }) }))
+  })
+})

--- a/packages/studio/src/hooks.ts
+++ b/packages/studio/src/hooks.ts
@@ -1,11 +1,101 @@
-import type { Hookable, KubbHooks, StudioHooks } from '@kubb/core'
+import type { Hookable, KubbHooks } from '@kubb/core'
 import { x } from 'tinyexec'
 
 /**
- * Event bus shared with `createKubb`. Core emits its generation lifecycle events here, and the
- * `studio:*` session events ride alongside them, so one logger renders the whole connection.
+ * Events a host emits about its Kubb Studio session, as opposed to a generation. `kubb:` stays
+ * reserved for generation lifecycle.
  */
-export type AgentHooks = KubbHooks & StudioHooks
+export type StudioConnectingContext = {
+  /**
+   * The Studio instance this session is opening against.
+   */
+  url: string
+}
+
+export type StudioConnectedContext = {
+  /**
+   * The Studio instance this session attached to.
+   */
+  url: string
+  /**
+   * Both sides of the connection, so a host can print them and make a mismatch visible.
+   */
+  versions: {
+    /**
+     * The Studio instance's own version, when it sent one.
+     */
+    studio?: string
+    /**
+     * The version of the runtime that connected.
+     */
+    kubb: string
+    /**
+     * The version of the host itself, such as the `kubb` CLI or the agent image.
+     */
+    agent: string
+  }
+}
+
+export type StudioDisconnectedContext = {
+  /**
+   * Why Studio ended the session.
+   */
+  reason: string
+}
+
+export type StudioCommandStartContext = {
+  /**
+   * The command Studio sent, without its `studio:` prefix: `generate`, `connect` or `save`.
+   */
+  command: string
+}
+
+export type StudioCommandEndContext = {
+  /**
+   * The command that finished, without its `studio:` prefix.
+   */
+  command: string
+  /**
+   * What the command did, when there is something to report: `applied 2/3 edits to kubb.config.ts`.
+   */
+  info?: string
+}
+
+export type StudioWarnContext = {
+  /**
+   * What was refused or ignored, and what would change it.
+   */
+  message: string
+}
+
+export type StudioErrorContext = {
+  /**
+   * The failure, for the host's own output. One Studio needs to hear about goes over the socket
+   * through the `kubb:error` generation hook instead.
+   */
+  error: Error
+}
+
+declare global {
+  namespace Kubb {
+    interface KubbHooksRegistry {
+      'studio:connecting': [ctx: StudioConnectingContext]
+      'studio:connected': [ctx: StudioConnectedContext]
+      'studio:disconnected': [ctx: StudioDisconnectedContext]
+      'studio:command:start': [ctx: StudioCommandStartContext]
+      'studio:command:end': [ctx: StudioCommandEndContext]
+      'studio:warn': [ctx: StudioWarnContext]
+      'studio:error': [ctx: StudioErrorContext]
+    }
+  }
+}
+
+/**
+ * Event bus shared with `createKubb`. Core emits its generation lifecycle events here, and the
+ * `studio:*` session events this package adds to {@link KubbHooks} ride alongside them, so one
+ * logger renders the whole connection.
+ */
+export type AgentHooks = KubbHooks
 
 /**
  * Register a `kubb:hook:start` listener that spawns the requested command via tinyexec,

--- a/packages/studio/src/hooks.ts
+++ b/packages/studio/src/hooks.ts
@@ -1,0 +1,76 @@
+import type { Hookable, KubbHooks, StudioHooks } from '@kubb/core'
+import { x } from 'tinyexec'
+
+/**
+ * Event bus shared with `createKubb`. Core emits its generation lifecycle events here, and the
+ * `studio:*` session events ride alongside them, so one logger renders the whole connection.
+ */
+export type AgentHooks = KubbHooks & StudioHooks
+
+/**
+ * Register a `kubb:hook:start` listener that spawns the requested command via tinyexec,
+ * streams each stdout line as a `kubb:hook:line` event, and calls `kubb:hook:end` with the result.
+ * Streaming the output lets Kubb Studio render live hook progress over the WebSocket connection.
+ */
+export function setupHookListener(hooks: Hookable<AgentHooks>, root: string): void {
+  hooks.hook('kubb:hook:start', async (ctx) => {
+    const { id, command, args } = ctx
+    // No id means nothing is waiting on the result (benchmarks, tests).
+    if (!id) {
+      return
+    }
+
+    const commandWithArgs = args?.length ? `${command} ${args.join(' ')}` : command
+
+    try {
+      const proc = x(command, [...(args ?? [])], {
+        nodeOptions: { cwd: root, detached: true },
+      })
+
+      for await (const line of proc) {
+        await hooks.callHook('kubb:hook:line', { id, line })
+      }
+
+      const { exitCode } = await proc
+
+      if (exitCode !== 0) {
+        const error = new Error(`Hook execute failed: ${commandWithArgs}`)
+
+        await hooks.callHook('kubb:hook:end', { id, command, args, success: false, error })
+        await hooks.callHook('kubb:error', { error })
+
+        return
+      }
+
+      await hooks.callHook('kubb:hook:end', { id, command, args, success: true, error: null })
+    } catch (caughtError) {
+      const error = new Error(`Hook execute failed: ${commandWithArgs}`)
+      error.cause = caughtError
+
+      await hooks.callHook('kubb:hook:end', { id, command, args, success: false, error })
+      await hooks.callHook('kubb:error', { error })
+    }
+  })
+}
+
+/**
+ * Waits for the `kubb:hook:end` matching `hookId`. Register this before calling `kubb:hook:start`:
+ * `callHook` awaits its listeners, and {@link setupHookListener} calls `kubb:hook:end` from inside
+ * that same listener, so a handler added afterward would already have missed it.
+ */
+export function waitForHookEnd(hooks: Hookable<AgentHooks>, hookId: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const handleHookEnd = (ctx: { id?: string; success: boolean; error?: Error | null }) => {
+      if (ctx.id !== hookId) return
+      hooks.removeHook('kubb:hook:end', handleHookEnd)
+
+      if (ctx.success) {
+        resolve()
+      } else {
+        reject(ctx.error)
+      }
+    }
+
+    hooks.hook('kubb:hook:end', handleHookEnd)
+  })
+}

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -1,0 +1,3 @@
+export type { AgentHooks } from './hooks.ts'
+export { defaultStudioUrl } from './constants.ts'
+export { createFileStorage, setStorage } from './machine.ts'

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -1,3 +1,12 @@
-export type { AgentHooks } from './hooks.ts'
+export type {
+  AgentHooks,
+  StudioCommandEndContext,
+  StudioCommandStartContext,
+  StudioConnectedContext,
+  StudioConnectingContext,
+  StudioDisconnectedContext,
+  StudioErrorContext,
+  StudioWarnContext,
+} from './hooks.ts'
 export { defaultStudioUrl } from './constants.ts'
 export { createFileStorage, setStorage } from './machine.ts'

--- a/packages/studio/src/machine.test.ts
+++ b/packages/studio/src/machine.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { hash } from 'node:crypto'
+import type { Storage } from 'unstorage'
+
+// Silence the deliberate warning path so it does not pollute test output.
+vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+const store = new Map<string, unknown>()
+const mockStorage = {
+  getItem: vi.fn(async (key: string) => store.get(key) ?? null),
+  setItem: vi.fn(async (key: string, value: unknown) => {
+    store.set(key, value)
+  }),
+}
+
+// `token.ts` caches the fallback secret per module instance, so a "restart" means resetting
+// modules. The storage module resets with it, hence re-installing the mock on every fresh import.
+async function importFreshToken() {
+  const { setStorage } = await import('./machine.ts')
+  setStorage(mockStorage as unknown as Storage)
+
+  const module = await import('./machine.ts')
+  return module.getMachineToken
+}
+
+describe('getMachineToken', () => {
+  const originalSecret = process.env.KUBB_AGENT_SECRET
+
+  beforeEach(() => {
+    delete process.env.KUBB_AGENT_SECRET
+    store.clear()
+    mockStorage.getItem.mockClear()
+    mockStorage.setItem.mockClear()
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    if (originalSecret !== undefined) {
+      process.env.KUBB_AGENT_SECRET = originalSecret
+    } else {
+      delete process.env.KUBB_AGENT_SECRET
+    }
+  })
+
+  it('returns a 64-character hex string', async () => {
+    const getMachineToken = await importFreshToken()
+
+    await expect(getMachineToken()).resolves.toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it('returns a consistent value when KUBB_AGENT_SECRET is not set', async () => {
+    const getMachineToken = await importFreshToken()
+
+    await expect(getMachineToken()).resolves.toBe(await getMachineToken())
+  })
+
+  it('returns a deterministic value derived from KUBB_AGENT_SECRET without touching storage', async () => {
+    process.env.KUBB_AGENT_SECRET = 'my-secret'
+    const getMachineToken = await importFreshToken()
+
+    await expect(getMachineToken()).resolves.toBe(hash('sha256', 'my-secret'))
+    expect(mockStorage.getItem).not.toHaveBeenCalled()
+  })
+
+  it('returns a different value for different KUBB_AGENT_SECRET values', async () => {
+    const getMachineToken = await importFreshToken()
+
+    process.env.KUBB_AGENT_SECRET = 'secret-a'
+    const tokenA = await getMachineToken()
+
+    process.env.KUBB_AGENT_SECRET = 'secret-b'
+    const tokenB = await getMachineToken()
+
+    expect(tokenA).not.toBe(tokenB)
+  })
+
+  it('persists the generated fallback secret to storage on first use', async () => {
+    const getMachineToken = await importFreshToken()
+
+    await getMachineToken()
+
+    expect(mockStorage.setItem).toHaveBeenCalledWith('machine-secret', expect.stringMatching(/^[a-f0-9]{64}$/))
+  })
+
+  it('returns the same token across restarts by reusing the persisted secret', async () => {
+    const getMachineToken = await importFreshToken()
+    const firstToken = await getMachineToken()
+
+    // Simulate a process restart: fresh module state, same value in storage
+    vi.resetModules()
+    const freshGetMachineToken = await importFreshToken()
+
+    await expect(freshGetMachineToken()).resolves.toBe(firstToken)
+  })
+
+  it('still returns a stable in-process token when persisting fails', async () => {
+    mockStorage.setItem.mockRejectedValueOnce(new Error('EACCES'))
+    const getMachineToken = await importFreshToken()
+
+    await expect(getMachineToken()).resolves.toBe(await getMachineToken())
+  })
+})

--- a/packages/studio/src/machine.ts
+++ b/packages/studio/src/machine.ts
@@ -1,0 +1,85 @@
+import { hash, randomBytes } from 'node:crypto'
+import process from 'node:process'
+import { styleText } from 'node:util'
+import { createStorage, type Storage } from 'unstorage'
+import fsDriver from 'unstorage/drivers/fs'
+
+/**
+ * Key-value storage the runtime uses for its machine secret and the last Studio config.
+ *
+ * One storage per process, since one process serves one config file. Hosts install their own
+ * driver on startup: Nitro passes its `kubb` mount, the CLI an fs driver under `~/.kubb/cache`.
+ * The in-memory default keeps the runtime usable without a host, at the cost of a machine
+ * identity that changes on every restart.
+ */
+let storage: Storage = createStorage()
+let hasInstalledStorage = false
+
+/**
+ * Installs the storage driver the runtime persists to. Call once, before connecting.
+ */
+export function setStorage(next: Storage): void {
+  storage = next
+  hasInstalledStorage = true
+}
+
+/**
+ * A storage backed by files under `base`, so the machine secret and the last Studio config
+ * survive a restart. Repeated pairings of one machine depend on that secret staying put.
+ */
+export function createFileStorage(base: string): Storage {
+  return createStorage({ driver: fsDriver({ base }) })
+}
+
+let fallbackSecretPromise: Promise<string> | null = null
+
+/**
+ * Loads the fallback machine secret from the runtime storage.
+ * On first use it generates a secret and persists it, so the machine identity stays
+ * stable across restarts. An identity that changes on every boot breaks session
+ * creation with Studio whenever the startup registration call fails.
+ */
+async function loadOrCreateFallbackSecret(): Promise<string> {
+  // The secret is memoized for the life of the process, so a host that reads the machine token
+  // before installing its storage is bound to the throwaway in-memory default. Nothing else
+  // surfaces that: the write succeeds, and the identity silently changes on every restart, which
+  // Studio rejects with a 403 on the next session create.
+  if (!hasInstalledStorage) {
+    console.warn(
+      styleText('yellow', 'Deriving the machine token before a storage driver was installed'),
+      'call setStorage() first, or set KUBB_AGENT_SECRET, to keep a stable machine identity across restarts',
+    )
+  }
+
+  const stored = await storage.getItem('machine-secret').catch(() => null)
+
+  if (typeof stored === 'string' && stored) {
+    return stored
+  }
+
+  const secret = randomBytes(32).toString('hex')
+
+  await storage.setItem('machine-secret', secret).catch(() => {
+    console.warn(
+      styleText('yellow', 'Could not persist the generated machine secret'),
+      'set KUBB_AGENT_SECRET to keep a stable machine identity across restarts',
+    )
+  })
+
+  return secret
+}
+
+/**
+ * Returns the machine token derived from the `KUBB_AGENT_SECRET` environment variable.
+ * Falls back to a generated secret persisted in the runtime storage if the env var is not set.
+ * The token is hashed with SHA-256.
+ */
+export async function getMachineToken(): Promise<string> {
+  if (process.env.KUBB_AGENT_SECRET) {
+    return hash('sha256', process.env.KUBB_AGENT_SECRET)
+  }
+
+  fallbackSecretPromise ??= loadOrCreateFallbackSecret()
+
+  return hash('sha256', await fallbackSecretPromise)
+}

--- a/packages/studio/src/protocol/index.test.ts
+++ b/packages/studio/src/protocol/index.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentMessage } from './index.ts'
+import { commandTypes, isCommandMessage, isDataMessage, isDisconnectMessage, isStudioPingMessage } from './index.ts'
+
+describe('agent protocol', () => {
+  describe('message type guards', () => {
+    it('identifies command messages', () => {
+      const message: AgentMessage = {
+        type: 'studio:generate',
+        payload: {},
+      }
+
+      expect(isCommandMessage(message)).toBe(true)
+      expect(isDataMessage(message)).toBe(false)
+    })
+
+    it('identifies every command type', () => {
+      for (const type of commandTypes) {
+        expect(isCommandMessage({ type } as AgentMessage)).toBe(true)
+      }
+    })
+
+    it('tells the two sides of the heartbeat apart', () => {
+      expect(isStudioPingMessage({ type: 'studio:ping' })).toBe(true)
+      expect(isStudioPingMessage({ type: 'agent:ping' })).toBe(false)
+    })
+
+    it('identifies data messages', () => {
+      const message: AgentMessage = {
+        type: 'agent:data',
+        payload: {
+          type: 'kubb:info',
+          data: [{ message: 'message' }],
+          timestamp: Date.now(),
+          seq: 0,
+        },
+      }
+
+      expect(isDataMessage(message)).toBe(true)
+      expect(isCommandMessage(message)).toBe(false)
+
+      const event = isDataMessage(message, 'kubb:info') ? message : undefined
+      expect(event?.payload.type).toStrictEqual('kubb:info')
+    })
+
+    it('identifies a disconnect message and carries its reason', () => {
+      const message: AgentMessage = { type: 'studio:disconnect', reason: 'revoked' }
+
+      expect(isDisconnectMessage(message)).toBe(true)
+      expect(isCommandMessage(message)).toBe(false)
+      expect(isDataMessage(message)).toBe(false)
+      if (isDisconnectMessage(message)) {
+        expect(message.reason).toBe('revoked')
+      }
+    })
+  })
+})

--- a/packages/studio/src/protocol/index.ts
+++ b/packages/studio/src/protocol/index.ts
@@ -1,0 +1,532 @@
+/**
+ * WebSocket message types for the agent ↔ Studio protocol. Every message name carries the side that
+ * sent it, so direction reads off the name instead of the verb's tense:
+ *
+ * - Studio → agent: `studio:generate`, `studio:connect`, `studio:save`, `studio:ping`,
+ *   `studio:disconnect`, `studio:error`
+ * - Agent → Studio: `agent:connect`, `agent:save`, `agent:data`, `agent:ping`
+ *
+ * `kubb:` stays reserved for generation lifecycle, so the {@link KubbHooks} events relayed inside an
+ * `agent:data` payload keep their own names. The envelope says who sent it, the payload says what
+ * happened.
+ */
+
+import type { Config } from '@kubb/core'
+
+/**
+ * JSON-serializable Kubb config exchanged over the WebSocket. A live `kubb/kit` config holds
+ * functions and class instances that cannot survive JSON, so both sides pass this flattened shape
+ * and rebuild the real config from it.
+ */
+export type JSONKubbConfig = {
+  /**
+   * Plugins with their serialized options. `name` is the package name (e.g. `@kubb/plugin-ts`)
+   * and `options` is an opaque blob the agent forwards unchanged to the plugin factory. An entry
+   * with `disabled: true` is dropped even when the disk config's `plugins` array still lists it.
+   */
+  plugins?: Array<{
+    name: string
+    options?: object
+    disabled?: boolean
+  }>
+  /**
+   * Raw OpenAPI / Swagger spec content (YAML or JSON string).
+   * Always honored for a 'sandbox' agent. For a non-sandbox agent it is honored only when the
+   * agent opts in with `KUBB_AGENT_ALLOW_INPUT`; otherwise the spec is read from disk and this is ignored.
+   */
+  input?: string
+  /**
+   * Adapter option overrides sent from Studio UI. Merged into the disk config's adapter options
+   * and re-applied through the same adapter factory, since an adapter instance's functions
+   * (`parse`, `getImports`, ...) can't survive JSON serialization over the WebSocket.
+   */
+  adapter?: object
+}
+
+/**
+ * Which `defineConfig(...)` entry an edit targets, for a config file that exports an array.
+ *
+ * A number selects by position, a string matches the entry's `name`. Omitted targets the only
+ * entry, or the first one when the file exports an array.
+ */
+export type ConfigRef = string | number
+
+/**
+ * A value the agent can read out of a plugin option in `kubb.config.ts` and round-trip through JSON.
+ */
+export type OptionValue = string | number | boolean | null | Array<OptionValue> | { [key: string]: OptionValue }
+
+/**
+ * One change to a plugin's options in the user's `kubb.config.ts`.
+ *
+ * `plugin` is the package name (`@kubb/plugin-ts`), the same identity used in {@link JSONKubbConfig}.
+ * The agent applies these to the file with an AST patch, so only the targeted values are rewritten.
+ *
+ * Declared here rather than in `configFile.ts` because this is the wire contract, and the patcher
+ * imports it from here. Type-only, so nothing pulls `magicast` into this entry point.
+ */
+export type ConfigEdit =
+  /**
+   * Write a literal option value. `path` walks nested objects, so `['enum', 'type']` targets
+   * `pluginTs({ enum: { type } })`.
+   */
+  | { operation: 'set'; config?: ConfigRef; plugin: string; path: Array<string>; value: unknown }
+  /**
+   * Drop an option so the plugin falls back to its default.
+   */
+  | { operation: 'remove'; config?: ConfigRef; plugin: string; path: Array<string> }
+  /**
+   * Add a plugin factory call and its import to the `plugins` array.
+   */
+  | { operation: 'add-plugin'; config?: ConfigRef; plugin: string; importName?: string; options?: Record<string, unknown> }
+  /**
+   * Comment the plugin call out, keeping its options in the file so enabling it again restores them.
+   */
+  | { operation: 'disable-plugin'; config?: ConfigRef; plugin: string }
+  /**
+   * Uncomment a plugin call a previous `disable-plugin` commented out.
+   */
+  | { operation: 'enable-plugin'; config?: ConfigRef; plugin: string }
+
+/**
+ * A plugin factory call the agent found in the `plugins` array of a `defineConfig(...)`.
+ */
+export type PluginView = {
+  /**
+   * Local identifier of the factory in the file, e.g. `pluginTs`. This is the alias when the plugin
+   * was imported under one.
+   */
+  importName: string
+  /**
+   * Module the factory is imported from, e.g. `@kubb/plugin-ts`.
+   */
+  packageName: string
+  /**
+   * Top-level option keys, each flagged with whether the agent may write it and, when it can, the
+   * value found in the file. An option marked `literal: false` holds a function or a reference the
+   * agent will not overwrite, so Studio shows the control disabled rather than hiding it, and
+   * `value` is absent since there is nothing safe to display as the current value.
+   */
+  options: Record<string, { literal: boolean; value?: OptionValue }>
+  /**
+   * Set when the plugin call is commented out in the file. Its options stay on disk but are not
+   * readable, so `options` is empty until it is enabled again.
+   */
+  disabled?: true
+}
+
+/**
+ * One `defineConfig(...)` entry. A config file that exports a single object has exactly one.
+ */
+export type ConfigView = {
+  /**
+   * The entry's `name`, when it sets one. Studio labels the config picker with it.
+   */
+  name?: string
+  /**
+   * Each plugin call in the entry, with its top-level option keys.
+   */
+  plugins: Array<PluginView>
+}
+
+/**
+ * What the agent found in the user's config file, so Studio knows which controls it may offer.
+ * Absent when the agent could not read the file at all.
+ */
+export type ConfigFileView =
+  | {
+      managed: true
+      /**
+       * One entry per config the file exports, in source order. Every {@link ConfigEdit} names
+       * which of these it targets through its `config` field.
+       */
+      configs: Array<ConfigView>
+    }
+  | {
+      managed: false
+      /**
+       * Why the file is outside what the agent edits, for example a default export that is not a
+       * `defineConfig(...)` call. Studio shows this and offers no property-level controls.
+       */
+      reason: string
+    }
+
+/**
+ * Outcome of a single {@link ConfigEdit}, returned in a {@link ConfigSavedMessage}.
+ */
+export type ConfigEditOutcome = {
+  edit: ConfigEdit
+  applied: boolean
+  /**
+   * Why the edit was refused, absent when it was applied.
+   */
+  reason?: string
+}
+
+/**
+ * Typed events sent by the Kubb agent to Studio over WebSocket.
+ * Mirrors the single-context-object tuple style of {@link KubbHooks} in `kubb/kit`,
+ * using JSON-serializable shapes (e.g. `sources` as a `Record` instead of `Map`,
+ * `error` as `{ message; stack? }` instead of `Error`).
+ */
+export type KubbHooks = {
+  'kubb:plugin:start': [ctx: { plugin: { name: string } }]
+  'kubb:plugin:end': [ctx: { plugin: { name: string }; duration: number; success: boolean }]
+  'kubb:build:start': [ctx: { config: { name?: string }; adapter: { name: string } }]
+  'kubb:build:end': [ctx: { files: Array<{ path: string; name: string }>; outputDir: string }]
+  'kubb:files:processing:start': [ctx: { total: number }]
+  'kubb:files:processing:update': [
+    ctx: {
+      files: Array<{
+        file: string
+        processed: number
+        total: number
+        percentage: number
+      }>
+    },
+  ]
+  'kubb:files:processing:end': [ctx: { total: number }]
+  'kubb:info': [ctx: { message: string; info?: string }]
+  'kubb:success': [ctx: { message: string; info?: string }]
+  'kubb:warn': [ctx: { message: string; info?: string }]
+  'kubb:error': [ctx: { message: string; stack?: string }]
+  'kubb:debug': [ctx: { logs: Array<string>; fileName?: string }]
+  'kubb:generation:start': [ctx: { name?: string; plugins: number }]
+  'kubb:generation:end': [ctx: { config: Config; storage: Record<string, string> }]
+  'kubb:generation:summary': [ctx: { duration: number; fileCount: number; failedPlugins: number; status: 'success' | 'failed' }]
+  'kubb:lifecycle:start': []
+  'kubb:lifecycle:end': []
+  'kubb:format:start': []
+  'kubb:format:end': []
+  'kubb:lint:start': []
+  'kubb:lint:end': []
+  'kubb:hooks:start': []
+  'kubb:hooks:end': []
+  'kubb:hook:start': [ctx: { id?: string; command: string; args?: Array<string> }]
+  'kubb:hook:line': [ctx: { id: string; line: string }]
+  'kubb:hook:end': [
+    ctx: {
+      id?: string
+      command: string
+      args?: Array<string>
+      success: boolean
+      error?: { message: string; stack?: string }
+    },
+  ]
+}
+
+export type KubbHook = keyof KubbHooks
+
+/**
+ * Run a generation with the given config. `payload` is the merged config Studio wants generated.
+ */
+export type StudioGenerateMessage = {
+  type: 'studio:generate'
+  payload: JSONKubbConfig
+}
+
+/**
+ * Ask the agent to send a fresh `agent:connect` payload. Permissions are fixed when the host starts
+ * the agent; this message only triggers another read of disk config and saved Studio state.
+ */
+export type StudioConnectMessage = {
+  type: 'studio:connect'
+  /**
+   * Version of the Studio instance asking, which refreshes what the agent picked up when the
+   * session was created. Absent when Studio predates the field.
+   */
+  version?: string
+}
+
+/**
+ * Change plugin options in the user's `kubb.config.ts`. Applied only when the agent was granted
+ * `allowConfigEdit`; otherwise every edit comes back refused.
+ */
+export type StudioSaveMessage = {
+  type: 'studio:save'
+  edits: Array<ConfigEdit>
+}
+
+/**
+ * Anything Studio asks the agent to do. Each command is its own `type`, so a handler switches once
+ * instead of reading a `type` and then a nested `command` field.
+ */
+export type CommandMessage = StudioGenerateMessage | StudioConnectMessage | StudioSaveMessage
+
+/**
+ * The command names, for a host that needs the list rather than the union.
+ */
+export const commandTypes = ['studio:generate', 'studio:connect', 'studio:save'] as const
+
+/**
+ * Identifies the host running the Kubb runtime. Local to the runtime rather than part of the wire:
+ * it picks which remedy a refused-input warning suggests, since the Docker agent and the CLI grant
+ * `allowInput` different ways.
+ */
+export type ClientInfo = {
+  /**
+   * `cli` for a `kubb studio` connection from a developer's machine, `docker` for the agent image.
+   */
+  kind: 'cli' | 'docker'
+}
+
+/**
+ * Payload of the `agent:connect` handshake, sent when the agent attaches to a session. Carries only
+ * what Studio renders, with everything about the config under one key.
+ */
+export type ConnectMessagePayload = {
+  /**
+   * Always sent, so a mismatch is visible on both sides: Studio badges the connection with these
+   * and the host prints them.
+   */
+  versions: {
+    /**
+     * The version of the `@kubb/studio` runtime the agent runs.
+     */
+    kubb: string
+    /**
+     * The version of the host itself (the `kubb.agent` package or the `kubb` CLI).
+     */
+    agent: string
+  }
+  /**
+   * The agent's project root (`KUBB_AGENT_ROOT`, or the working directory when unset). This is the
+   * workspace that generation runs against.
+   */
+  root: string
+  /**
+   * The baseline every generation starts from.
+   */
+  config: {
+    /**
+     * The config path as configured (`KUBB_AGENT_CONFIG`), relative to `root` unless absolute.
+     */
+    path: string
+    /**
+     * What the agent read out of the config file itself, so Studio can render the plugin editor
+     * against the real file. Absent when the agent could not read it, or was not granted
+     * `allowConfigEdit`.
+     */
+    file?: ConfigFileView
+    /**
+     * Plugins the config registers, with their serialized options.
+     */
+    plugins?: Array<{
+      name: string
+      options?: object
+    }>
+  }
+  permissions: {
+    /**
+     * Whether the agent writes generated files to disk. False for a sandbox agent. For a local
+     * agent it mirrors the agent's `KUBB_AGENT_ALLOW_WRITE`.
+     */
+    allowWrite: boolean
+    /**
+     * Whether the agent will accept and generate from an OpenAPI spec supplied by Studio.
+     * Always true for a sandbox agent; otherwise it mirrors the agent's own opt-in. Studio reads
+     * this to decide whether to send `input`.
+     */
+    allowInput: boolean
+    /**
+     * Whether the agent runs the formatter, the linter, and `output.postGenerate` as child
+     * processes after a generation. Always true for the Docker agent, where the image bounds what
+     * can run. The CLI runs in the user's own project and defaults it off.
+     */
+    allowExec: boolean
+    /**
+     * Whether the agent may change plugin options in the user's `kubb.config.ts`. Separate from
+     * `allowWrite`, which covers generated output: this one edits a hand-authored source file.
+     */
+    allowConfigEdit: boolean
+  }
+}
+
+/**
+ * Agent → Studio handshake. Sent when the WebSocket opens and again after a `connect` command.
+ * Carries the on-disk config baseline, granted permissions, and paths Studio needs to render the editor.
+ */
+export type AgentConnectMessage = {
+  type: 'agent:connect'
+  payload: ConnectMessagePayload
+}
+
+/**
+ * Reply to a `save` command: what the agent did to the file on disk.
+ */
+export type AgentSaveMessage = {
+  type: 'agent:save'
+  payload: {
+    /**
+     * Per-edit result, in the order the edits were sent.
+     */
+    outcomes: Array<ConfigEditOutcome>
+    /**
+     * Whether the file on disk changed. False when every edit was refused, and when the applied
+     * edits produced the text the file already had.
+     */
+    changed: boolean
+    /**
+     * The config file as it now stands, so Studio can re-render without a round trip. Absent when
+     * nothing was written. Named to match `config.file` in the connect payload.
+     */
+    file?: ConfigFileView
+  }
+}
+
+/**
+ * Failure notice from Studio for something that breaks outside a generation, such as a malformed
+ * command. The agent's own failures travel as an `agent:data` message carrying a `kubb:error`
+ * payload, which keeps them ordered against the generation events around them.
+ */
+export type StudioErrorMessage = {
+  type: 'studio:error'
+  message: string
+}
+
+/**
+ * Heartbeat sent by the Agent to Studio so the connection is not treated as idle.
+ */
+export type AgentPingMessage = {
+  type: 'agent:ping'
+}
+
+/**
+ * Studio's reply to an `agent:ping`, confirming the connection is still alive.
+ */
+export type StudioPingMessage = {
+  type: 'studio:ping'
+}
+
+/**
+ * Disconnect message sent from Studio to Agent when the session is expired or revoked.
+ * The agent should close the connection without reconnecting.
+ */
+export type StudioDisconnectMessage = {
+  type: 'studio:disconnect'
+  reason: 'expired' | 'revoked'
+}
+
+/**
+ * The agent going away, so Studio marks the session offline instead of waiting out the heartbeat
+ * window. The mirror of {@link StudioDisconnectMessage}.
+ *
+ * Only sent for a shutdown. An expired or revoked session was Studio's own decision, so echoing it
+ * back says nothing new.
+ */
+export type AgentDisconnectMessage = {
+  type: 'agent:disconnect'
+  reason: 'shutdown'
+}
+
+/**
+ * Payload of an `agent:data` message: a single Kubb generation event forwarded to Studio in real time.
+ * Generic over the hook name so `data` is typed to that hook's context tuple.
+ */
+export type DataMessagePayload<T extends KubbHook = KubbHook> = {
+  /**
+   * The Kubb hook this event is for (e.g. `kubb:plugin:start`).
+   */
+  type: T
+  /**
+   * The hook's context tuple, matching `KubbHooks[type]`.
+   */
+  data: KubbHooks[T]
+  /**
+   * When the agent emitted the event, epoch milliseconds.
+   */
+  timestamp: number
+  /**
+   * Monotonic per-connection counter stamped in the order the agent emits events. Studio orders the
+   * event log by this, since `timestamp` has millisecond resolution and a full generation fires
+   * dozens of events per tick, and the relay can deliver them out of order.
+   */
+  seq: number
+}
+
+/**
+ * Envelope for a single generation event streamed from Agent to Studio. Wraps a
+ * {@link DataMessagePayload} so both sides can switch on `type: 'agent:data'`.
+ */
+export type DataMessage<T extends KubbHook = KubbHook> = {
+  type: 'agent:data'
+  payload: DataMessagePayload<T>
+}
+
+/**
+ * Response returned by the Studio `/api/agent/sessions` endpoint.
+ */
+export type AgentConnectResponse = {
+  /**
+   * WebSocket URL the agent opens to reach the session, with the session token embedded.
+   */
+  wsUrl: string
+  /**
+   * When the session expires and the wsUrl stops working (ISO 8601).
+   */
+  expiresAt: string
+  /**
+   * When the session was revoked (ISO 8601), or null while it is still valid.
+   */
+  revokedAt: string | null
+  /**
+   * Opaque session token, also embedded in `wsUrl`. Store it to revoke the session later.
+   */
+  sessionId: string
+  /**
+   * Short readable identifier for this connection, used in logs (e.g. brave-otter).
+   */
+  slug: string | null
+  /**
+   * Whether this session belongs to a shared sandbox agent rather than an owned one.
+   */
+  isSandbox: boolean
+  /**
+   * The Studio instance's own version. Reported here rather than only on `studio:connect`, so the
+   * agent knows it before it announces itself and can name both sides from the first connect.
+   * Absent when Studio predates the field.
+   */
+  version?: string
+}
+
+/**
+ * Every message that can cross the agent WebSocket, in either direction. Narrow it with the
+ * `is*Message` guards below before reading a variant's fields.
+ */
+export type AgentMessage =
+  | CommandMessage
+  | DataMessage
+  | AgentConnectMessage
+  | AgentSaveMessage
+  | AgentPingMessage
+  | AgentDisconnectMessage
+  | StudioErrorMessage
+  | StudioPingMessage
+  | StudioDisconnectMessage
+
+export function isCommandMessage(msg: AgentMessage): msg is CommandMessage {
+  return (commandTypes as ReadonlyArray<string>).includes(msg.type)
+}
+
+/**
+ * Type guard to narrow a data message to a specific event type.
+ *
+ * @example
+ * ```ts
+ * if (isDataMessage(msg, 'kubb:plugin:start')) {
+ *   // msg.payload.data is now typed as [ctx: { plugin: { name: string } }]
+ *   const pluginName = msg.payload.data[0].plugin.name
+ * }
+ * ```
+ */
+export function isDataMessage<T extends KubbHook>(msg: AgentMessage, type?: T): msg is DataMessage<T> {
+  return msg.type === 'agent:data' && (type ? msg.payload.type === type : true)
+}
+
+export function isStudioPingMessage(msg: AgentMessage): msg is StudioPingMessage {
+  return msg.type === 'studio:ping'
+}
+
+export function isDisconnectMessage(msg: AgentMessage): msg is StudioDisconnectMessage {
+  return msg.type === 'studio:disconnect'
+}

--- a/packages/studio/src/websocket.mock.ts
+++ b/packages/studio/src/websocket.mock.ts
@@ -1,0 +1,58 @@
+/**
+ * A minimal WebSocket mock for use in tests.
+ * Stores event listeners and supports async-safe triggering.
+ */
+export class MockWebSocket {
+  private listeners = new Map<string, Array<(...args: Array<unknown>) => unknown>>()
+
+  /**
+   * Simulates the OPEN ready state so sendAgentMessage does not bail early.
+   */
+  public readyState = 1
+
+  /**
+   * Tracks whether close() has been called.
+   */
+  public closed = false
+
+  /**
+   * Tracks whether terminate() has been called.
+   */
+  public terminated = false
+
+  addEventListener(event: string, cb: (...args: Array<unknown>) => unknown): void {
+    if (!this.listeners.has(event)) this.listeners.set(event, [])
+    this.listeners.get(event)!.push(cb)
+  }
+
+  removeEventListener(event: string, cb: (...args: Array<unknown>) => unknown): void {
+    const list = this.listeners.get(event)
+    if (list) {
+      const idx = list.indexOf(cb)
+      if (idx >= 0) list.splice(idx, 1)
+    }
+  }
+
+  /**
+   * Simulate the WebSocket being closed from the client side.
+   */
+  close(_code?: number, _reason?: string): void {
+    this.closed = true
+  }
+
+  /**
+   * Simulate an immediate teardown without a closing handshake.
+   */
+  terminate(): void {
+    this.terminated = true
+  }
+
+  /**
+   * Trigger all listeners for an event and await their completion in order.
+   */
+  async trigger(event: string, data?: unknown): Promise<void> {
+    for (const cb of this.listeners.get(event) ?? []) {
+      await cb(data)
+    }
+  }
+}

--- a/packages/studio/src/ws.test.ts
+++ b/packages/studio/src/ws.test.ts
@@ -1,0 +1,52 @@
+import { Hookable, type KubbPluginStartContext } from '@kubb/core'
+import type WebSocket from 'ws'
+import { describe, expect, it, vi } from 'vitest'
+import type { AgentHooks } from './hooks.ts'
+import type { AgentMessage } from './protocol/index.ts'
+import { setupEventsStream } from './ws.ts'
+
+/**
+ * `sendAgentMessage` only needs a socket that reports OPEN and records what it was handed, so the
+ * fake stays smaller than `MockWebSocket` (which has no `send`).
+ */
+function fakeSocket() {
+  const send = vi.fn()
+
+  return {
+    send,
+    ws: { readyState: 1, send } as unknown as WebSocket,
+    sent(): Array<AgentMessage> {
+      return send.mock.calls.map(([frame]) => JSON.parse(frame as string) as AgentMessage)
+    },
+  }
+}
+
+describe('setupEventsStream', () => {
+  it('forwards a generation event as an agent:data envelope around its kubb: payload', async () => {
+    const socket = fakeSocket()
+    const hooks = new Hookable<AgentHooks>()
+    setupEventsStream(socket.ws, hooks)
+
+    await hooks.callHook('kubb:plugin:start', { plugin: { name: 'plugin-ts' } as unknown as KubbPluginStartContext['plugin'] })
+
+    expect(socket.sent()).toStrictEqual([
+      {
+        type: 'agent:data',
+        payload: { type: 'kubb:plugin:start', data: [{ plugin: { name: 'plugin-ts' } }], timestamp: expect.any(Number), seq: 0 },
+      },
+    ])
+  })
+
+  it('keeps session events off the wire', async () => {
+    const socket = fakeSocket()
+    const hooks = new Hookable<AgentHooks>()
+    setupEventsStream(socket.ws, hooks)
+
+    // `studio:*` narrates the connection for whoever is running the agent. Studio has its own view
+    // of the session, so forwarding these would duplicate it and leak local paths and remedies.
+    // `setupEventsStream` subscribes to hook names one by one, so one event proves the namespace.
+    await hooks.callHook('studio:warn', { message: 'Ignored save: editing kubb.config.ts was not granted' })
+
+    expect(socket.send).not.toHaveBeenCalled()
+  })
+})

--- a/packages/studio/src/ws.ts
+++ b/packages/studio/src/ws.ts
@@ -1,0 +1,256 @@
+import { getElapsedMs, inParallel } from '@internals/utils'
+import { Diagnostics, type Hookable } from '@kubb/core'
+import WebSocket from 'ws'
+import type { AgentMessage, DataMessagePayload } from './protocol/index.ts'
+import type { AgentHooks } from './hooks.ts'
+
+type WebSocketOptions = WebSocket.ClientOptions
+
+/**
+ * How many generated files are read from storage at once when building the
+ * `kubb:generation:end` payload. A spec producing thousands of files would otherwise fire one
+ * `storage.readItem` per file simultaneously.
+ */
+const FILE_READ_CONCURRENCY = 50
+
+/**
+ * How long the initial handshake may take before the socket is closed and the reconnect loop
+ * takes over.
+ */
+const CONNECT_TIMEOUT_MS = 5_000
+
+/**
+ * Per-socket event counter. Every data message carries the next value so Studio can restore the
+ * agent's emission order even when the relay delivers frames out of order. Keyed by the socket so
+ * the count stays monotonic across every generation run on one connection, and is dropped
+ * automatically once the socket is collected.
+ */
+const eventSeqCounters = new WeakMap<WebSocket, number>()
+
+function nextEventSeq(ws: WebSocket): number {
+  const seq = eventSeqCounters.get(ws) ?? 0
+  eventSeqCounters.set(ws, seq + 1)
+
+  return seq
+}
+
+/**
+ * Opens a Studio WebSocket connection and closes it when the initial handshake exceeds the configured timeout.
+ */
+export function createWebsocket(url: string, options: WebSocketOptions): WebSocket {
+  const ws = new WebSocket(url, options)
+
+  const timer = setTimeout(() => {
+    if (ws.readyState === WebSocket.CONNECTING) {
+      ws.close(3008, 'Connection timeout')
+    }
+  }, CONNECT_TIMEOUT_MS)
+
+  // Once the handshake settles the timer has nothing left to check, and leaving it pending holds
+  // the socket for the rest of the window.
+  ws.once('open', () => clearTimeout(timer))
+  ws.once('close', () => clearTimeout(timer))
+
+  return ws
+}
+
+/**
+ * Sends a serialized agent message when the Studio socket is ready to accept frames.
+ */
+export function sendAgentMessage(ws: WebSocket, message: AgentMessage): void {
+  try {
+    if (ws.readyState !== WebSocket.OPEN) {
+      return
+    }
+
+    ws.send(JSON.stringify(message))
+  } catch (error) {
+    throw new Error('Failed to send message to Kubb Studio', { cause: error })
+  }
+}
+
+/**
+ * Sends a single `kubb:error` payload to Studio, stamped from the same per-socket counter the event stream
+ * uses so Studio can still order it against the generation events around it.
+ */
+export function sendErrorMessage(ws: WebSocket, error: Error): void {
+  sendAgentMessage(ws, {
+    type: 'agent:data',
+    payload: { type: 'kubb:error', data: [{ message: error.message, stack: error.stack }], timestamp: Date.now(), seq: nextEventSeq(ws) },
+  })
+}
+
+/**
+ * Forwards selected Kubb lifecycle events to Studio as data messages for the active session.
+ */
+export function setupEventsStream(ws: WebSocket, hooks: Hookable<AgentHooks>): void {
+  function sendDataMessage(payload: Omit<DataMessagePayload, 'seq' | 'timestamp'>) {
+    sendAgentMessage(ws, {
+      type: 'agent:data',
+      payload: { ...payload, timestamp: Date.now(), seq: nextEventSeq(ws) },
+    })
+  }
+
+  hooks.hook('kubb:plugin:start', (ctx) => {
+    sendDataMessage({
+      type: 'kubb:plugin:start',
+      data: [{ plugin: ctx.plugin }],
+    })
+  })
+
+  hooks.hook('kubb:plugin:end', (ctx) => {
+    sendDataMessage({
+      type: 'kubb:plugin:end',
+      data: [{ plugin: ctx.plugin, duration: ctx.duration, success: ctx.success }],
+    })
+  })
+
+  hooks.hook('kubb:build:start', ({ config, adapter }) => {
+    sendDataMessage({
+      type: 'kubb:build:start',
+      data: [{ config: { name: config.name }, adapter: { name: adapter.name } }],
+    })
+  })
+
+  hooks.hook('kubb:build:end', ({ files, outputDir }) => {
+    sendDataMessage({
+      type: 'kubb:build:end',
+      data: [{ files: files.map((file) => ({ path: file.path, name: file.name })), outputDir }],
+    })
+  })
+
+  hooks.hook('kubb:files:processing:start', ({ files }) => {
+    sendDataMessage({
+      type: 'kubb:files:processing:start',
+      data: [{ total: files.length }],
+    })
+  })
+
+  hooks.hook('kubb:files:processing:update', ({ files }) => {
+    sendDataMessage({
+      type: 'kubb:files:processing:update',
+      data: [
+        {
+          files: files.map(({ file, processed, total, percentage }) => ({
+            file: file.path,
+            processed,
+            total,
+            percentage,
+          })),
+        },
+      ],
+    })
+  })
+
+  hooks.hook('kubb:files:processing:end', ({ files }) => {
+    sendDataMessage({
+      type: 'kubb:files:processing:end',
+      data: [{ total: files.length }],
+    })
+  })
+
+  // The three log levels differ only in their event name.
+  for (const type of ['kubb:info', 'kubb:success', 'kubb:warn'] as const) {
+    hooks.hook(type, ({ message, info }) => {
+      sendDataMessage({ type, data: [{ message, info }] })
+    })
+  }
+
+  hooks.hook('kubb:generation:start', ({ config }) => {
+    sendDataMessage({
+      type: 'kubb:generation:start',
+      data: [
+        {
+          name: config.name,
+          plugins: config.plugins.length,
+        },
+      ],
+    })
+  })
+
+  hooks.hook('kubb:generation:end', async ({ config, storage, diagnostics = [], status, hrStart, filesCreated }) => {
+    const paths = await storage.readKeys()
+    const files: Record<string, string> = {}
+    await inParallel({
+      items: paths,
+      limit: FILE_READ_CONCURRENCY,
+      run: async (path) => {
+        const content = await storage.readItem(path)
+        if (content !== null) files[path] = content
+      },
+    })
+
+    sendDataMessage({
+      type: 'kubb:generation:end',
+      data: [{ config, storage: files }],
+    })
+
+    if (!hrStart) {
+      return
+    }
+
+    const duration = Math.round(getElapsedMs(hrStart))
+
+    sendDataMessage({
+      type: 'kubb:generation:summary',
+      data: [{ duration, fileCount: filesCreated ?? 0, failedPlugins: Diagnostics.failedPlugins(diagnostics).length, status: status ?? 'success' }],
+    })
+  })
+
+  hooks.hook('kubb:error', ({ error }) => {
+    sendDataMessage({
+      type: 'kubb:error',
+      data: [
+        {
+          message: error.message,
+          stack: error.stack,
+        },
+      ],
+    })
+  })
+
+  // Bracketing events carry no context, so they forward identically.
+  for (const type of [
+    'kubb:lifecycle:start',
+    'kubb:lifecycle:end',
+    'kubb:format:start',
+    'kubb:format:end',
+    'kubb:lint:start',
+    'kubb:lint:end',
+    'kubb:hooks:start',
+    'kubb:hooks:end',
+  ] as const) {
+    hooks.hook(type, () => {
+      sendDataMessage({ type, data: [] })
+    })
+  }
+
+  hooks.hook('kubb:hook:start', ({ id, command, args }) => {
+    sendDataMessage({
+      type: 'kubb:hook:start',
+      data: [{ id, command, args: args ? [...args] : undefined }],
+    })
+  })
+
+  hooks.hook('kubb:hook:line', ({ id, line }) => {
+    sendDataMessage({
+      type: 'kubb:hook:line',
+      data: [{ id, line }],
+    })
+  })
+
+  hooks.hook('kubb:hook:end', ({ id, command, args, success, error }) => {
+    sendDataMessage({
+      type: 'kubb:hook:end',
+      data: [
+        {
+          id,
+          command,
+          args: args ? [...args] : undefined,
+          success,
+          error: error ? { message: error.message, stack: error.stack } : undefined,
+        },
+      ],
+    })
+  })
+}

--- a/packages/studio/tsconfig.json
+++ b/packages/studio/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun-types", "../../reset.d.ts"]
+  },
+  "include": ["src/**/*", "./package.json", "./tsdown.config.ts", "./vitest.config.ts"]
+}

--- a/packages/studio/tsdown.config.ts
+++ b/packages/studio/tsdown.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, type UserConfig } from 'tsdown'
+
+const entry = {
+  index: 'src/index.ts',
+  protocol: 'src/protocol/index.ts',
+}
+
+const shared: Partial<UserConfig> = {
+  platform: 'node',
+  sourcemap: true,
+  shims: true,
+  exports: true,
+  deps: {
+    neverBundle: [/^@kubb\//],
+    alwaysBundle: [/@internals/],
+  },
+  fixedExtension: false,
+  outputOptions: {
+    keepNames: true,
+  },
+}
+
+export default defineConfig([
+  {
+    entry,
+    format: 'esm',
+    dts: true,
+    ...shared,
+  },
+  {
+    entry,
+    format: 'cjs',
+    dts: false,
+    ...shared,
+  },
+])

--- a/packages/studio/vitest.config.ts
+++ b/packages/studio/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    dir: './src',
+  },
+  resolve: {
+    tsconfigPaths: true,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -344,6 +344,40 @@ importers:
         specifier: 'catalog:'
         version: 2.9.0
 
+  packages/studio:
+    dependencies:
+      '@kubb/core':
+        specifier: workspace:*
+        version: link:../core
+      magicast:
+        specifier: ^0.5.4
+        version: 0.5.4
+      ofetch:
+        specifier: ^1.5.1
+        version: 1.5.1
+      remeda:
+        specifier: ^2.45.0
+        version: 2.45.0
+      tinyexec:
+        specifier: 'catalog:'
+        version: 1.3.0
+      unstorage:
+        specifier: ^1.17.5
+        version: 1.17.5
+      ws:
+        specifier: ^8.21.3
+        version: 8.21.3
+    devDependencies:
+      '@internals/utils':
+        specifier: workspace:*
+        version: link:../../internals/utils
+      '@kubb/adapter-oas':
+        specifier: workspace:*
+        version: link:../adapter-oas
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
+
   packages/unplugin-kubb:
     dependencies:
       '@kubb/adapter-oas':
@@ -370,7 +404,7 @@ importers:
         version: link:../ast
       '@nuxt/kit':
         specifier: ^4.5.2
-        version: 4.5.2(magic-string@0.30.21)(magicast@0.5.3)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
+        version: 4.5.2(magic-string@0.30.21)(magicast@0.5.4)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
       '@nuxt/schema':
         specifier: ^4.5.2
         version: 4.5.2
@@ -911,9 +945,6 @@ packages:
   '@oxc-project/types@0.142.0':
     resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
 
-  '@oxc-project/types@0.146.0':
-    resolution: {integrity: sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==}
-
   '@oxc-project/types@0.147.0':
     resolution: {integrity: sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==}
 
@@ -1187,12 +1218,6 @@ packages:
     resolution: {integrity: sha512-hrG//9/+RpOZTrUDirU4OzfMqaxCdY5BMpr3YuLf3Rje9rfNsydQJsH9iCPTie9ZRu9xe+0OUD4fHe0JmGwa2w==}
     engines: {node: '>=20'}
 
-  '@rolldown/binding-android-arm-eabi@1.2.5':
-    resolution: {integrity: sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [android]
-
   '@rolldown/binding-android-arm-eabi@1.2.6':
     resolution: {integrity: sha512-b+jTcARdTiFLI6jB4a5XjTm0RWd6KcRfQj/I2356fxUZemiho9zQLxo0RtCuMDAyKcLo6cEltkgbQp6d1+sjjQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1201,12 +1226,6 @@ packages:
 
   '@rolldown/binding-android-arm64@1.2.1':
     resolution: {integrity: sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
-  '@rolldown/binding-android-arm64@1.2.5':
-    resolution: {integrity: sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -1223,12 +1242,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-arm64@1.2.5':
-    resolution: {integrity: sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rolldown/binding-darwin-arm64@1.2.6':
     resolution: {integrity: sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1237,12 +1250,6 @@ packages:
 
   '@rolldown/binding-darwin-x64@1.2.1':
     resolution: {integrity: sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [darwin]
-
-  '@rolldown/binding-darwin-x64@1.2.5':
-    resolution: {integrity: sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -1259,12 +1266,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-freebsd-x64@1.2.5':
-    resolution: {integrity: sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
   '@rolldown/binding-freebsd-x64@1.2.6':
     resolution: {integrity: sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1277,12 +1278,6 @@ packages:
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.2.5':
-    resolution: {integrity: sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
   '@rolldown/binding-linux-arm-gnueabihf@1.2.6':
     resolution: {integrity: sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1291,13 +1286,6 @@ packages:
 
   '@rolldown/binding-linux-arm64-gnu@1.2.1':
     resolution: {integrity: sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-arm64-gnu@1.2.5':
-    resolution: {integrity: sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -1317,13 +1305,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-arm64-musl@1.2.5':
-    resolution: {integrity: sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@rolldown/binding-linux-arm64-musl@1.2.6':
     resolution: {integrity: sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1333,13 +1314,6 @@ packages:
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.1':
     resolution: {integrity: sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-ppc64-gnu@1.2.5':
-    resolution: {integrity: sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -1359,13 +1333,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.2.5':
-    resolution: {integrity: sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-s390x-gnu@1.2.6':
     resolution: {integrity: sha512-2bWNjRSIayvupRKxXUY2tWG9fYdoUlTqWywHRvE8Eq3GvuQ+f2HeIkve697fIt+IQs/PV8yFsdWuhp1aJ1PdnA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1375,13 +1342,6 @@ packages:
 
   '@rolldown/binding-linux-x64-gnu@1.2.1':
     resolution: {integrity: sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-x64-gnu@1.2.5':
-    resolution: {integrity: sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -1401,13 +1361,6 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-x64-musl@1.2.5':
-    resolution: {integrity: sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
   '@rolldown/binding-linux-x64-musl@1.2.6':
     resolution: {integrity: sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1417,12 +1370,6 @@ packages:
 
   '@rolldown/binding-openharmony-arm64@1.2.1':
     resolution: {integrity: sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@rolldown/binding-openharmony-arm64@1.2.5':
-    resolution: {integrity: sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -1443,12 +1390,6 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.2.5':
-    resolution: {integrity: sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
   '@rolldown/binding-win32-arm64-msvc@1.2.6':
     resolution: {integrity: sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1457,12 +1398,6 @@ packages:
 
   '@rolldown/binding-win32-x64-msvc@1.2.1':
     resolution: {integrity: sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [win32]
-
-  '@rolldown/binding-win32-x64-msvc@1.2.5':
-    resolution: {integrity: sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1709,6 +1644,9 @@ packages:
 
   '@types/ua-parser-js@0.7.39':
     resolution: {integrity: sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@valibot/to-json-schema@1.7.1':
     resolution: {integrity: sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A==}
@@ -2136,6 +2074,9 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie-es@1.2.3:
+    resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
+
   cookies@0.9.1:
     resolution: {integrity: sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==}
     engines: {node: '>= 0.8'}
@@ -2146,6 +2087,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  crossws@0.3.5:
+    resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
 
   dataloader@2.2.3:
     resolution: {integrity: sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==}
@@ -2520,6 +2464,9 @@ packages:
     resolution: {integrity: sha512-C3t35z65PQpAHay/gzEu4J/7SNWXn2NhfC4RfZQPxyOqkPfDTizthxCPoSU48OazoVherCuCpFDKI1qcY425Gw==}
     engines: {node: '>= 22'}
 
+  h3@1.15.11:
+    resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -2602,6 +2549,9 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  iron-webcrypto@1.2.1:
+    resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -2872,11 +2822,18 @@ packages:
     resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
     engines: {node: '>= 0.6.0'}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   magicast@0.5.3:
     resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
+
+  magicast@0.5.4:
+    resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -3000,6 +2957,9 @@ packages:
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-mock-http@1.0.5:
+    resolution: {integrity: sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==}
 
   node-releases@2.0.50:
     resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
@@ -3187,6 +3147,9 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  radix3@1.1.2:
+    resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
+
   rc9@3.0.1:
     resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
 
@@ -3201,6 +3164,10 @@ packages:
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
+
+  remeda@2.45.0:
+    resolution: {integrity: sha512-CTftZ0GJSox3CH77OhJemj20sXXUScH/kpkExD6t2LP3IG+mPKASBMFkbvWtsvzhU+54gKcgH38WWVihfr7bCA==}
+    engines: {node: '>=18.0.0'}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -3249,11 +3216,6 @@ packages:
 
   rolldown@1.2.1:
     resolution: {integrity: sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
-  rolldown@1.2.5:
-    resolution: {integrity: sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -3523,6 +3485,9 @@ packages:
   unconfig@7.5.0:
     resolution: {integrity: sha512-oi8Qy2JV4D3UQ0PsopR28CzdQ3S/5A1zwsUwp/rosSbfhJ5z7b90bIyTwi/F7hCLD4SGcZVjDzd4XoUQcEanvA==}
 
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
   unctx@3.0.0:
     resolution: {integrity: sha512-DoXdZVeyi2jyEsn86i8MO5RTItm1kffUkH9/+DQORn3Q688AMOy2551CIl6AdGL2UpwD675wtbNOl75wIQN/uA==}
     peerDependencies:
@@ -3589,6 +3554,68 @@ packages:
       vite:
         optional: true
       webpack:
+        optional: true
+
+  unstorage@1.17.5:
+    resolution: {integrity: sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==}
+    peerDependencies:
+      '@azure/app-configuration': ^1.8.0
+      '@azure/cosmos': ^4.2.0
+      '@azure/data-tables': ^13.3.0
+      '@azure/identity': ^4.6.0
+      '@azure/keyvault-secrets': ^4.9.0
+      '@azure/storage-blob': ^12.26.0
+      '@capacitor/preferences': ^6 || ^7 || ^8
+      '@deno/kv': '>=0.9.0'
+      '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
+      '@planetscale/database': ^1.19.0
+      '@upstash/redis': ^1.34.3
+      '@vercel/blob': '>=0.27.1'
+      '@vercel/functions': ^2.2.12 || ^3.0.0
+      '@vercel/kv': ^1 || ^2 || ^3
+      aws4fetch: ^1.0.20
+      db0: '>=0.2.1'
+      idb-keyval: ^6.2.1
+      ioredis: ^5.4.2
+      uploadthing: ^7.4.4
+    peerDependenciesMeta:
+      '@azure/app-configuration':
+        optional: true
+      '@azure/cosmos':
+        optional: true
+      '@azure/data-tables':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/keyvault-secrets':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@capacitor/preferences':
+        optional: true
+      '@deno/kv':
+        optional: true
+      '@netlify/blobs':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      '@vercel/functions':
+        optional: true
+      '@vercel/kv':
+        optional: true
+      aws4fetch:
+        optional: true
+      db0:
+        optional: true
+      idb-keyval:
+        optional: true
+      ioredis:
+        optional: true
+      uploadthing:
         optional: true
 
   untildify@4.0.0:
@@ -3745,6 +3772,18 @@ packages:
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -4453,36 +4492,6 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@nuxt/kit@4.5.2(magic-string@0.30.21)(magicast@0.5.3)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))':
-    dependencies:
-      c12: 3.3.4(magicast@0.5.3)
-      consola: 3.4.2
-      defu: 6.1.7
-      destr: 2.0.5
-      errx: 0.1.2
-      exsolve: 1.1.1
-      ignore: 7.0.6
-      jiti: 2.7.0
-      klona: 2.0.6
-      mlly: 1.8.2
-      nostics: 1.2.0
-      ohash: 2.0.11
-      pathe: 2.0.3
-      pkg-types: 2.3.1
-      rc9: 3.0.1
-      scule: 1.3.0
-      tinyglobby: 0.2.17
-      ufo: 1.6.4
-      unctx: 3.0.0(magic-string@0.30.21)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
-      untyped: 2.0.0
-      verkit: 0.3.2
-    transitivePeerDependencies:
-      - magic-string
-      - magicast
-      - oxc-parser
-      - rolldown
-      - unplugin
-
   '@nuxt/kit@4.5.2(magic-string@0.30.21)(magicast@0.5.3)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@26.0.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))':
     dependencies:
       c12: 3.3.4(magicast@0.5.3)
@@ -4513,6 +4522,36 @@ snapshots:
       - rolldown
       - unplugin
 
+  '@nuxt/kit@4.5.2(magic-string@0.30.21)(magicast@0.5.4)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))':
+    dependencies:
+      c12: 3.3.4(magicast@0.5.4)
+      consola: 3.4.2
+      defu: 6.1.7
+      destr: 2.0.5
+      errx: 0.1.2
+      exsolve: 1.1.1
+      ignore: 7.0.6
+      jiti: 2.7.0
+      klona: 2.0.6
+      mlly: 1.8.2
+      nostics: 1.2.0
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      rc9: 3.0.1
+      scule: 1.3.0
+      tinyglobby: 0.2.17
+      ufo: 1.6.4
+      unctx: 3.0.0(magic-string@0.30.21)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
+      untyped: 2.0.0
+      verkit: 0.3.2
+    transitivePeerDependencies:
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
+
   '@nuxt/schema@4.5.2':
     dependencies:
       '@vue/shared': 3.5.40
@@ -4523,8 +4562,6 @@ snapshots:
       std-env: 4.2.0
 
   '@oxc-project/types@0.142.0': {}
-
-  '@oxc-project/types@0.146.0': {}
 
   '@oxc-project/types@0.147.0': {}
 
@@ -4674,16 +4711,10 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@rolldown/binding-android-arm-eabi@1.2.5':
-    optional: true
-
   '@rolldown/binding-android-arm-eabi@1.2.6':
     optional: true
 
   '@rolldown/binding-android-arm64@1.2.1':
-    optional: true
-
-  '@rolldown/binding-android-arm64@1.2.5':
     optional: true
 
   '@rolldown/binding-android-arm64@1.2.6':
@@ -4692,16 +4723,10 @@ snapshots:
   '@rolldown/binding-darwin-arm64@1.2.1':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.2.5':
-    optional: true
-
   '@rolldown/binding-darwin-arm64@1.2.6':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.2.1':
-    optional: true
-
-  '@rolldown/binding-darwin-x64@1.2.5':
     optional: true
 
   '@rolldown/binding-darwin-x64@1.2.6':
@@ -4710,16 +4735,10 @@ snapshots:
   '@rolldown/binding-freebsd-x64@1.2.1':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.2.5':
-    optional: true
-
   '@rolldown/binding-freebsd-x64@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.2.1':
-    optional: true
-
-  '@rolldown/binding-linux-arm-gnueabihf@1.2.5':
     optional: true
 
   '@rolldown/binding-linux-arm-gnueabihf@1.2.6':
@@ -4728,16 +4747,10 @@ snapshots:
   '@rolldown/binding-linux-arm64-gnu@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.2.5':
-    optional: true
-
   '@rolldown/binding-linux-arm64-gnu@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.2.1':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-musl@1.2.5':
     optional: true
 
   '@rolldown/binding-linux-arm64-musl@1.2.6':
@@ -4746,16 +4759,10 @@ snapshots:
   '@rolldown/binding-linux-ppc64-gnu@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.2.5':
-    optional: true
-
   '@rolldown/binding-linux-ppc64-gnu@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.2.1':
-    optional: true
-
-  '@rolldown/binding-linux-s390x-gnu@1.2.5':
     optional: true
 
   '@rolldown/binding-linux-s390x-gnu@1.2.6':
@@ -4764,25 +4771,16 @@ snapshots:
   '@rolldown/binding-linux-x64-gnu@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.2.5':
-    optional: true
-
   '@rolldown/binding-linux-x64-gnu@1.2.6':
     optional: true
 
   '@rolldown/binding-linux-x64-musl@1.2.1':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.2.5':
-    optional: true
-
   '@rolldown/binding-linux-x64-musl@1.2.6':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.2.1':
-    optional: true
-
-  '@rolldown/binding-openharmony-arm64@1.2.5':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.2.6':
@@ -4798,16 +4796,10 @@ snapshots:
   '@rolldown/binding-win32-arm64-msvc@1.2.1':
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.2.5':
-    optional: true
-
   '@rolldown/binding-win32-arm64-msvc@1.2.6':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.2.1':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.2.5':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.2.6':
@@ -4972,6 +4964,10 @@ snapshots:
   '@types/semver@7.7.1': {}
 
   '@types/ua-parser-js@0.7.39': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 26.0.1
 
   '@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3))':
     dependencies:
@@ -5306,6 +5302,23 @@ snapshots:
     optionalDependencies:
       magicast: 0.5.3
 
+  c12@3.3.4(magicast@0.5.4):
+    dependencies:
+      chokidar: 5.0.0
+      confbox: 0.2.4
+      defu: 6.1.7
+      dotenv: 17.4.2
+      exsolve: 1.1.0
+      giget: 3.3.0
+      jiti: 2.7.0
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.1
+      rc9: 3.0.1
+    optionalDependencies:
+      magicast: 0.5.4
+
   cac@6.7.14: {}
 
   cac@7.0.0: {}
@@ -5375,6 +5388,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie-es@1.2.3: {}
+
   cookies@0.9.1:
     dependencies:
       depd: 2.0.0
@@ -5387,6 +5402,10 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  crossws@0.3.5:
+    dependencies:
+      uncrypto: 0.1.3
 
   dataloader@2.2.3: {}
 
@@ -5758,6 +5777,18 @@ snapshots:
 
   gunshi@0.37.1: {}
 
+  h3@1.15.11:
+    dependencies:
+      cookie-es: 1.2.3
+      crossws: 0.3.5
+      defu: 6.1.7
+      destr: 2.0.5
+      iron-webcrypto: 1.2.1
+      node-mock-http: 1.0.5
+      radix3: 1.1.2
+      ufo: 1.6.4
+      uncrypto: 0.1.3
+
   has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
@@ -5842,6 +5873,8 @@ snapshots:
   inherits@2.0.3: {}
 
   inherits@2.0.4: {}
+
+  iron-webcrypto@1.2.1: {}
 
   is-binary-path@2.1.0:
     dependencies:
@@ -6094,11 +6127,19 @@ snapshots:
 
   loglevel@1.9.2: {}
 
+  lru-cache@11.5.2: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   magicast@0.5.3:
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      source-map-js: 1.2.1
+
+  magicast@0.5.4:
     dependencies:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
@@ -6169,6 +6210,8 @@ snapshots:
   neo-async@2.6.2: {}
 
   node-fetch-native@1.6.7: {}
+
+  node-mock-http@1.0.5: {}
 
   node-releases@2.0.50: {}
 
@@ -6347,6 +6390,8 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  radix3@1.1.2: {}
+
   rc9@3.0.1:
     dependencies:
       defu: 6.1.7
@@ -6364,6 +6409,8 @@ snapshots:
       picomatch: 2.3.2
 
   readdirp@5.0.0: {}
+
+  remeda@2.45.0: {}
 
   require-from-string@2.0.2: {}
 
@@ -6419,27 +6466,6 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.2.1
       '@rolldown/binding-win32-arm64-msvc': 1.2.1
       '@rolldown/binding-win32-x64-msvc': 1.2.1
-
-  rolldown@1.2.5:
-    dependencies:
-      '@oxc-project/types': 0.146.0
-      '@rolldown/pluginutils': 1.0.1
-    optionalDependencies:
-      '@rolldown/binding-android-arm-eabi': 1.2.5
-      '@rolldown/binding-android-arm64': 1.2.5
-      '@rolldown/binding-darwin-arm64': 1.2.5
-      '@rolldown/binding-darwin-x64': 1.2.5
-      '@rolldown/binding-freebsd-x64': 1.2.5
-      '@rolldown/binding-linux-arm-gnueabihf': 1.2.5
-      '@rolldown/binding-linux-arm64-gnu': 1.2.5
-      '@rolldown/binding-linux-arm64-musl': 1.2.5
-      '@rolldown/binding-linux-ppc64-gnu': 1.2.5
-      '@rolldown/binding-linux-s390x-gnu': 1.2.5
-      '@rolldown/binding-linux-x64-gnu': 1.2.5
-      '@rolldown/binding-linux-x64-musl': 1.2.5
-      '@rolldown/binding-openharmony-arm64': 1.2.5
-      '@rolldown/binding-win32-arm64-msvc': 1.2.5
-      '@rolldown/binding-win32-x64-msvc': 1.2.5
 
   rolldown@1.2.6:
     dependencies:
@@ -6722,6 +6748,8 @@ snapshots:
       quansync: 1.0.0
       unconfig-core: 7.5.0
 
+  uncrypto@0.1.3: {}
+
   unctx@3.0.0(magic-string@0.30.21)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))):
     optionalDependencies:
       magic-string: 0.30.21
@@ -6771,6 +6799,17 @@ snapshots:
       webpack: 5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)
     optional: true
 
+  unstorage@1.17.5:
+    dependencies:
+      anymatch: 3.1.3
+      chokidar: 5.0.0
+      destr: 2.0.5
+      h3: 1.15.11
+      lru-cache: 11.5.2
+      node-fetch-native: 1.6.7
+      ofetch: 1.5.1
+      ufo: 1.6.4
+
   untildify@4.0.0: {}
 
   untyped@2.0.0:
@@ -6804,7 +6843,7 @@ snapshots:
       lightningcss: 1.33.0
       picomatch: 4.0.5
       postcss: 8.5.26
-      rolldown: 1.2.5
+      rolldown: 1.2.6
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 22.20.1
@@ -6896,6 +6935,8 @@ snapshots:
       stackback: 0.0.2
 
   ws@8.21.0: {}
+
+  ws@8.21.3: {}
 
   yaml@2.9.0: {}
 


### PR DESCRIPTION
## 🎯 Changes

PR2 of a 5-PR stack splitting up #3936 by concept. Base is PR1
(#3968) so it only shows the diff for this slice. First slice of the new `@kubb/studio` package:
the wire protocol and the reconnecting WebSocket client, no pairing or config editing yet.

- `protocol/index.ts` defines every `studio:*`/`agent:*` message. Names carry the sender:
  `studio:generate`, `studio:connect`, `studio:save` from Studio; `agent:connect`, `agent:save`,
  `agent:data`, `agent:ping`, `agent:disconnect` from the agent. `kubb:` stays reserved for
  generation lifecycle only.
- `ws.ts` is the reconnecting socket, built on the shared `inParallel` worker pool from PR1.
- `hooks.ts` extends `@kubb/core`'s `Kubb.KubbHooksRegistry` with the `studio:*` session events via
  declaration merging, instead of `@kubb/core` exporting a second, Studio-specific hook type. A
  host only needs to know `KubbHooks`; once `@kubb/studio` is in the program, `KubbHooks` carries
  the `studio:*` keys too. `AgentHooks` (the type an embedder installs to render a session) is now
  just `KubbHooks` with that merge applied.
- `machine.ts` is the pluggable credential/session storage (in-memory or file-backed).
- `@kubb/studio` and `@kubb/core` both gain a `types` condition in their `exports` map, so
  `node16`/`nodenext` resolution finds `@kubb/studio`'s and `@kubb/studio/protocol`'s declaration
  files.

Pairing (PR3), config resolution and writeback (PR4), and the public `createClient`/
`connectStudio` orchestration plus the `kubb studio` command (PR5) land in the rest of the stack.
`index.ts` here only re-exports what exists so far; the README is added complete once the package
is usable end-to-end, in PR5.

Stack: PR1 (#3968) → **PR2 (this PR)** → PR3: pairing → PR4: config writeback → PR5: `kubb studio`
command.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oTZxx4JE5oY1Wb6NC4ojP

---
_Generated by [Claude Code](https://claude.ai/code/session_018oTZxx4JE5oY1Wb6NC4ojP)_