### PR TITLE
feat(studio): add device-authorization pairing

### DIFF
--- a/.changeset/plain-moons-pair.md
+++ b/.changeset/plain-moons-pair.md
@@ -1,0 +1,15 @@
+---
+'@kubb/studio': minor
+---
+
+Let a host pair as something other than the CLI.
+
+`startPairing` takes an optional `clientId` and `agentKind`. It still defaults to
+`kubb-cli`, which `kubb studio login` uses and any signed-in member can approve. A host that pairs
+shared or tier-limited infrastructure, such as the `kubblabs/kubb-agent` image, passes
+`clientId: 'kubb-agent'` and the kind it wants to register as, whose codes only an admin can
+approve.
+
+`pollForPairingToken` now surfaces the server's `error_description` when it has one, so a pairing
+refused for a reason of Studio's own, such as the organization already being at its agent limit,
+says why instead of reporting a generic expiry.

--- a/.changeset/silver-jars-melt.md
+++ b/.changeset/silver-jars-melt.md
@@ -1,0 +1,10 @@
+---
+'@kubb/studio': patch
+---
+
+Studio's HTTP calls now go through `ofetch`. It handles JSON encoding and parsing, throws on a
+non-2xx status, and retries agent registration on its own, which replaces the package's own
+`HttpError` class and its hand-written retry loop.
+
+Registration now retries only what is worth retrying: a network failure or a 5xx, and no longer a
+403, which cannot succeed on a second try with the same machine token.

--- a/packages/studio/src/api.test.ts
+++ b/packages/studio/src/api.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { spyOnConsole } from './console.mock.ts'
+import { createAgentSession, disconnect, InvalidAgentTokenError, registerAgent } from './api.ts'
+
+const consoleSpy = spyOnConsole()
+
+// Partial: `api.ts` only wants the machine token stubbed, and a full factory would also replace
+// the storage accessors that the rest of the package shares.
+vi.mock('./machine.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./machine.ts')>()),
+  getMachineToken: vi.fn(async () => 'machine-token-hash'),
+}))
+
+const createMockResponse = (data: unknown, status = 200) => new Response(JSON.stringify(data), { status, headers: { 'Content-Type': 'application/json' } })
+
+const fetchMock = vi.fn()
+
+const session = {
+  sessionId: 'session-abc',
+  slug: 'brave-otter',
+  wsUrl: 'ws://localhost:3000/api/agent/sessions/session-abc/socket',
+  expiresAt: new Date().toISOString(),
+  revokedAt: null,
+  isSandbox: false,
+}
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  vi.useFakeTimers()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('registerAgent', () => {
+  it('throws instead of retrying when Studio rejects the token, so a deleted agent stops the loop', async () => {
+    fetchMock.mockResolvedValue(createMockResponse({ message: 'invalid_agent_token' }, 401))
+
+    await expect(registerAgent({ token: 'agent-token', studioUrl: 'http://localhost:3000' })).rejects.toBeInstanceOf(InvalidAgentTokenError)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns true when registration succeeds on the first attempt', async () => {
+    fetchMock.mockResolvedValueOnce(createMockResponse({}))
+
+    const promise = registerAgent({ token: 'tok', studioUrl: 'http://studio' })
+    await vi.runAllTimersAsync()
+
+    await expect(promise).resolves.toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    const [url, init] = fetchMock.mock.calls[0]!
+    expect(url).toBe('http://studio/api/agent/connect')
+    expect(init.method).toBe('POST')
+    expect(new Headers(init.headers).get('Authorization')).toBe('Bearer tok')
+  })
+
+  it('retries with backoff and returns true once an attempt succeeds', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('502')).mockRejectedValueOnce(new Error('502')).mockResolvedValueOnce(createMockResponse({}))
+
+    const promise = registerAgent({ token: 'tok', studioUrl: 'http://studio' })
+    await vi.runAllTimersAsync()
+
+    await expect(promise).resolves.toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('returns false when every attempt fails', async () => {
+    fetchMock.mockRejectedValue(new Error('502'))
+
+    const promise = registerAgent({ token: 'tok', studioUrl: 'http://studio' })
+    await vi.runAllTimersAsync()
+
+    await expect(promise).resolves.toBe(false)
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+  })
+})
+
+describe('createAgentSession', () => {
+  it('returns the session on success', async () => {
+    fetchMock.mockResolvedValueOnce(createMockResponse(session))
+
+    await expect(createAgentSession({ token: 'tok', studioUrl: 'http://studio' })).resolves.toEqual(session)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws on a non-403 error without re-registering', async () => {
+    fetchMock.mockResolvedValueOnce(createMockResponse({ message: 'Bad Gateway' }, 502))
+
+    await expect(createAgentSession({ token: 'tok', studioUrl: 'http://studio' })).rejects.toThrow('Failed to get agent session from Kubb Studio: Bad Gateway')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-registers and retries once when Studio rejects the machine token', async () => {
+    // 1: session create → 403, 2: register → ok, 3: session create retry → ok
+    fetchMock
+      .mockResolvedValueOnce(createMockResponse({ message: 'machine token mismatch' }, 403))
+      .mockResolvedValueOnce(createMockResponse({}))
+      .mockResolvedValueOnce(createMockResponse(session))
+
+    const promise = createAgentSession({ token: 'tok', studioUrl: 'http://studio' })
+    await vi.runAllTimersAsync()
+
+    await expect(promise).resolves.toEqual(session)
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+    expect(fetchMock.mock.calls[1]![0]).toBe('http://studio/api/agent/connect')
+  })
+
+  it('throws when re-registration fails after a machine token rejection', async () => {
+    fetchMock.mockResolvedValue(createMockResponse({ message: 'Forbidden' }, 403))
+
+    const promise = createAgentSession({ token: 'tok', studioUrl: 'http://studio' })
+    promise.catch(() => {})
+    await vi.runAllTimersAsync()
+
+    await expect(promise).rejects.toThrow('Failed to get agent session from Kubb Studio: Forbidden')
+    // 1 session create + 1 register. A 403 is not retried: the machine token was refused, and
+    // asking again with the same one cannot change that.
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('throws InvalidAgentTokenError when the retry after re-register still gets a 401', async () => {
+    fetchMock
+      .mockResolvedValueOnce(createMockResponse({ message: 'machine token mismatch' }, 403))
+      .mockResolvedValueOnce(createMockResponse({}))
+      .mockResolvedValueOnce(createMockResponse({ message: 'revoked' }, 401))
+
+    const promise = createAgentSession({ token: 'tok', studioUrl: 'http://studio' })
+    promise.catch(() => {})
+    await vi.runAllTimersAsync()
+
+    await expect(promise).rejects.toBeInstanceOf(InvalidAgentTokenError)
+  })
+})
+
+describe('disconnect', () => {
+  it('logs the slug when one is known', async () => {
+    fetchMock.mockResolvedValueOnce(createMockResponse({}))
+
+    await disconnect({ sessionId: 'session-abc', token: 'tok', studioUrl: 'http://studio', slug: 'brave-otter' })
+
+    expect(consoleSpy.log).toHaveBeenCalledWith('[brave-otter] Disconnected from Studio')
+  })
+
+  it('falls back to a generic tag when no slug is known', async () => {
+    fetchMock.mockResolvedValueOnce(createMockResponse({}))
+
+    await disconnect({ sessionId: 'session-abc', token: 'tok', studioUrl: 'http://studio' })
+
+    expect(consoleSpy.log).toHaveBeenCalledWith('[agent] Disconnected from Studio')
+  })
+
+  it('warns instead of throwing when Studio cannot be notified', async () => {
+    fetchMock.mockResolvedValueOnce(createMockResponse({ message: 'gone' }, 500))
+
+    await expect(disconnect({ sessionId: 'session-abc', token: 'tok', studioUrl: 'http://studio', slug: 'brave-otter' })).resolves.toBeUndefined()
+
+    expect(consoleSpy.warn).toHaveBeenCalledWith(expect.stringContaining('[brave-otter] Failed to notify Studio of disconnection'))
+  })
+})

--- a/packages/studio/src/api.ts
+++ b/packages/studio/src/api.ts
@@ -1,0 +1,199 @@
+import { styleText } from 'node:util'
+import { getErrorMessage } from '@internals/utils'
+import { FetchError, ofetch } from 'ofetch'
+import type { AgentConnectResponse } from './protocol/index.ts'
+import { getMachineToken } from './machine.ts'
+
+/**
+ * Reads a human-readable message from a Studio JSON error body, when it has one. `FetchError`'s own
+ * message stops at the status line, so the detail Studio sends with a failure (an agent limit, a
+ * revoked token) would otherwise never reach the user.
+ */
+function responseMessage(data: unknown): string | undefined {
+  if (!data || typeof data !== 'object') {
+    return undefined
+  }
+
+  const body = data as { error_description?: unknown; message?: unknown; error?: unknown }
+  for (const value of [body.error_description, body.message, body.error]) {
+    if (typeof value === 'string' && value) {
+      return value
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Retries after the first registration attempt, each backing off twice as far as the last.
+ */
+const REGISTER_RETRIES = 3
+
+/**
+ * Shared in-flight registration so concurrent pool sessions trigger one purge, not N.
+ */
+let registrationInFlight: Promise<boolean> | null = null
+
+type ConnectProps = {
+  studioUrl: string
+  token: string
+}
+
+/**
+ * Thrown when Studio rejects the agent token itself (401). Retrying cannot help: the token was
+ * revoked, or the agent it belonged to was deleted in the Studio UI. Hosts catch this to forget
+ * the stored credential and pair again.
+ */
+export class InvalidAgentTokenError extends Error {
+  constructor(studioUrl: string, options?: ErrorOptions) {
+    super(`Kubb Studio rejected this agent's token. It was revoked or the agent was deleted in ${studioUrl}.`, options)
+    this.name = 'InvalidAgentTokenError'
+  }
+}
+
+/**
+ * Whether a thrown value carries `statusCode`. Not narrowed to `FetchError`: a host wrapper can
+ * throw its own error shape with the same field.
+ *
+ * A 401 means the agent token itself was rejected. A 403 from the session create endpoint means
+ * the machine token stored in Studio no longer matches this agent (missing or mismatched).
+ */
+function rejectedWith(error: unknown, statusCode: number): boolean {
+  return (error as { statusCode?: number } | undefined)?.statusCode === statusCode
+}
+
+function sessionError(cause: unknown): Error {
+  const detail = (cause instanceof FetchError ? responseMessage(cause.data) : undefined) ?? getErrorMessage(cause)
+  return new Error(detail ? `Failed to get agent session from Kubb Studio: ${detail}` : 'Failed to get agent session from Kubb Studio', { cause })
+}
+
+/**
+ * Performs the raw session create request against Studio.
+ */
+async function requestAgentSession({ token, studioUrl }: ConnectProps): Promise<AgentConnectResponse> {
+  const url = `${studioUrl}/api/agent/sessions`
+
+  const data = await ofetch<AgentConnectResponse>(url, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+    body: { machineToken: await getMachineToken() },
+  })
+
+  if (!data) {
+    throw new Error('No data available for agent session')
+  }
+
+  return data
+}
+
+/**
+ * Obtain an agent session token from Kubb Studio via HTTP.
+ *
+ * When Studio rejects the machine token (403), for example after the agent restarted
+ * with a new identity while the startup registration call failed, the agent re-registers
+ * and retries once, so a single failed registration can't permanently block session creation.
+ */
+export async function createAgentSession({ token, studioUrl }: ConnectProps): Promise<AgentConnectResponse> {
+  try {
+    return await requestAgentSession({ token, studioUrl })
+  } catch (error: unknown) {
+    if (rejectedWith(error, 401)) {
+      throw new InvalidAgentTokenError(studioUrl, { cause: error })
+    }
+
+    if (!rejectedWith(error, 403) || !(await registerAgent({ token, studioUrl }))) {
+      throw sessionError(error)
+    }
+
+    try {
+      return await requestAgentSession({ token, studioUrl })
+    } catch (retryError: unknown) {
+      if (rejectedWith(retryError, 401)) {
+        throw new InvalidAgentTokenError(studioUrl, { cause: retryError })
+      }
+
+      throw sessionError(retryError)
+    }
+  }
+}
+
+type RegisterProps = {
+  studioUrl: string
+  token: string
+  poolSize?: number
+}
+
+/**
+ * Register this agent with Kubb Studio by sending the machine ID.
+ * Called on agent startup before creating a WebSocket session, and again when
+ * Studio rejects the machine token during session creation.
+ *
+ * Retries with backoff because a failed registration leaves Studio with a stale
+ * machine token that blocks every subsequent session create call. Registration
+ * purges all of the agent's sessions on the Studio side, so concurrent callers
+ * (multiple pool sessions hitting a 403 at once) share one in-flight run instead
+ * of purging each other's fresh sessions.
+ */
+export function registerAgent(props: RegisterProps): Promise<boolean> {
+  registrationInFlight ??= runRegistration(props).finally(() => {
+    registrationInFlight = null
+  })
+
+  return registrationInFlight
+}
+
+async function runRegistration({ token, studioUrl, poolSize }: RegisterProps): Promise<boolean> {
+  const machineToken = await getMachineToken()
+
+  try {
+    await ofetch(`${studioUrl}/api/agent/connect`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+      body: { machineToken, poolSize },
+      retry: REGISTER_RETRIES,
+      // 2s, 4s, then 8s. `retry` counts down, so the first retry is the one with the most left.
+      retryDelay: ({ options }) => 2_000 * 2 ** (REGISTER_RETRIES - Number(options.retry)),
+    })
+
+    return true
+  } catch (error) {
+    if (rejectedWith(error, 401)) {
+      throw new InvalidAgentTokenError(studioUrl, { cause: error })
+    }
+
+    console.error(styleText('red', `Failed to register agent with Studio after ${REGISTER_RETRIES + 1} attempts`))
+
+    return false
+  }
+}
+
+type DisconnectProps = {
+  studioUrl: string
+  token: string
+  sessionId: string
+  slug?: string | null
+}
+
+/**
+ * Notify Kubb Studio that this agent is disconnecting.
+ * Called on process termination or server close. A failed notify is logged and swallowed: the
+ * local socket is already gone, and failing teardown must not block shutdown or reconnect.
+ */
+export async function disconnect({ sessionId, token, studioUrl, slug }: DisconnectProps): Promise<void> {
+  const url = `${studioUrl}/api/agent/sessions/${sessionId}/disconnect`
+  const tag = slug ?? 'agent'
+
+  try {
+    await ofetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+    console.log(styleText('green', `[${tag}] Disconnected from Studio`))
+  } catch (error) {
+    console.warn(styleText('yellow', `[${tag}] Failed to notify Studio of disconnection: ${getErrorMessage(error)}`))
+  }
+}

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -10,3 +10,5 @@ export type {
 } from './hooks.ts'
 export { defaultStudioUrl } from './constants.ts'
 export { createFileStorage, setStorage } from './machine.ts'
+export { InvalidAgentTokenError } from './api.ts'
+export { pollForPairingToken, startPairing } from './pair.ts'

--- a/packages/studio/src/pair.test.ts
+++ b/packages/studio/src/pair.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { setTimeout as delay } from 'node:timers/promises'
+import { pollForPairingToken, type PairingSession } from './pair.ts'
+
+vi.mock('node:timers/promises', () => ({
+  setTimeout: vi.fn(async () => {}),
+}))
+
+const delayMock = vi.mocked(delay)
+
+vi.mock('./machine.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./machine.ts')>()),
+  getMachineToken: vi.fn(async () => 'machine-token-hash'),
+}))
+
+const fetchMock = vi.fn()
+
+const session: PairingSession = {
+  device_code: 'device',
+  user_code: 'ABCD-EFGH',
+  verification_uri: 'https://kubb.studio/pair',
+  verification_uri_complete: 'https://kubb.studio/pair?user_code=ABCD-EFGH',
+  expires_in: 60,
+  interval: 1,
+}
+
+const createMockResponse = (data: unknown, status = 200) =>
+  new Response(data === undefined ? null : JSON.stringify(data), { status, headers: { 'Content-Type': 'application/json' } })
+
+beforeEach(() => {
+  fetchMock.mockReset()
+  vi.useFakeTimers()
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('pollForPairingToken', () => {
+  it('returns the token once Studio approves', async () => {
+    const result = {
+      token: 'agent-token',
+      agent: { id: '1', slug: 'brave-otter', name: 'demo' },
+    }
+    fetchMock.mockResolvedValueOnce(createMockResponse({ error: 'authorization_pending' }, 400)).mockResolvedValueOnce(createMockResponse(result))
+
+    const promise = pollForPairingToken({ studioUrl: 'http://studio', session })
+    await vi.runAllTimersAsync()
+
+    await expect(promise).resolves.toEqual(result)
+  })
+
+  it("surfaces Studio's error_description on access_denied", async () => {
+    fetchMock.mockResolvedValueOnce(createMockResponse({ error: 'access_denied', error_description: 'agent limit reached' }, 403))
+
+    const promise = pollForPairingToken({ studioUrl: 'http://studio', session })
+    promise.catch(() => {})
+    await vi.runAllTimersAsync()
+
+    await expect(promise).rejects.toThrow('agent limit reached')
+  })
+
+  it('throws on an unexpected pairing error instead of spinning until expiry', async () => {
+    fetchMock.mockResolvedValueOnce(createMockResponse({ error: 'server_error', error_description: 'pairing store unavailable' }, 500))
+
+    const promise = pollForPairingToken({ studioUrl: 'http://studio', session })
+    promise.catch(() => {})
+    await vi.runAllTimersAsync()
+
+    await expect(promise).rejects.toThrow('pairing store unavailable')
+  })
+
+  it('throws when Studio returns an empty body', async () => {
+    fetchMock.mockResolvedValueOnce(createMockResponse(undefined, 500))
+
+    const promise = pollForPairingToken({ studioUrl: 'http://studio', session })
+    promise.catch(() => {})
+    await vi.runAllTimersAsync()
+
+    await expect(promise).rejects.toThrow('empty pairing response')
+  })
+
+  it('falls back to a 5s interval instead of spinning when Studio omits it', async () => {
+    const result = { token: 'agent-token', agent: { id: '1', slug: 'brave-otter', name: 'demo' } }
+    fetchMock.mockResolvedValueOnce(createMockResponse(result))
+
+    const promise = pollForPairingToken({ studioUrl: 'http://studio', session: { ...session, interval: 0 } })
+    await vi.runAllTimersAsync()
+    await promise
+
+    expect(delayMock).toHaveBeenCalledWith(5_000)
+  })
+
+  it('falls back to a 600s expiry instead of expiring before the first poll when Studio omits it', async () => {
+    const result = { token: 'agent-token', agent: { id: '1', slug: 'brave-otter', name: 'demo' } }
+    fetchMock.mockResolvedValueOnce(createMockResponse(result))
+
+    const promise = pollForPairingToken({ studioUrl: 'http://studio', session: { ...session, expires_in: 0 } })
+    await vi.runAllTimersAsync()
+
+    await expect(promise).resolves.toEqual(result)
+  })
+
+  it('keeps polling when Studio is briefly unreachable', async () => {
+    using warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const result = { token: 'agent-token', agent: { id: '1', slug: 'brave-otter', name: 'demo' } }
+    fetchMock.mockRejectedValueOnce(new Error('socket hang up')).mockResolvedValueOnce(createMockResponse(result))
+
+    const promise = pollForPairingToken({ studioUrl: 'http://studio', session })
+    await vi.runAllTimersAsync()
+
+    await expect(promise).resolves.toEqual(result)
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('socket hang up'))
+  })
+})

--- a/packages/studio/src/pair.ts
+++ b/packages/studio/src/pair.ts
@@ -1,0 +1,178 @@
+import { setTimeout as delay } from 'node:timers/promises'
+import { styleText } from 'node:util'
+import { getErrorMessage } from '@internals/utils'
+import { ofetch } from 'ofetch'
+import { agentDefaults } from './constants.ts'
+import { getMachineToken } from './machine.ts'
+
+/**
+ * RFC 8628 device-authorization response from Studio's `/api/auth/device/code` endpoint.
+ * Field names match the RFC; the CLI polls with `device_code` and shows `user_code` to the user.
+ */
+export type PairingSession = {
+  device_code: string
+  user_code: string
+  verification_uri: string
+  verification_uri_complete: string
+  expires_in: number
+  interval: number
+}
+
+export type PairingResult = {
+  /**
+   * Bearer token for this machine. Write credentials with mode 0600 and never log the value.
+   */
+  token: string
+  agent: {
+    /**
+     * Stable agent id in Studio.
+     */
+    id: string
+    /**
+     * Short slug used in logs and the UI (for example `brave-otter`).
+     */
+    slug: string
+    /**
+     * Display name chosen at pairing time.
+     */
+    name: string
+  }
+}
+
+/**
+ * Identifies the CLI to Studio's device authorization endpoint. A label, not a secret: what
+ * authorizes a pairing is a signed-in person approving the code in the browser.
+ */
+const CLIENT_ID = 'kubb-cli'
+
+type StartPairingOptions = {
+  studioUrl?: string
+  /**
+   * Display name for the agent, usually the project or machine name.
+   */
+  name: string
+  hostname: string
+  /**
+   * Which client is pairing. Defaults to the CLI, where any signed-in member may approve their own
+   * machine. The Docker image passes `kubb-agent`, whose codes only an admin can approve.
+   */
+  clientId?: string
+  /**
+   * What a `kubb-agent` pairing asks to be registered as. Studio rejects the request without it,
+   * and ignores it for the CLI.
+   */
+  agentKind?: 'user' | 'sandbox'
+}
+
+/**
+ * Asks Studio for a pairing code. The machine token travels with the request and is stored against
+ * the code, so approval knows which machine it is pairing: the same machine pairing twice rotates
+ * one agent's token instead of creating a second agent.
+ */
+export async function startPairing({
+  studioUrl = agentDefaults.studioUrl,
+  name,
+  hostname,
+  clientId = CLIENT_ID,
+  agentKind,
+}: StartPairingOptions): Promise<PairingSession> {
+  return ofetch<PairingSession>(`${studioUrl}/api/auth/device/code`, {
+    method: 'POST',
+    body: {
+      client_id: clientId,
+      name,
+      hostname,
+      machine_token: await getMachineToken(),
+      agent_kind: agentKind,
+    },
+  })
+}
+
+type PollOptions = {
+  studioUrl?: string
+  session: PairingSession
+}
+
+type PollError = 'authorization_pending' | 'slow_down' | 'expired_token' | 'access_denied' | 'invalid_grant'
+
+type PollResponse =
+  | PairingResult
+  | {
+      error: PollError | string
+      /**
+       * Why, when Studio has something more useful to say than the RFC code. An approval that hits
+       * the organization's agent limit comes back as `access_denied` with the limit spelled out.
+       */
+      error_description?: string
+    }
+
+function isPairingResult(response: PollResponse | undefined): response is PairingResult {
+  return !!response && typeof response === 'object' && 'token' in response && typeof response.token === 'string'
+}
+
+/**
+ * Polls until the user approves or denies, honoring the server's `slow_down` back-off. A poll that
+ * cannot reach Studio is warned about and retried, since the code stays valid either way.
+ *
+ * Studio's own endpoint is used rather than the auth layer's `/device/token`, because an approved
+ * Kubb pairing is worth an agent bearer token, not a user session.
+ *
+ * @throws when the code expires, the user denies it, or Studio returns an unexpected error.
+ */
+export async function pollForPairingToken({ studioUrl = agentDefaults.studioUrl, session }: PollOptions): Promise<PairingResult> {
+  // Both fields cross the network, so neither is trusted as-is: a missing or zero `interval` would
+  // spin the poll loop, and a missing or zero `expires_in` would expire the code before the first
+  // poll. `> 0` is also false for `NaN` and for a missing field, so it doubles as the type guard.
+  const deadline = Date.now() + (session.expires_in > 0 ? session.expires_in : 600) * 1000
+  let intervalMs = (session.interval > 0 ? session.interval : 5) * 1000
+
+  while (Date.now() < deadline) {
+    await delay(intervalMs)
+
+    let response: PollResponse | undefined
+    try {
+      response = await ofetch<PollResponse | undefined>(`${studioUrl}/api/agent/token`, {
+        method: 'POST',
+        body: { device_code: session.device_code },
+        // A denial, an expiry, and "not yet" all come back as 4xx with a body the caller needs to
+        // read, so let every response through and switch on `error` instead of catching.
+        ignoreResponseError: true,
+      })
+    } catch (error) {
+      // Studio can go briefly unreachable (a deploy, a dropped connection) during the minutes the
+      // user has to approve in the browser. One failed poll should not end a pairing whose code is
+      // still valid, so warn and try again on the next tick, the way `registerAgent` retries.
+      console.warn(styleText('yellow', `Could not reach Kubb Studio while waiting for approval, retrying: ${getErrorMessage(error)}`))
+      continue
+    }
+
+    if (isPairingResult(response)) {
+      return response
+    }
+
+    if (!response || typeof response !== 'object' || !('error' in response) || typeof response.error !== 'string') {
+      throw new Error('Kubb Studio returned an empty pairing response, pair again')
+    }
+
+    if (response.error === 'authorization_pending') {
+      continue
+    }
+
+    if (response.error === 'slow_down') {
+      intervalMs += 5_000
+      continue
+    }
+
+    if (response.error === 'access_denied') {
+      throw new Error(response.error_description ?? 'Pairing was denied in the browser')
+    }
+
+    if (response.error === 'expired_token' || response.error === 'invalid_grant') {
+      throw new Error(response.error_description ?? 'The pairing code expired, pair again')
+    }
+
+    throw new Error(response.error_description ?? `Pairing failed (${response.error})`)
+  }
+
+  throw new Error('The pairing code expired, pair again')
+}


### PR DESCRIPTION
## 🎯 Changes

PR3 of a 5-PR stack splitting up #3936 by concept. Base is PR2
(#3969) so it only shows the diff for this slice. Second slice of `@kubb/studio`: how a host proves
its identity to Studio.

- `pair.ts` implements RFC 8628 device-authorization pairing (`startPairing`/
  `pollForPairingToken`). `startPairing` takes an optional `clientId` and `agentKind`, defaulting
  to `kubb-cli` (used by `kubb studio login`, approvable by any signed-in member). A host that
  pairs shared or tier-limited infrastructure, such as the `kubblabs/kubb-agent` image, passes its
  own `clientId` and the kind it wants to register as, whose codes only an admin can approve.
  `pollForPairingToken` surfaces the server's `error_description` when it has one, so a pairing
  refused for a reason of Studio's own says why instead of reporting a generic expiry.
- `api.ts` registers and disconnects an agent session over HTTP, through `ofetch`: it encodes and
  parses JSON, throws on a non-2xx status, and retries registration on its own. Registration
  retries a network failure or a 5xx, never a 403, which cannot succeed twice with the same
  machine token.

Config resolution and writeback (PR4) and the public orchestration plus the `kubb studio` command
(PR5) land next in this stack.

Stack: PR1 (#3968) → PR2 (#3969) → **PR3 (this PR)** → PR4: config writeback → PR5: `kubb studio`
command.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oTZxx4JE5oY1Wb6NC4ojP

---
_Generated by [Claude Code](https://claude.ai/code/session_018oTZxx4JE5oY1Wb6NC4ojP)_