### PR TITLE
feat(cli): add the kubb studio command

### DIFF
--- a/.changeset/lucky-donuts-shave.md
+++ b/.changeset/lucky-donuts-shave.md
@@ -1,0 +1,10 @@
+---
+'@kubb/cli': minor
+---
+
+`kubb studio` gains `--allowConfigEdit`, letting Studio change plugin options in your
+`kubb.config.ts`. The CLI asks for it once per project, the same as the other permissions, and
+leaves it off in CI.
+
+It is separate from `--allowWrite`, which covers generated output. Editing the config changes a
+file you wrote by hand, so it is granted on its own.

--- a/.changeset/quiet-lions-relax.md
+++ b/.changeset/quiet-lions-relax.md
@@ -1,0 +1,7 @@
+---
+'@kubb/studio': patch
+'@kubb/cli': patch
+---
+
+Space out `kubb studio` log output with blank lines between setup, connection, and each
+command round trip, so the terminal reads as separate blocks instead of one dense run.

--- a/.changeset/wild-pots-attack.md
+++ b/.changeset/wild-pots-attack.md
@@ -1,0 +1,18 @@
+---
+'@kubb/studio': minor
+'@kubb/cli': minor
+---
+
+Add `@kubb/studio`, the client runtime that connects a Kubb project to Kubb Studio, and a
+`kubb studio` command that uses it.
+
+`kubb studio` pairs a machine by showing a code you approve in the browser (an RFC 8628 device
+authorization grant), then streams generation events over the same WebSocket relay the Docker
+agent uses. It runs against the project's own config and its own installed plugins, so no
+container and no pinned plugin set are involved.
+
+Everything is read-only by default: `--allowWrite` writes generated files, `--allowInput`
+accepts a spec from Studio, and `--allowExec` runs the formatter, the linter, and
+`output.postGenerate`. Studio can only configure plugins the local config already imports.
+
+`kubb studio login`, `kubb studio logout`, and `kubb studio status` manage the pairing.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+model_verbosity = "low"
+model_reasoning_summary = "concise"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ Thanks to everyone who contributed to this release:
 #### Bug Fixes
 
 - Move `unplugin-kubb` past its squatted npm version range.
-  
+
   Versions 5.0.1 through 5.0.30 were already published on npm from `unplugin-kubb`'s
   pre-monorepo history and depend on kubb v4, so the package's version was set directly to
   5.0.31 to clear that range. This changeset picks up from that 5.0.31 baseline and puts

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -41,6 +41,7 @@ npm install -D @kubb/cli
 
 - [`kubb init`](#kubb-init) — scaffold a new project
 - [`kubb generate`](#kubb-generate) — run code generation
+- [`kubb studio`](#kubb-studio) — connect this project to Kubb Studio
 - [`kubb validate`](#kubb-validate) — validate an OpenAPI spec
 - [`kubb mcp`](#kubb-mcp) — start the MCP server for AI assistants
 
@@ -133,6 +134,71 @@ npx kubb generate --verbose
 # Write a JSON run report alongside the CLI output
 npx kubb generate --reporter cli,json
 ```
+
+---
+
+### `kubb studio`
+
+Connect this project to [Kubb Studio](https://kubb.studio) and generate from the browser. Kubb runs
+on your machine, reads your config and spec from disk, and streams progress and files back to
+Studio over a WebSocket.
+
+```bash
+npx kubb studio
+```
+
+The first run pairs the machine. The CLI prints a short code, you approve it in Studio, and the CLI
+stores the agent token in `~/.kubb/credentials.json` at mode `0600`. Later runs reuse it. Set
+`KUBB_HOME` to store it, the machine secret, and the session registry somewhere other than
+`~/.kubb`.
+
+The connection is read-only by default. On the first connect to a project the CLI asks yes/no
+for each permission separately: writing generated files, editing `kubb.config.ts`, accepting a
+spec from Studio, and running the formatter, linter, or `postGenerate`. Each `--allow*` flag
+skips the question for that one permission.
+
+#### Arguments
+
+| Argument   | Required | Description                                        |
+| ---------- | -------- | -------------------------------------------------- |
+| `[action]` | No       | `connect` (default), `login`, `logout` or `status` |
+
+#### Options
+
+| Flag                 | Short | Type    | Default               | Description                                                                                   |
+| -------------------- | ----- | ------- | --------------------- | --------------------------------------------------------------------------------------------- |
+| `--config <path>`    | `-c`  | string  |                       | Path to the Kubb config file                                                                  |
+| `--url <url>`        |       | string  | `https://kubb.studio` | Base URL of the Kubb Studio instance                                                          |
+| `--allowWrite`       |       | boolean | `false`               | Write generated files to disk. Asked for once per project when omitted                        |
+| `--allowConfigEdit`  |       | boolean | `false`               | Edit plugin options in `kubb.config.ts`. Asked for once per project when omitted              |
+| `--allowInput`       |       | boolean | `false`               | Generate from a spec sent by Studio. Asked for once per project when omitted                  |
+| `--allowExec`        |       | boolean | `false`               | Run the formatter, the linter, and `output.postGenerate`. Asked once per project when omitted |
+| `--no-open`          |       | boolean |                       | Do not open the approval page in a browser while pairing                                      |
+| `--logLevel <level>` | `-l`  | string  | `info`                | Log level: `silent`, `info`, or `verbose`                                                     |
+
+#### Examples
+
+```bash
+# Pair on first run, then connect read-only
+npx kubb studio
+
+# Let Studio write generated files to disk
+npx kubb studio --allowWrite
+
+# Pair without connecting
+npx kubb studio login
+
+# Show which machine is paired, and with which Studio
+npx kubb studio status
+
+# Forget the stored token
+npx kubb studio logout
+
+# Point at a self-hosted Studio
+npx kubb studio --url http://localhost:3000
+```
+
+Flags are camelCase. `--allow-write` is not recognized and is silently ignored.
 
 ---
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kubb/cli",
   "version": "5.1.0",
-  "description": "Official CLI for Kubb. Run kubb generate, kubb init, kubb validate, and kubb mcp to manage the full code generation lifecycle.",
+  "description": "Official CLI for Kubb. Run kubb generate, kubb init, kubb validate, kubb studio, and kubb mcp to manage the full code generation lifecycle.",
   "keywords": [
     "cli",
     "code-generator",
@@ -79,17 +79,22 @@
   "devDependencies": {
     "@internals/shared": "workspace:*",
     "@internals/utils": "workspace:*",
-    "@kubb/adapter-oas": "workspace:*"
+    "@kubb/adapter-oas": "workspace:*",
+    "@kubb/studio": "workspace:*"
   },
   "peerDependencies": {
     "@kubb/adapter-oas": "workspace:*",
-    "@kubb/mcp": "workspace:*"
+    "@kubb/mcp": "workspace:*",
+    "@kubb/studio": "workspace:*"
   },
   "peerDependenciesMeta": {
     "@kubb/adapter-oas": {
       "optional": true
     },
     "@kubb/mcp": {
+      "optional": true
+    },
+    "@kubb/studio": {
       "optional": true
     }
   },

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -36,9 +36,16 @@ export const command = defineWithTypes<{ extensions: DryRunExtensions }>()({
   name: 'generate',
   description:
     'Generate TypeScript types, API clients, React Query hooks, Zod schemas, and more from an OpenAPI specification. Reads kubb.config.ts by default. Pass an OpenAPI file path as the first argument to override the input without editing the config.',
-  examples: ['kubb generate', 'kubb generate ./openapi.yaml', 'kubb generate --config kubb.config.ts', 'kubb generate --watch', 'kubb generate --dryRun'].join(
-    '\n',
-  ),
+  examples: [
+    'kubb generate                     # generate from kubb.config.ts',
+    'kubb generate ./openapi.yaml      # generate from this spec instead of the config input',
+    'kubb generate --config kubb.config.ts',
+    'kubb generate --watch             # regenerate whenever the spec changes',
+    'kubb generate --dryRun            # preview the run without writing files',
+    'kubb studio                       # connect this project to Kubb Studio and generate from the browser',
+    'kubb studio --allowWrite          # let Studio write the generated files to disk',
+    'kubb studio login                 # pair this machine with Studio without connecting',
+  ].join('\n'),
   args: {
     input: {
       type: 'positional',

--- a/packages/cli/src/commands/studio.ts
+++ b/packages/cli/src/commands/studio.ts
@@ -1,0 +1,70 @@
+import { define } from 'gunshi'
+
+/**
+ * Declaration only, so listing `kubb --help` never loads `@kubb/studio`. `index.ts` pairs this
+ * with the runner through gunshi's `lazy`.
+ */
+export const definition = define({
+  name: 'studio',
+  description:
+    'Connect this project to Kubb Studio and generate from the browser. The first run pairs the machine: the CLI shows a code, you approve it in Studio, and the token is stored in ~/.kubb. The connection is read-only unless you grant more with --allowWrite, --allowConfigEdit, --allowInput or --allowExec.',
+  examples: [
+    'kubb studio                              # connect this project, asking what Studio may do',
+    'kubb studio --allowWrite                 # grant writing generated files, no question asked',
+    'kubb studio --allowWrite --allowExec     # also run the formatter, the linter, and postGenerate',
+    'kubb studio --allowConfigEdit            # let Studio change plugin options in kubb.config.ts',
+    'kubb studio login                        # pair this machine without connecting',
+    'kubb studio status                       # show what this machine is paired as',
+    'kubb studio logout                       # forget the stored token',
+    'kubb studio --url http://localhost:3000  # use a self-hosted Studio',
+  ].join('\n'),
+  args: {
+    action: {
+      type: 'positional',
+      required: false,
+      description: 'connect (default), login, logout or status',
+    },
+    config: {
+      type: 'string',
+      description: 'Path to the Kubb config',
+      short: 'c',
+    },
+    url: {
+      type: 'string',
+      description: 'Base URL of the Kubb Studio instance',
+    },
+    allowWrite: {
+      type: 'boolean',
+      description: 'Write generated files to disk. Asked for once per project when omitted',
+      default: false,
+    },
+    allowConfigEdit: {
+      type: 'boolean',
+      description: 'Let Studio change plugin options in kubb.config.ts. Asked for once per project when omitted',
+      default: false,
+    },
+    allowInput: {
+      type: 'boolean',
+      description: 'Generate from an OpenAPI spec sent by Studio instead of the one on disk. Asked for once per project when omitted',
+      default: false,
+    },
+    allowExec: {
+      type: 'boolean',
+      description: 'Run the formatter, the linter, and output.postGenerate after a generation',
+      default: false,
+    },
+    open: {
+      type: 'boolean',
+      description: 'Open the approval page in a browser while pairing',
+      default: true,
+      negatable: true,
+    },
+    logLevel: {
+      type: 'enum',
+      choices: ['silent', 'info', 'verbose'] as const,
+      description: 'Info, silent or verbose',
+      short: 'l',
+      default: 'info',
+    },
+  },
+})

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,7 +17,7 @@ function stripExecArgs(argv: Array<string>): Array<string> {
 
 /**
  * Entry point for the `kubb` CLI. Prints the telemetry notice unless telemetry is disabled or a
- * quiet flag is passed, then runs the generate, validate, mcp, and init commands. Defaults to
+ * quiet flag is passed, then runs the generate, validate, mcp, studio, and init commands. Defaults to
  * `generate` when no command is given.
  */
 export async function run(argv: Array<string> = process.argv): Promise<void> {
@@ -31,22 +31,27 @@ export async function run(argv: Array<string> = process.argv): Promise<void> {
 
   const { command: generateCommand } = await import('./commands/generate.ts')
   const { command: initCommand } = await import('./commands/init.ts')
-  // Each runner pulls in an optional peer (@kubb/adapter-oas, @kubb/mcp), so it loads only when
-  // its command runs.
+  // Each runner pulls in an optional peer (@kubb/adapter-oas, @kubb/mcp, @kubb/studio), so it
+  // loads only when its command runs.
   const { definition: validateDefinition } = await import('./commands/validate.ts')
   const validateCommand = lazy(async () => (await import('./runners/validate/run.ts')).runner, validateDefinition)
   const { definition: mcpDefinition } = await import('./commands/mcp.ts')
   const mcpCommand = lazy(async () => (await import('./runners/mcp/run.ts')).runner, mcpDefinition)
+  const { definition: studioDefinition } = await import('./commands/studio.ts')
+  const studioCommand = lazy(async () => (await import('./runners/studio/run.ts')).runner, studioDefinition)
 
   await cli(stripExecArgs(argv), generateCommand, {
     name: 'kubb',
     version,
-    description: generateCommand.description,
+    // Not `generateCommand.description`: gunshi prints this on every subcommand's help too, so
+    // `kubb studio --help` would open with a paragraph about generating types.
+    description: 'Generate code from an OpenAPI specification, or connect the project to Kubb Studio.',
     subCommands: {
       generate: generateCommand,
       init: initCommand,
       validate: validateCommand,
       mcp: mcpCommand,
+      studio: studioCommand,
     },
     fallbackToEntry: true,
     strict: true,

--- a/packages/cli/src/loggers/clackLogger.ts
+++ b/packages/cli/src/loggers/clackLogger.ts
@@ -12,6 +12,7 @@ import {
   formatCommandWithArgs,
   formatErrorFrames,
   formatMessage,
+  formatVersions,
   getInputPath,
   recordPluginResult,
   resetProgressCounters,
@@ -192,6 +193,76 @@ Run \`npm install -g @kubb/cli\` to update`,
       // gutter and bar (`symbol`/`secondarySymbol`) and let the block stand on its own.
       const { headline, details } = Diagnostics.format(diagnostic)
       clack.log.message([headline, ...details], { symbol: '', secondarySymbol: '' })
+    })
+
+    // A `kubb studio` session emits these on the same emitter as its generations, so one logger
+    // renders the whole command. The socket opens without being awaited, hence the spinner.
+    context.hook('studio:connecting', ({ url }) => {
+      if (logLevel <= logLevelMap.silent) {
+        return
+      }
+
+      state.spinner = clack.spinner()
+      state.spinner.start(getMessage(`Connecting to ${styleText('cyan', url)}`))
+      state.isSpinning = true
+    })
+
+    context.hook('studio:connected', ({ url, versions }) => {
+      if (logLevel <= logLevelMap.silent) {
+        return
+      }
+
+      const text = getMessage(`Connected to ${styleText('cyan', url)} ${styleText('dim', `(${formatVersions(versions)})`)}`)
+
+      if (state.isSpinning) {
+        stopSpinner(text)
+        return
+      }
+      clack.log.success(text)
+    })
+
+    context.hook('studio:disconnected', ({ reason }) => {
+      if (logLevel < logLevelMap.warn) {
+        return
+      }
+
+      stopSpinner()
+      clack.log.warn(getMessage(`Kubb Studio ended the session (${reason})`))
+    })
+
+    context.hook('studio:command:start', ({ command }) => {
+      if (logLevel <= logLevelMap.silent) {
+        return
+      }
+
+      clack.log.info(getMessage(`Kubb Studio asked to ${styleText('bold', command)}`))
+    })
+
+    context.hook('studio:command:end', ({ command, info }) => {
+      if (logLevel <= logLevelMap.silent) {
+        return
+      }
+
+      clack.log.success(getMessage(`Finished ${command}${info ? ` ${styleText('dim', `(${info})`)}` : ''}`))
+    })
+
+    context.hook('studio:warn', ({ message }) => {
+      if (logLevel < logLevelMap.warn) {
+        return
+      }
+
+      clack.log.warn(getMessage(message))
+    })
+
+    // Unguarded, like `kubb:error`: a failure stays visible even at silent.
+    context.hook('studio:error', ({ error }) => {
+      const text = getMessage([styleText('red', '✗'), error.message].join(' '))
+
+      if (state.isSpinning) {
+        stopSpinner(text)
+        return
+      }
+      clack.log.error(text)
     })
 
     context.hook('kubb:lifecycle:start', async ({ version }) => {

--- a/packages/cli/src/loggers/defineLogger.ts
+++ b/packages/cli/src/loggers/defineLogger.ts
@@ -13,8 +13,8 @@ export type LoggerOptions = {
 
 /**
  * Hook emitter handed to `Logger.install`. Use `.hook('kubb:info', ...)` to subscribe to build
- * hooks. `@kubb/studio` extends `KubbHooks` with `studio:*` session events, so once a package
- * pulls it in, the same emitter carries those too.
+ * hooks, or `.hook('studio:connected', ...)` for the Studio session events a `kubb studio`
+ * connection emits on the same emitter.
  */
 export type LoggerContext = Hookable<KubbHooks>
 

--- a/packages/cli/src/loggers/plainLogger.ts
+++ b/packages/cli/src/loggers/plainLogger.ts
@@ -2,7 +2,7 @@ import { relative } from 'node:path'
 import { formatMs } from '@internals/utils'
 import { Diagnostics, type KubbHooks, logLevel as logLevelMap } from '@kubb/core'
 import type { Logger } from './defineLogger.ts'
-import { createHookTimer, formatCommandWithArgs, formatErrorFrames, formatMessage, getInputPath } from './utils.ts'
+import { createHookTimer, formatCommandWithArgs, formatErrorFrames, formatMessage, formatVersions, getInputPath } from './utils.ts'
 
 /**
  * Plain console adapter for non-TTY environments, built on `console.log`.
@@ -84,6 +84,55 @@ export const plainLogger = {
         return
       }
       console.log(getMessage(Diagnostics.formatLines(diagnostic).join('\n')))
+    })
+
+    // A `kubb studio` session emits these on the same emitter as its generations, so one logger
+    // renders the whole command. Nothing to animate here, so no spinner.
+    context.hook('studio:connecting', ({ url }) => {
+      if (logLevel <= logLevelMap.silent) {
+        return
+      }
+      console.log(getMessage(`Connecting to ${url}`))
+    })
+
+    context.hook('studio:connected', ({ url, versions }) => {
+      if (logLevel <= logLevelMap.silent) {
+        return
+      }
+      console.log(getMessage(`✓ Connected to ${url} (${formatVersions(versions)})`))
+    })
+
+    context.hook('studio:disconnected', ({ reason }) => {
+      if (logLevel < logLevelMap.warn) {
+        return
+      }
+      console.log(getMessage(`⚠ Kubb Studio ended the session (${reason})`))
+    })
+
+    context.hook('studio:command:start', ({ command }) => {
+      if (logLevel <= logLevelMap.silent) {
+        return
+      }
+      console.log(getMessage(`Kubb Studio asked to ${command}`))
+    })
+
+    context.hook('studio:command:end', ({ command, info }) => {
+      if (logLevel <= logLevelMap.silent) {
+        return
+      }
+      console.log(getMessage(`✓ Finished ${command}${info ? ` (${info})` : ''}`))
+    })
+
+    context.hook('studio:warn', ({ message }) => {
+      if (logLevel < logLevelMap.warn) {
+        return
+      }
+      console.log(getMessage(`⚠ ${message}`))
+    })
+
+    // Unguarded, like `kubb:error`: a failure stays visible even at silent.
+    context.hook('studio:error', ({ error }) => {
+      console.log(getMessage(`✗ ${error.message}`))
     })
 
     context.hook('kubb:lifecycle:start', ({ version }) => {

--- a/packages/cli/src/loggers/reporters.test.ts
+++ b/packages/cli/src/loggers/reporters.test.ts
@@ -126,3 +126,50 @@ describe('setupReporters', () => {
     expect(context.listenerCount('kubb:hook:line')).toBeGreaterThan(0)
   })
 })
+
+describe('studio session events', () => {
+  /**
+   * A `kubb studio` connection emits `studio:*` on the same emitter as its generations, so the
+   * loggers `kubb generate` installs render the whole command. Non-TTY here, so `plainLogger`
+   * answers and the output is plain text.
+   */
+  async function render(emit: (context: Hookable<KubbHooks>) => Promise<void> | void, level: number = logLevel.info) {
+    using _tty = vi.spyOn(env, 'canUseTTY').mockReturnValue(false)
+    const context = new Hookable<KubbHooks>()
+    const lines: Array<string> = []
+    using _log = vi.spyOn(console, 'log').mockImplementation((line) => void lines.push(String(line)))
+
+    await setupReporters(context, { logLevel: level, reporters: [cliReporter] })
+    await emit(context)
+
+    return lines
+  }
+
+  it('names both sides on connect, so a version mismatch is visible', async () => {
+    const lines = await render((context) =>
+      context.callHook('studio:connected', { url: 'http://localhost:3000', versions: { studio: '5.1.0', kubb: '5.0.6', agent: '5.0.6' } }),
+    )
+
+    expect(lines).toStrictEqual(['✓ Connected to http://localhost:3000 (v5.0.6, Studio v5.1.0)'])
+  })
+
+  it('reports a command and what it did', async () => {
+    const lines = await render(async (context) => {
+      await context.callHook('studio:command:start', { command: 'save' })
+      await context.callHook('studio:command:end', { command: 'save', info: 'applied 2/3 edits to kubb.config.ts' })
+    })
+
+    expect(lines).toStrictEqual(['Kubb Studio asked to save', '✓ Finished save (applied 2/3 edits to kubb.config.ts)'])
+  })
+
+  it('drops everything but errors at silent', async () => {
+    const lines = await render(async (context) => {
+      await context.callHook('studio:connecting', { url: 'http://localhost:3000' })
+      await context.callHook('studio:warn', { message: 'Ignored save' })
+      // A failure stays visible, or the command exits without saying why.
+      await context.callHook('studio:error', { error: new Error('token revoked') })
+    }, logLevel.silent)
+
+    expect(lines).toStrictEqual(['✗ token revoked'])
+  })
+})

--- a/packages/cli/src/loggers/utils.ts
+++ b/packages/cli/src/loggers/utils.ts
@@ -3,6 +3,7 @@ import { styleText } from 'node:util'
 import { formatMs, getElapsedMs } from '@internals/utils'
 import type { Config, Reporter, ReporterContext } from '@kubb/core'
 import { logLevel as logLevelMap } from '@kubb/core'
+import type { StudioConnectedContext } from '@kubb/studio'
 import { getAgentName } from '../agent.ts'
 import { canUseTTY } from '../utils/env.ts'
 import type { LoggerContext, LoggerOptions } from './defineLogger.ts'
@@ -34,6 +35,14 @@ export function formatMessage(message: string, logLevel: number): string {
     return `${styleText('dim', `[${timestamp}]`)} ${message}`
   }
   return message
+}
+
+/**
+ * Renders the versions from a `studio:connected` event as one parenthetical. The runtime is listed
+ * only when it differs from the host, and Studio's only when it sent one.
+ */
+export function formatVersions({ studio, kubb, agent }: StudioConnectedContext['versions']): string {
+  return [`v${agent}`, kubb !== agent ? `runtime v${kubb}` : undefined, studio ? `Studio v${studio}` : undefined].filter(Boolean).join(', ')
 }
 
 /**

--- a/packages/cli/src/runners/studio/credentials.ts
+++ b/packages/cli/src/runners/studio/credentials.ts
@@ -1,0 +1,79 @@
+import { chmod, mkdir } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { clean, read, write } from '@internals/utils'
+
+/**
+ * Root for everything the CLI persists between runs: the paired credential, the machine secret,
+ * the last Studio config, and the live-session registry. `KUBB_HOME` relocates all of it.
+ */
+export function getKubbHome(): string {
+  return process.env.KUBB_HOME ?? path.join(homedir(), '.kubb')
+}
+
+const CREDENTIALS_FILENAME = 'credentials.json'
+
+/**
+ * Absolute path of the stored credential, so callers can name it in output without rebuilding it.
+ */
+export function getCredentialsPath(): string {
+  return path.join(getKubbHome(), CREDENTIALS_FILENAME)
+}
+
+export type Credentials = {
+  /**
+   * The Studio instance this machine paired with. A different `--url` means re-pairing.
+   */
+  studioUrl: string
+  /**
+   * Bearer token for this machine. Never logged, never printed.
+   */
+  token: string
+  agentId: string
+  agentSlug: string
+  /**
+   * Permissions the user has already granted, keyed by absolute project path, so the CLI asks
+   * once per project instead of on every run.
+   */
+  projects?: Record<string, { allowWrite?: boolean; allowConfigEdit?: boolean; allowInput?: boolean; allowExec?: boolean }>
+}
+
+/**
+ * Reads the stored credential, or null when this machine has not paired yet or the file is
+ * unreadable or corrupt. A bad file is treated as "not paired" so `kubb studio login` can
+ * overwrite it rather than the CLI dying on it.
+ */
+export async function readCredentials(): Promise<Credentials | null> {
+  const raw = await read(getCredentialsPath()).catch(() => null)
+  if (!raw) {
+    return null
+  }
+
+  try {
+    return JSON.parse(raw) as Credentials
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Writes the credential with owner-only permissions. The file holds a bearer token, so the mode
+ * is set explicitly rather than left to the process umask.
+ */
+export async function writeCredentials(credentials: Credentials): Promise<void> {
+  const file = getCredentialsPath()
+
+  await mkdir(path.dirname(file), { recursive: true, mode: 0o700 })
+  await write(file, JSON.stringify(credentials, null, 2))
+  // Not `write`'s own permissions, which only apply when the file is created: an existing
+  // credential file keeps whatever mode it had.
+  await chmod(file, 0o600)
+}
+
+/**
+ * Forgets the stored credential. Succeeds when there was nothing to forget.
+ */
+export async function clearCredentials(): Promise<void> {
+  await clean(getCredentialsPath())
+}

--- a/packages/cli/src/runners/studio/credentials.ts
+++ b/packages/cli/src/runners/studio/credentials.ts
@@ -1,8 +1,8 @@
-import { chmod, mkdir } from 'node:fs/promises'
+import { mkdir, writeFile } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import path from 'node:path'
 import process from 'node:process'
-import { clean, read, write } from '@internals/utils'
+import { clean, read } from '@internals/utils'
 
 /**
  * Root for everything the CLI persists between runs: the paired credential, the machine secret,
@@ -59,16 +59,14 @@ export async function readCredentials(): Promise<Credentials | null> {
 
 /**
  * Writes the credential with owner-only permissions. The file holds a bearer token, so the mode
- * is set explicitly rather than left to the process umask.
+ * is set at creation time rather than left to the process umask or fixed up afterward, which
+ * would leave the token briefly readable under the umask's default mode.
  */
 export async function writeCredentials(credentials: Credentials): Promise<void> {
   const file = getCredentialsPath()
 
   await mkdir(path.dirname(file), { recursive: true, mode: 0o700 })
-  await write(file, JSON.stringify(credentials, null, 2))
-  // Not `write`'s own permissions, which only apply when the file is created: an existing
-  // credential file keeps whatever mode it had.
-  await chmod(file, 0o600)
+  await writeFile(file, JSON.stringify(credentials, null, 2), { mode: 0o600 })
 }
 
 /**

--- a/packages/cli/src/runners/studio/run.test.ts
+++ b/packages/cli/src/runners/studio/run.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as prompts from '@clack/prompts'
+import type { Credentials } from './credentials.ts'
+import { formatPermissionRows, resolvePermissions, type StudioOptions } from './run.ts'
+
+vi.mock('@clack/prompts', () => ({ confirm: vi.fn() }))
+vi.mock('../../utils/env.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../utils/env.ts')>()),
+  isCIEnvironment: () => false,
+  canUseTTY: () => true,
+}))
+vi.mock('./credentials.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./credentials.ts')>()),
+  writeCredentials: vi.fn().mockResolvedValue(undefined),
+}))
+const confirm = vi.mocked(prompts.confirm)
+const { writeCredentials } = await import('./credentials.ts')
+
+const options: StudioOptions = {
+  action: 'connect',
+  version: '0.0.0',
+  studioUrl: 'http://localhost:3000',
+  permission: { allowWrite: false, allowConfigEdit: false, allowInput: false, allowExec: false },
+  autoOpen: false,
+}
+
+const credentials: Credentials = { studioUrl: options.studioUrl, token: 'token', agentId: 'id', agentSlug: 'slug' }
+
+beforeEach(() => {
+  confirm.mockReset()
+  vi.mocked(writeCredentials).mockClear()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('resolvePermissions', () => {
+  it('asks for every permission and stores the answers', async () => {
+    confirm.mockResolvedValueOnce(true).mockResolvedValueOnce(false).mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+
+    const answers = { allowWrite: true, allowConfigEdit: false, allowInput: false, allowExec: true }
+
+    await expect(resolvePermissions(options, credentials)).resolves.toEqual(answers)
+    expect(confirm).toHaveBeenCalledTimes(4)
+    expect(writeCredentials).toHaveBeenCalledWith(expect.objectContaining({ projects: { [process.cwd()]: answers } }))
+  })
+
+  it('asks for editing kubb.config.ts on its own, not as part of writing generated files', async () => {
+    confirm.mockResolvedValue(false)
+
+    await resolvePermissions(options, credentials)
+
+    // The project path is machine-specific, so it is stood in for rather than snapshotted.
+    const questions = confirm.mock.calls.map(([call]) => call?.message?.replace(process.cwd(), '<project>'))
+    expect(questions).toStrictEqual([
+      'Let Kubb Studio write generated files into <project>?',
+      'Let Kubb Studio change plugin options in kubb.config.ts?',
+      'Let Kubb Studio generate from an OpenAPI spec it sends, instead of the one on disk?',
+      'Let Kubb Studio run the formatter, the linter, and output.postGenerate?',
+    ])
+  })
+
+  it('names the config the project actually has, not the default', async () => {
+    confirm.mockResolvedValue(false)
+
+    await resolvePermissions(options, credentials, 'configs/kubb.config.mjs')
+
+    expect(confirm.mock.calls.map(([call]) => call?.message).find((message) => message?.includes('plugin options'))).toBe(
+      'Let Kubb Studio change plugin options in configs/kubb.config.mjs?',
+    )
+  })
+
+  it('asks nothing again once the project answered, and never stores a flag-granted permission', async () => {
+    const remembered = { allowWrite: false, allowConfigEdit: false, allowInput: false, allowExec: false }
+    const stored: Credentials = { ...credentials, projects: { [process.cwd()]: remembered } }
+
+    await expect(resolvePermissions({ ...options, permission: { ...options.permission, allowExec: true } }, stored)).resolves.toEqual({
+      ...remembered,
+      allowExec: true,
+    })
+    expect(confirm).not.toHaveBeenCalled()
+    expect(writeCredentials).not.toHaveBeenCalled()
+  })
+
+  it('still asks for the other three when one permission is granted by flag', async () => {
+    confirm.mockResolvedValue(false)
+
+    await resolvePermissions({ ...options, permission: { ...options.permission, allowConfigEdit: true } }, credentials)
+
+    expect(confirm).toHaveBeenCalledTimes(3)
+    expect(confirm.mock.calls.some(([call]) => call?.message?.includes('plugin options'))).toBe(false)
+  })
+
+  it('still answers the questions but never writes to disk when persist is false', async () => {
+    confirm.mockResolvedValueOnce(true).mockResolvedValueOnce(false).mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+
+    const answers = { allowWrite: true, allowConfigEdit: false, allowInput: false, allowExec: true }
+
+    await expect(resolvePermissions(options, credentials, undefined, false)).resolves.toEqual(answers)
+    expect(confirm).toHaveBeenCalledTimes(4)
+    expect(writeCredentials).not.toHaveBeenCalled()
+  })
+})
+
+describe('formatPermissionRows', () => {
+  it('marks every permission with whether it was granted', () => {
+    expect(formatPermissionRows({ allowWrite: true, allowConfigEdit: false, allowInput: true, allowExec: false })).toStrictEqual([
+      '✔ write generated files',
+      '✘ edit kubb.config.ts',
+      '✔ use a Studio spec',
+      '✘ run formatter, linter, postGenerate',
+    ])
+  })
+})

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -369,7 +369,7 @@ async function status(options: StudioOptions): Promise<void> {
  */
 async function run(options: StudioOptions): Promise<void> {
   // The machine secret lives here and pairing binds it, so storage is installed before anything
-  // reads `getMachineToken()` — which `startPairing` does, before any client exists.
+  // reads `getMachineToken()`, which `startPairing` does, before any client exists.
   setStorage(createFileStorage(path.join(getKubbHome(), 'cache')))
 
   const hrStart = process.hrtime()

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -1,0 +1,438 @@
+import { hostname } from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { styleText } from 'node:util'
+import * as prompts from '@clack/prompts'
+import { KUBB_CONFIG_FILENAME } from '@internals/shared'
+import { toError } from '@internals/utils'
+import type { CLIOptions, Config } from '@kubb/core'
+import { cliReporter, logLevel as logLevelMap } from '@kubb/core'
+import { createFileStorage, createClient, defaultStudioUrl, InvalidAgentTokenError, pollForPairingToken, setStorage, startPairing } from '@kubb/studio'
+import { x } from 'tinyexec'
+import type { CommandRunner } from 'gunshi'
+import { buildTelemetryEvent, sendTelemetry } from '../../Telemetry.ts'
+import { version } from '../../../package.json'
+import type { definition } from '../../commands/studio.ts'
+import setupReporters from '../../loggers/utils.ts'
+import { canUseTTY, isCIEnvironment, isRichOutput } from '../../utils/env.ts'
+import { getConfigs } from '../generate/utils.ts'
+import { clearCredentials, type Credentials, getCredentialsPath, getKubbHome, readCredentials, writeCredentials } from './credentials.ts'
+
+const ACTIONS = ['connect', 'login', 'logout', 'status'] as const
+
+export type StudioAction = (typeof ACTIONS)[number]
+
+type Permission = 'allowWrite' | 'allowConfigEdit' | 'allowInput' | 'allowExec'
+
+export type StudioOptions = {
+  action: StudioAction
+  /**
+   * Current `@kubb/cli` version, reported to Studio and used for the telemetry payload.
+   */
+  version: string
+  configPath?: string
+  /**
+   * Base URL of the Studio instance, for a self-hosted deployment. Resolved before it reaches here,
+   * since stored credentials are bound to it.
+   */
+  studioUrl: string
+  /**
+   * What Studio may do in this project. Each flag grants outright; the rest are asked once per
+   * project through {@link resolvePermissions}.
+   */
+  permission: Record<Permission, boolean>
+  /**
+   * Whether to open the approval page in a browser during pairing.
+   */
+  autoOpen: boolean
+  logLevel?: CLIOptions['logLevel']
+}
+
+/**
+ * Opens a URL in the user's browser. Best effort: a failure just means the user follows the
+ * printed link instead.
+ *
+ * `start` is a `cmd.exe` builtin, not an executable on PATH, so Windows runs it through `cmd`.
+ * The empty string is the window-title argument `start` expects before the URL.
+ */
+async function openInBrowser(url: string): Promise<void> {
+  try {
+    if (process.platform === 'win32') {
+      await x('cmd', ['/c', 'start', '', url])
+    } else {
+      await x(process.platform === 'darwin' ? 'open' : 'xdg-open', [url])
+    }
+  } catch {}
+}
+
+/**
+ * Pairs this machine with Studio and stores the resulting token.
+ *
+ * The CLI holds a code and the browser approves it, rather than the user copying a token out of
+ * the UI. The token comes back over the CLI's own HTTPS POST, so it never lands in a URL, a
+ * server log, or a `Referer` header.
+ */
+async function login({ studioUrl, autoOpen }: StudioOptions): Promise<Credentials> {
+  const session = await startPairing({ studioUrl, name: path.basename(process.cwd()), hostname: hostname() })
+
+  console.log(`\nOpen ${styleText('cyan', session.verification_uri)} and approve the code ${styleText('bold', session.user_code)}`)
+
+  if (autoOpen) {
+    await openInBrowser(session.verification_uri_complete)
+  }
+
+  const spinner = canUseTTY() ? prompts.spinner() : null
+  spinner?.start('Waiting for approval')
+
+  try {
+    const { token, agent } = await pollForPairingToken({ studioUrl, session })
+    spinner?.stop(`Paired as ${agent.name}`)
+
+    const credentials: Credentials = { studioUrl, token, agentId: agent.id, agentSlug: agent.slug }
+    await writeCredentials(credentials)
+
+    console.log(`Credentials stored in ${getCredentialsPath()}`)
+
+    return credentials
+  } catch (error) {
+    spinner?.stop('Pairing failed')
+    throw error
+  }
+}
+
+/**
+ * What each permission is asked as, in the order the questions appear.
+ */
+const PERMISSIONS: ReadonlyArray<{
+  key: Permission
+  /**
+   * Short label for status output and the connect summary.
+   */
+  label: string
+  question: (project: string, configPath: string) => string
+}> = [
+  { key: 'allowWrite', label: 'write generated files', question: (project) => `Let Kubb Studio write generated files into ${project}?` },
+  {
+    key: 'allowConfigEdit',
+    label: 'edit kubb.config.ts',
+    question: (_project, configPath) => `Let Kubb Studio change plugin options in ${configPath}?`,
+  },
+  {
+    key: 'allowInput',
+    label: 'use a Studio spec',
+    question: () => 'Let Kubb Studio generate from an OpenAPI spec it sends, instead of the one on disk?',
+  },
+  {
+    key: 'allowExec',
+    label: 'run formatter, linter, postGenerate',
+    question: () => 'Let Kubb Studio run the formatter, the linter, and output.postGenerate?',
+  },
+]
+
+/**
+ * One row per permission, for the connect banner and `kubb studio status`. A list rather than a
+ * joined line: four labels this long read as one run-on sentence side by side.
+ */
+export function formatPermissionRows(granted: Record<Permission, boolean>): Array<string> {
+  return PERMISSIONS.map(({ key, label }) => `${granted[key] ? styleText('green', '✔') : styleText('red', '✘')} ${label}`)
+}
+
+/**
+ * Resolves Studio permissions for the current project.
+ * Flags win, saved answers are reused, and new answers are stored unless `persist` is false.
+ */
+export async function resolvePermissions(
+  options: StudioOptions,
+  credentials: Credentials,
+  configPath: string = KUBB_CONFIG_FILENAME,
+  /**
+   * Stores new answers in `~/.kubb/credentials.json`.
+   * Pass `false` for `KUBB_AGENT_TOKEN` sessions so a temporary token is not written back to disk.
+   */
+  persist = true,
+): Promise<Record<Permission, boolean>> {
+  const project = process.cwd()
+  const remembered = credentials.projects?.[project]
+  const granted: Record<Permission, boolean> = { allowWrite: false, allowConfigEdit: false, allowInput: false, allowExec: false }
+  const answers: Partial<Record<Permission, boolean>> = {}
+
+  for (const { key, question } of PERMISSIONS) {
+    if (options.permission[key] || typeof remembered?.[key] === 'boolean') {
+      granted[key] = options.permission[key] || remembered?.[key] === true
+      continue
+    }
+
+    if (isCIEnvironment() || !canUseTTY()) {
+      granted[key] = false
+      continue
+    }
+
+    granted[key] = (await prompts.confirm({ message: question(project, configPath), initialValue: false })) === true
+    answers[key] = granted[key]
+  }
+
+  if (persist && Object.keys(answers).length) {
+    await writeCredentials({
+      ...credentials,
+      projects: { ...credentials.projects, [project]: { ...remembered, ...answers } },
+    })
+  }
+
+  return granted
+}
+
+/**
+ * Loads the project's Kubb config the same way `kubb generate` does.
+ * Returns the first config and the full config array.
+ */
+async function loadConfigs(options: StudioOptions): Promise<{ configPath: string; config: Config; configs: Array<Config> }> {
+  const { configPath, configs } = await getConfigs({ configPath: options.configPath, logLevel: options.logLevel })
+  const [config] = configs
+
+  if (!config) {
+    throw new Error('Config not defined, create a kubb.config.ts or pass it with --config')
+  }
+
+  return { configPath, config, configs }
+}
+
+/**
+ * Connects this project to Studio and streams generation events until the process is stopped.
+ */
+async function connect(options: StudioOptions, retryPairing = true): Promise<void> {
+  const envToken = process.env.KUBB_AGENT_TOKEN
+  const stored = envToken ? null : await readCredentials()
+
+  const credentials: Credentials = await (async () => {
+    // A credential is only reused for the Studio it was issued by, so switching `--url` re-pairs
+    // instead of sending one instance's token to another.
+    const resolved = envToken
+      ? { studioUrl: options.studioUrl, token: envToken, agentId: '', agentSlug: '' }
+      : stored?.studioUrl === options.studioUrl
+        ? stored
+        : null
+
+    if (resolved) {
+      return resolved
+    }
+
+    if (isCIEnvironment()) {
+      throw new Error(`Not paired with ${options.studioUrl}. Set KUBB_AGENT_TOKEN, or run \`kubb studio login\` on a machine with a browser.`)
+    }
+
+    return login(options)
+  })()
+
+  const { configPath, configs } = await loadConfigs(options)
+  const { allowWrite, allowConfigEdit, allowInput, allowExec } = await resolvePermissions(options, credentials, configPath, !envToken)
+  const granted = { allowWrite, allowConfigEdit, allowInput, allowExec }
+
+  const logLevel = logLevelMap[options.logLevel ?? 'info']
+  const isRich = isRichOutput()
+  // One clack gutter block, or the same lines plainly.
+  const say = (lines: string | Array<string>) => (isRich ? prompts.log.message(lines) : console.log([lines].flat().join('\n')))
+  const detail = (label: string, value: string) => `${styleText('dim', label.padEnd(7))}  ${value}`
+  let hinted = false
+
+  if (options.logLevel !== 'silent') {
+    say([
+      detail('Studio', styleText('cyan', options.studioUrl)),
+      detail('Project', path.basename(process.cwd())),
+      detail('Config', path.relative(process.cwd(), configPath) || configPath),
+      '',
+      styleText('dim', 'Permissions'),
+      ...formatPermissionRows(granted),
+    ])
+  }
+
+  const client = createClient({
+    token: credentials.token,
+    studioUrl: options.studioUrl,
+    configPath,
+    version: options.version,
+    // Reloaded on every generate, so an edit to kubb.config.ts is picked up without reconnecting.
+    loadConfig: async () => (await loadConfigs(options)).config,
+    client: { kind: 'cli' },
+    root: process.cwd(),
+    allowWrite,
+    allowConfigEdit,
+    allowInput,
+    allowExec,
+    // The loggers `kubb generate` installs, on both emitters, so one place renders the session
+    // events and the generations it drives.
+    installLogger: async (hooks) => {
+      await setupReporters(hooks, { logLevel, reporters: [cliReporter] })
+
+      // `client.connect()` resolves once the agent is registered, not once a session is open, so
+      // this is the only point that knows the connection is live. Registered after the loggers so
+      // it lands under their "Connected to ..." line, and once, since every reconnect fires again.
+      hooks.hook('studio:connected', () => {
+        if (hinted || options.logLevel === 'silent') {
+          return
+        }
+        hinted = true
+
+        say(styleText('dim', 'Press Ctrl+C to disconnect'))
+      })
+    },
+    // The local config bounds what Studio may import. Without this a `generate` payload could name
+    // any module in the project's node_modules and the runtime would import it. Union of every
+    // config entry's plugins, since Studio edits any entry, not only the one it generates from.
+    allowedPlugins: [...new Set(configs.flatMap((entry) => entry.plugins.map((plugin) => plugin.name)))],
+  })
+
+  try {
+    await client.connect()
+  } catch (error) {
+    if (!(error instanceof InvalidAgentTokenError)) {
+      throw error
+    }
+
+    // The token is dead: the agent was deleted in Studio, or the token was revoked. Keeping it
+    // only produces 401s on every run, so forget it and pair again.
+    if (envToken) {
+      throw new Error(`${error.message} Pair again and update KUBB_AGENT_TOKEN.`)
+    }
+
+    await clearCredentials()
+
+    if (isCIEnvironment() || !retryPairing) {
+      throw new Error(`${error.message} Run \`kubb studio login\` to pair again.`)
+    }
+
+    console.log(styleText('yellow', `${error.message} Pairing again...`))
+
+    return connect(options, false)
+  }
+
+  await new Promise<void>((resolve) => {
+    const stop = () => {
+      client.disconnect()
+
+      if (options.logLevel !== 'silent') {
+        // `outro` closes the block `intro` opened, so it is not a written line.
+        if (isRich) {
+          prompts.outro('Disconnected')
+        } else {
+          console.log('Disconnected')
+        }
+      }
+
+      resolve()
+    }
+
+    process.once('SIGINT', stop)
+    process.once('SIGTERM', stop)
+  })
+}
+
+/**
+ * Reports the paired agent and any saved permissions for the current project.
+ */
+async function status(options: StudioOptions): Promise<void> {
+  const credentials = await readCredentials()
+
+  if (!credentials) {
+    console.log('Not paired. Run `kubb studio login`.')
+
+    return
+  }
+
+  console.log(`Paired with ${credentials.studioUrl} as ${styleText('cyan', credentials.agentSlug || credentials.agentId)}`)
+
+  if (credentials.studioUrl !== options.studioUrl) {
+    console.log(styleText('yellow', `Connecting to ${options.studioUrl} needs pairing again.`))
+  }
+
+  const remembered = credentials.projects?.[process.cwd()]
+
+  if (!remembered) {
+    console.log(styleText('dim', 'No saved permissions for this project. Run `kubb studio` to connect and choose.'))
+
+    return
+  }
+
+  console.log(styleText('dim', 'Saved permissions'))
+
+  for (const row of formatPermissionRows({
+    allowWrite: remembered.allowWrite === true,
+    allowConfigEdit: remembered.allowConfigEdit === true,
+    allowInput: remembered.allowInput === true,
+    allowExec: remembered.allowExec === true,
+  })) {
+    console.log(row)
+  }
+}
+
+/**
+ * Runs a `kubb studio` action and reports the outcome to telemetry.
+ */
+async function run(options: StudioOptions): Promise<void> {
+  // The machine secret lives here and pairing binds it, so storage is installed before anything
+  // reads `getMachineToken()` — which `startPairing` does, before any client exists.
+  setStorage(createFileStorage(path.join(getKubbHome(), 'cache')))
+
+  const hrStart = process.hrtime()
+  const report = (status: 'success' | 'failed') => sendTelemetry(buildTelemetryEvent({ command: 'studio', kubbVersion: options.version, hrStart, status }))
+
+  try {
+    if (options.logLevel !== 'silent') {
+      const banner = `Kubb Studio  ${styleText('dim', `v${options.version}`)}`
+      const caution = styleText('yellow', 'This feature is still under development, use with caution')
+
+      if (isRichOutput() && options.action === 'connect') {
+        prompts.intro(banner)
+        prompts.log.warn(caution)
+      } else {
+        console.log(banner)
+        console.warn(caution)
+        console.log()
+      }
+    }
+
+    switch (options.action) {
+      case 'login':
+        await login(options)
+        break
+      case 'logout':
+        await clearCredentials()
+        console.log('Signed out of Kubb Studio.')
+        break
+      case 'status':
+        await status(options)
+        break
+      case 'connect':
+        await connect(options)
+        break
+      default:
+        throw new Error(`Unknown action "${options.action}", expected one of ${ACTIONS.join(', ')}`)
+    }
+
+    await report('success')
+  } catch (error) {
+    await report('failed')
+    console.error(toError(error).message)
+    process.exitCode = 1
+  }
+}
+
+/**
+ * Maps the parsed `kubb studio` flags onto {@link run}. Loaded on demand by `index.ts`, so the
+ * Studio client stays out of the process for every other command.
+ */
+export const runner: CommandRunner<{ args: typeof definition.args; extensions: {} }> = async ({ values }) => {
+  await run({
+    action: (values.action ?? 'connect') as StudioAction,
+    version,
+    configPath: values.config,
+    studioUrl: values.url ?? defaultStudioUrl,
+    permission: {
+      allowWrite: values.allowWrite,
+      allowConfigEdit: values.allowConfigEdit,
+      allowInput: values.allowInput,
+      allowExec: values.allowExec,
+    },
+    autoOpen: values.open,
+    logLevel: values.logLevel,
+  })
+}

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -183,9 +183,9 @@ export async function resolvePermissions(
 
 /**
  * Loads the project's Kubb config the same way `kubb generate` does.
- * Returns the first config and the full config array.
+ * Returns the first config.
  */
-async function loadConfigs(options: StudioOptions): Promise<{ configPath: string; config: Config; configs: Array<Config> }> {
+async function loadConfigs(options: StudioOptions): Promise<{ configPath: string; config: Config }> {
   const { configPath, configs } = await getConfigs({ configPath: options.configPath, logLevel: options.logLevel })
   const [config] = configs
 
@@ -196,7 +196,7 @@ async function loadConfigs(options: StudioOptions): Promise<{ configPath: string
   // `getConfigs` resolves this to an absolute path. Relativized here, once, so the permission
   // prompt and the path Studio receives over the wire both show the project-relative form instead
   // of leaking the local filesystem layout.
-  return { configPath: path.relative(process.cwd(), configPath) || configPath, config, configs }
+  return { configPath: path.relative(process.cwd(), configPath) || configPath, config }
 }
 
 /**
@@ -226,7 +226,7 @@ async function connect(options: StudioOptions, retryPairing = true): Promise<voi
     return login(options)
   })()
 
-  const { configPath, configs } = await loadConfigs(options)
+  const { configPath } = await loadConfigs(options)
   const { allowWrite, allowConfigEdit, allowInput, allowExec } = await resolvePermissions(options, credentials, configPath, !envToken)
   const granted = { allowWrite, allowConfigEdit, allowInput, allowExec }
 
@@ -278,10 +278,6 @@ async function connect(options: StudioOptions, retryPairing = true): Promise<voi
         say(styleText('dim', 'Press Ctrl+C to disconnect'))
       })
     },
-    // The local config bounds what Studio may import. Without this a `generate` payload could name
-    // any module in the project's node_modules and the runtime would import it. Union of every
-    // config entry's plugins, since Studio edits any entry, not only the one it generates from.
-    allowedPlugins: [...new Set(configs.flatMap((entry) => entry.plugins.map((plugin) => plugin.name)))],
   })
 
   try {

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -81,7 +81,7 @@ async function login({ studioUrl, autoOpen }: StudioOptions): Promise<Credential
     await openInBrowser(session.verification_uri_complete)
   }
 
-  const spinner = canUseTTY() ? prompts.spinner() : null
+  const spinner = isRichOutput() ? prompts.spinner() : null
   spinner?.start('Waiting for approval')
 
   try {
@@ -193,7 +193,10 @@ async function loadConfigs(options: StudioOptions): Promise<{ configPath: string
     throw new Error('Config not defined, create a kubb.config.ts or pass it with --config')
   }
 
-  return { configPath, config, configs }
+  // `getConfigs` resolves this to an absolute path. Relativized here, once, so the permission
+  // prompt and the path Studio receives over the wire both show the project-relative form instead
+  // of leaking the local filesystem layout.
+  return { configPath: path.relative(process.cwd(), configPath) || configPath, config, configs }
 }
 
 /**

--- a/packages/kubb/package.json
+++ b/packages/kubb/package.json
@@ -166,7 +166,7 @@
     "rollup": "^4.63.1",
     "typescript": "catalog:",
     "vite": "^8.2.2",
-    "webpack": "^5.110.1"
+    "webpack": "^5.110.2"
   },
   "preferGlobal": true,
   "engines": {

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -22,7 +22,7 @@
 
 # @kubb/studio
 
-### Kubb Studio client runtime
+Kubb Studio client runtime.
 
 Connects a Kubb project to [Kubb Studio](https://kubb.studio) over a WebSocket relay and streams
 code generation events as they happen. It backs both front ends: the `kubb studio` CLI command and

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -1,0 +1,141 @@
+<div align="center">
+  <a href="https://kubb.dev" target="_blank" rel="noopener noreferrer">
+    <img src="https://kubb.dev/og.png" alt="Kubb banner">
+  </a>
+
+[![npm version][npm-version-src]][npm-version-href]
+[![npm downloads][npm-downloads-src]][npm-downloads-href]
+[![Stars][stars-src]][stars-href]
+[![License][license-src]][license-href]
+[![Node][node-src]][node-href]
+
+<h4>
+<a href="https://kubb.dev" target="_blank">Documentation</a>
+<span> · </span>
+<a href="https://github.com/kubb-labs/kubb/issues/" target="_blank">Report Bug</a>
+<span> · </span>
+<a href="https://github.com/kubb-labs/kubb/issues/" target="_blank">Request Feature</a>
+</h4>
+</div>
+
+<br />
+
+# @kubb/studio
+
+### Kubb Studio client runtime
+
+Connects a Kubb project to [Kubb Studio](https://kubb.studio) over a WebSocket relay and streams
+code generation events as they happen. It backs both front ends: the `kubb studio` CLI command and
+the `kubblabs/kubb-agent` Docker image.
+
+Most people never install this directly. Reach for `kubb studio` instead, which pairs your machine
+and runs this for you.
+
+## Installation
+
+```shell
+npm install @kubb/studio
+```
+
+## Usage
+
+```typescript
+import { createClient, createFileStorage } from '@kubb/studio'
+
+const client = createClient({
+  token: process.env.KUBB_AGENT_TOKEN!,
+  configPath: 'kubb.config.ts',
+  version: '1.0.0',
+  loadConfig: () => loadMyKubbConfig(),
+  storage: createFileStorage('./.kubb-cache'),
+})
+
+await client.connect()
+```
+
+The runtime discovers nothing on its own: the host injects the config loader, the storage, and its
+own version. That is what lets one runtime serve a CLI running in a developer's project and a
+container running a fixed plugin set.
+
+## Permissions
+
+Every permission is off by default, and each covers one trust boundary:
+
+| Option           | What it grants                                                                                 |
+| ---------------- | ---------------------------------------------------------------------------------------------- |
+| `allowWrite`     | Generated files are written to disk. Off means they exist only in memory and stream to Studio. |
+| `allowInput`     | An OpenAPI spec sent by Studio replaces the one on disk.                                       |
+| `allowExec`      | The formatter, the linter, and `output.postGenerate` run as child processes.                   |
+| `allowedPlugins` | Module specifiers Studio may name in a generate payload. Unset means no restriction.           |
+
+`allowedPlugins` is the one worth setting whenever the host does not control what is installed:
+plugins are resolved by `import(name)`, so an unrestricted payload can load any module the project
+can reach.
+
+## Connection flow
+
+Both hosts follow the same steps and send the agent's bearer token with every call. `/api/agent` is
+the machine-facing surface, singular because the caller is describing itself. The plural
+`/api/agents` is the collection a signed-in user manages in the browser, and the runtime never
+touches it.
+
+| Step       | Call                                              | What it does                                                                       |
+| ---------- | ------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Register   | `POST /api/agent/connect`                         | Binds the token to this machine with a `machineToken`. A failure here is not fatal |
+| Session    | `POST /api/agent/sessions`                        | Returns `{ wsUrl, sessionId, expiresAt }`                                          |
+| Connect    | `WS` on the returned `wsUrl`                      | Streams generation events until the session expires or is revoked                  |
+| Disconnect | `POST /api/agent/sessions/{sessionId}/disconnect` | Closes the session on a clean shutdown                                             |
+
+The runtime reconnects on its own when a session drops, and keeps retrying while Studio is
+unreachable.
+
+### Pairing
+
+No host starts with a token, so each one pairs over
+[RFC 8628](https://www.rfc-editor.org/rfc/rfc8628.html) device authorization: it asks
+`POST /api/auth/device/code` for a `device_code` and a short `user_code`, shows the code, and polls
+`POST /api/agent/token` until someone approves in the browser. Studio mints the token once and stores only its hash, so
+nothing can read it back.
+
+`startPairing` defaults to the `kubb-cli` client, which `kubb studio login` uses and any signed-in
+member can approve. A host that pairs a shared or tier-limited agent passes `clientId: 'kubb-agent'`
+and an `agentKind`, whose codes only an admin can approve.
+
+## Protocol
+
+`@kubb/studio/protocol` holds the WebSocket message types shared by both ends, so the agent and
+Studio itself compile against one definition rather than two hand-maintained copies.
+
+```typescript
+import { type AgentMessage, isDataMessage } from '@kubb/studio/protocol'
+```
+
+## Supporting Kubb
+
+Kubb is an open source project, and its development is funded entirely by sponsors. If you would like to become a sponsor, please consider:
+
+- [Become a Sponsor on GitHub](https://github.com/sponsors/stijnvanhulle)
+- [See sponsorship tiers and our sponsors](https://kubb.dev/sponsors)
+
+<p align="center">
+  <a href="https://github.com/sponsors/stijnvanhulle">
+    <img src="https://raw.githubusercontent.com/stijnvanhulle/sponsors/main/sponsors.svg" alt="My sponsors" />
+  </a>
+</p>
+
+## License
+
+[MIT](https://github.com/kubb-labs/kubb/blob/main/licenses/LICENSE-MIT)
+
+<!-- Badges -->
+
+[npm-version-src]: https://shieldcn.dev/npm/v/@kubb/studio.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[npm-version-href]: https://npmx.dev/package/@kubb/studio
+[npm-downloads-src]: https://shieldcn.dev/npm/dm/@kubb/studio.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[npm-downloads-href]: https://npmx.dev/package/@kubb/studio
+[stars-src]: https://shieldcn.dev/github/stars/kubb-labs/kubb.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[stars-href]: https://github.com/kubb-labs/kubb
+[license-src]: https://shieldcn.dev/npm/license/@kubb/studio.svg?variant=secondary&size=xs&theme=zinc
+[license-href]: https://github.com/kubb-labs/kubb/blob/main/LICENSE
+[node-src]: https://shieldcn.dev/npm/node/@kubb/studio.svg?variant=secondary&size=xs&theme=zinc&mode=dark
+[node-href]: https://npmx.dev/package/@kubb/studio

--- a/packages/studio/README.md
+++ b/packages/studio/README.md
@@ -61,16 +61,11 @@ container running a fixed plugin set.
 
 Every permission is off by default, and each covers one trust boundary:
 
-| Option           | What it grants                                                                                 |
-| ---------------- | ---------------------------------------------------------------------------------------------- |
-| `allowWrite`     | Generated files are written to disk. Off means they exist only in memory and stream to Studio. |
-| `allowInput`     | An OpenAPI spec sent by Studio replaces the one on disk.                                       |
-| `allowExec`      | The formatter, the linter, and `output.postGenerate` run as child processes.                   |
-| `allowedPlugins` | Module specifiers Studio may name in a generate payload. Unset means no restriction.           |
-
-`allowedPlugins` is the one worth setting whenever the host does not control what is installed:
-plugins are resolved by `import(name)`, so an unrestricted payload can load any module the project
-can reach.
+| Option       | What it grants                                                                                 |
+| ------------ | ---------------------------------------------------------------------------------------------- |
+| `allowWrite` | Generated files are written to disk. Off means they exist only in memory and stream to Studio. |
+| `allowInput` | An OpenAPI spec sent by Studio replaces the one on disk.                                       |
+| `allowExec`  | The formatter, the linter, and `output.postGenerate` run as child processes.                   |
 
 ## Connection flow
 

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -42,10 +42,12 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
     "./protocol": {
+      "types": "./dist/protocol.d.ts",
       "import": "./dist/protocol.js",
       "require": "./dist/protocol.cjs"
     },

--- a/packages/studio/src/client.e2e.test.ts
+++ b/packages/studio/src/client.e2e.test.ts
@@ -1,0 +1,233 @@
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { type Config, memoryStorage } from '@kubb/core'
+import { adapterOas } from '@kubb/adapter-oas'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { WebSocketServer, type WebSocket } from 'ws'
+import { createClient } from './index.ts'
+import type { AgentMessage, AgentConnectMessage, DataMessage } from './protocol/index.ts'
+
+/**
+ * A Kubb Studio small enough to run in a test: the two REST calls an agent makes on startup, and
+ * the session socket it then talks over. Everything the client does is real — the HTTP requests,
+ * the WebSocket frames, the generation.
+ */
+type FakeStudioOptions = {
+  /**
+   * How many session-create calls to answer with a 403 before succeeding. Studio replies this way
+   * when the stored machine token no longer matches the agent.
+   */
+  rejectMachineToken?: number
+}
+
+function createFakeStudio({ rejectMachineToken = 0 }: FakeStudioOptions = {}) {
+  const sockets: Array<WebSocket> = []
+  const received: Array<AgentMessage> = []
+  const calls: Array<string> = []
+  let rejectionsLeft = rejectMachineToken
+
+  const wss = new WebSocketServer({ noServer: true })
+  const server: Server = createServer((req, res) => {
+    // The POST body is not read, but it still has to be drained before `end` fires.
+    req.resume()
+    req.on('end', () => {
+      res.setHeader('content-type', 'application/json')
+      calls.push(req.url ?? '')
+
+      if (req.url === '/api/agent/connect') {
+        return res.end(JSON.stringify({ success: true }))
+      }
+
+      if (req.url === '/api/agent/sessions') {
+        if (rejectionsLeft > 0) {
+          rejectionsLeft--
+          res.statusCode = 403
+
+          return res.end(JSON.stringify({ message: 'machine token mismatch' }))
+        }
+
+        const { port } = server.address() as AddressInfo
+
+        return res.end(
+          JSON.stringify({
+            sessionId: 'session-1',
+            slug: 'brave-otter',
+            wsUrl: `ws://127.0.0.1:${port}/api/agent/sessions/session-1/socket`,
+            expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+            revokedAt: null,
+            isSandbox: false,
+          }),
+        )
+      }
+
+      res.end('{}')
+    })
+  })
+
+  server.on('upgrade', (req, duplex, head) => {
+    wss.handleUpgrade(req, duplex, head, (ws) => {
+      sockets.push(ws)
+      ws.on('message', (raw) => {
+        received.push(JSON.parse(String(raw)) as AgentMessage)
+      })
+    })
+  })
+
+  return {
+    received,
+    calls,
+    async listen(): Promise<string> {
+      await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+      return `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+    },
+    async close() {
+      sockets.forEach((ws) => ws.close())
+      wss.close()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    },
+    /**
+     * Sends to every attached agent. With a pool each slot has its own socket, and a command Studio
+     * broadcasts reaches all of them.
+     */
+    send(message: unknown) {
+      sockets.forEach((ws) => ws.send(JSON.stringify(message)))
+    },
+    /**
+     * Resolves once the agent has sent a message matching `predicate`, so tests wait on the socket
+     * rather than on a timer.
+     */
+    waitFor<T extends AgentMessage>(predicate: (message: AgentMessage) => message is T): Promise<T> {
+      return vi.waitFor(
+        () => {
+          const match = received.find(predicate)
+          if (!match) {
+            throw new Error(`No message from the agent matched. Received: ${received.map((message) => message.type).join(', ') || 'nothing'}`)
+          }
+
+          return match
+        },
+        { timeout: 5000 },
+      )
+    },
+  }
+}
+
+const spec = JSON.stringify({
+  openapi: '3.0.0',
+  info: { title: 'Pets', version: '1.0.0' },
+  paths: { '/pets': { get: { operationId: 'listPets', responses: { '200': { description: 'ok' } } } } },
+})
+
+/**
+ * What a project's `kubb.config.ts` resolves to. Nothing is written to disk: the client is
+ * read-only unless a host grants otherwise, so `storage` stays in memory.
+ */
+function projectConfig(): Config {
+  return {
+    root: process.cwd(),
+    input: spec,
+    output: { path: './gen', write: false },
+    storage: memoryStorage(),
+    adapter: adapterOas({}),
+    plugins: [],
+  } as unknown as Config
+}
+
+const isConnected = (message: AgentMessage): message is AgentConnectMessage => message.type === 'agent:connect'
+const isEnd = (message: AgentMessage): message is DataMessage => message.type === 'agent:data' && message.payload.type === 'kubb:generation:end'
+const isError = (message: AgentMessage): message is DataMessage => message.type === 'agent:data' && message.payload.type === 'kubb:error'
+
+describe('createClient against a Studio instance', () => {
+  let studio: ReturnType<typeof createFakeStudio>
+  let client: ReturnType<typeof createClient> | undefined
+
+  beforeEach(() => {
+    studio = createFakeStudio()
+  })
+
+  afterEach(async () => {
+    client?.disconnect()
+    client = undefined
+    await studio.close()
+  })
+
+  async function connect(options: Partial<Parameters<typeof createClient>[0]> = {}) {
+    const studioUrl = await studio.listen()
+
+    client = createClient({
+      token: 'test-token',
+      studioUrl,
+      configPath: 'kubb.config.ts',
+      version: '0.0.0-test',
+      loadConfig: async () => projectConfig(),
+      ...options,
+    })
+
+    await client.connect()
+
+    return studio.waitFor(isConnected)
+  }
+
+  it('registers, opens a session, and introduces itself with the local config', async () => {
+    const connected = await connect()
+
+    expect(connected.payload.config.path).toBe('kubb.config.ts')
+    expect(connected.payload.versions?.agent).toBe('0.0.0-test')
+    expect(studio.calls).toStrictEqual(['/api/agent/connect', '/api/agent/sessions'])
+  })
+
+  // Studio answers 403 when its stored machine token no longer matches, which happens whenever a
+  // restart raced a failed registration. One re-register and retry has to recover it, or the agent
+  // can never open a session again.
+  it('re-registers and retries once when Studio rejects the machine token', async () => {
+    studio = createFakeStudio({ rejectMachineToken: 1 })
+
+    await connect()
+
+    expect(studio.calls).toStrictEqual(['/api/agent/connect', '/api/agent/sessions', '/api/agent/connect', '/api/agent/sessions'])
+  })
+
+  it('is read-only until a host grants otherwise', async () => {
+    const connected = await connect()
+
+    expect(connected.payload.permissions).toMatchObject({ allowWrite: false, allowInput: false, allowExec: false })
+  })
+
+  it('runs a generation and streams it back to Studio', async () => {
+    await connect()
+
+    studio.send({ type: 'studio:generate', payload: { plugins: [] } })
+
+    await studio.waitFor(isEnd)
+
+    const types = studio.received.filter((message) => message.type === 'agent:data').map((message) => (message as DataMessage).payload.type)
+
+    expect(types).toContain('kubb:generation:start')
+    expect(types).toContain('kubb:build:start')
+    expect(types).toContain('kubb:generation:end')
+  })
+
+  // The allow-list has to reject the payload *before* resolution reaches `import(name)`. Asserting
+  // on the message rather than on "some error happened" is what tells the two apart: without the
+  // allow-list the same payload still fails, just later, from the import itself.
+  it('refuses a plugin the local config does not import, before importing it', async () => {
+    await connect({ allowedPlugins: ['@kubb/plugin-ts'] })
+
+    studio.send({ type: 'studio:generate', payload: { plugins: [{ name: 'evil-module', options: {} }] } })
+
+    const error = await studio.waitFor(isError)
+
+    expect((error.payload.data[0] as { message: string }).message).toContain('the local Kubb config does not import')
+  })
+
+  it('reaches the import, and fails there, when no allow-list is set', async () => {
+    await connect()
+
+    studio.send({ type: 'studio:generate', payload: { plugins: [{ name: 'evil-module', options: {} }] } })
+
+    const error = await studio.waitFor(isError)
+
+    expect((error.payload.data[0] as { message: string }).message).toContain('could not be loaded')
+  })
+})

--- a/packages/studio/src/client.e2e.test.ts
+++ b/packages/studio/src/client.e2e.test.ts
@@ -208,23 +208,20 @@ describe('createClient against a Studio instance', () => {
     expect(types).toContain('kubb:generation:end')
   })
 
-  // The allow-list has to reject the payload *before* resolution reaches `import(name)`. Asserting
-  // on the message rather than on "some error happened" is what tells the two apart: without the
-  // allow-list the same payload still fails, just later, from the import itself.
-  it('refuses a plugin the local config does not import, before importing it', async () => {
+  it('refuses a non-Kubb plugin before importing it', async () => {
     await connect()
 
     studio.send({ type: 'studio:generate', payload: { plugins: [{ name: 'evil-module', options: {} }] } })
 
     const error = await studio.waitFor(isError)
 
-    expect((error.payload.data[0] as { message: string }).message).toContain('the local Kubb config does not import')
+    expect((error.payload.data[0] as { message: string }).message).toContain('is not a @kubb/plugin-* package')
   })
 
-  it('reaches the import, and fails there, when no allow-list is set', async () => {
+  it('reaches the import for a missing Kubb plugin', async () => {
     await connect()
 
-    studio.send({ type: 'studio:generate', payload: { plugins: [{ name: 'evil-module', options: {} }] } })
+    studio.send({ type: 'studio:generate', payload: { plugins: [{ name: '@kubb/plugin-missing', options: {} }] } })
 
     const error = await studio.waitFor(isError)
 

--- a/packages/studio/src/client.e2e.test.ts
+++ b/packages/studio/src/client.e2e.test.ts
@@ -212,7 +212,7 @@ describe('createClient against a Studio instance', () => {
   // on the message rather than on "some error happened" is what tells the two apart: without the
   // allow-list the same payload still fails, just later, from the import itself.
   it('refuses a plugin the local config does not import, before importing it', async () => {
-    await connect({ allowedPlugins: ['@kubb/plugin-ts'] })
+    await connect()
 
     studio.send({ type: 'studio:generate', payload: { plugins: [{ name: 'evil-module', options: {} }] } })
 

--- a/packages/studio/src/client.e2e.test.ts
+++ b/packages/studio/src/client.e2e.test.ts
@@ -9,8 +9,8 @@ import type { AgentMessage, AgentConnectMessage, DataMessage } from './protocol/
 
 /**
  * A Kubb Studio small enough to run in a test: the two REST calls an agent makes on startup, and
- * the session socket it then talks over. Everything the client does is real — the HTTP requests,
- * the WebSocket frames, the generation.
+ * the session socket it then talks over. Everything the client does is real, including the HTTP
+ * requests, the WebSocket frames, and the generation.
  */
 type FakeStudioOptions = {
   /**

--- a/packages/studio/src/client.ts
+++ b/packages/studio/src/client.ts
@@ -1,5 +1,3 @@
-import { getErrorMessage } from '@internals/utils'
-import { styleText } from 'node:util'
 import type { Storage } from 'unstorage'
 import { agentDefaults } from './constants.ts'
 import { registerAgent } from './api.ts'
@@ -50,14 +48,11 @@ export function createClient({ storage, ...options }: ClientOptions): Client {
     async connect() {
       await registerAgent({ token: options.token, studioUrl: options.studioUrl ?? agentDefaults.studioUrl, poolSize })
 
-      for (const slot of Array.from({ length: poolSize }, (_, index) => index + 1)) {
-        // Each slot is its own session, so one Studio user never sees another's generation events.
-        // Not awaited: a slot retrying against a down Studio must not block the others, or the host's
-        // startup. `connectToStudio` owns the retry loop for the lifetime of the slot.
-        void connectToStudio({ ...options, signal: controller.signal }).catch((error: unknown) => {
-          console.warn(styleText('yellow', `Session ${slot}/${poolSize} failed to connect: ${getErrorMessage(error)}`))
-        })
-      }
+      // Each slot is its own session, so one Studio user never sees another's generation events.
+      // Awaited: `connectToStudio` only ever rejects with `InvalidAgentTokenError` (every other
+      // failure is retried internally through its own reconnect loop and resolves normally), so
+      // awaiting here surfaces a dead token to the caller without blocking on a down Studio.
+      await Promise.all(Array.from({ length: poolSize }, () => connectToStudio({ ...options, signal: controller.signal })))
     },
     disconnect() {
       controller.abort()

--- a/packages/studio/src/client.ts
+++ b/packages/studio/src/client.ts
@@ -1,0 +1,66 @@
+import { getErrorMessage } from '@internals/utils'
+import { styleText } from 'node:util'
+import type { Storage } from 'unstorage'
+import { agentDefaults } from './constants.ts'
+import { registerAgent } from './api.ts'
+import { type ConnectToStudioOptions, connectToStudio } from './connectStudio.ts'
+import { setStorage } from './machine.ts'
+
+export type ClientOptions = Omit<ConnectToStudioOptions, 'signal'> & {
+  /**
+   * Where the machine secret and the last Studio config are persisted. Defaults to in-memory,
+   * which gives up a stable machine identity across restarts.
+   */
+  storage?: Storage
+}
+
+export type Client = {
+  /**
+   * Registers with Studio and opens the session pool. Resolves once the pool is starting: the
+   * sessions keep running, and reconnect on their own, until `disconnect` is called.
+   */
+  connect: () => Promise<void>
+  /**
+   * Closes every session and stops reconnecting.
+   */
+  disconnect: () => void
+}
+
+/**
+ * Creates the Kubb Studio client: the connection, the command loop, and the generation event
+ * stream shared by the `kubb studio` CLI command and the Docker agent.
+ *
+ * Every permission is off by default. A host that wants more grants it explicitly.
+ *
+ * @example
+ * ```ts
+ * const studio = createClient({ token, configPath, version, loadConfig: () => loadMyConfig() })
+ * await studio.connect()
+ * ```
+ */
+export function createClient({ storage, ...options }: ClientOptions): Client {
+  if (storage) {
+    setStorage(storage)
+  }
+
+  const controller = new AbortController()
+  const poolSize = options.poolSize ?? agentDefaults.poolSize
+
+  return {
+    async connect() {
+      await registerAgent({ token: options.token, studioUrl: options.studioUrl ?? agentDefaults.studioUrl, poolSize })
+
+      for (const slot of Array.from({ length: poolSize }, (_, index) => index + 1)) {
+        // Each slot is its own session, so one Studio user never sees another's generation events.
+        // Not awaited: a slot retrying against a down Studio must not block the others, or the host's
+        // startup. `connectToStudio` owns the retry loop for the lifetime of the slot.
+        void connectToStudio({ ...options, signal: controller.signal }).catch((error: unknown) => {
+          console.warn(styleText('yellow', `Session ${slot}/${poolSize} failed to connect: ${getErrorMessage(error)}`))
+        })
+      }
+    },
+    disconnect() {
+      controller.abort()
+    },
+  }
+}

--- a/packages/studio/src/connectStudio.test.ts
+++ b/packages/studio/src/connectStudio.test.ts
@@ -1,0 +1,983 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { spyOnConsole } from './console.mock.ts'
+import { MockWebSocket } from './websocket.mock.ts'
+import type { AgentConnectResponse } from './protocol/index.ts'
+import type { Hookable, StudioHooks } from '@kubb/core'
+import type { AgentHooks } from './hooks.ts'
+import type { ConnectToStudioOptions } from './connectStudio.ts'
+import { connectToStudio } from './connectStudio.ts'
+
+vi.mock('./api.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./api.ts')>()),
+  createAgentSession: vi.fn(),
+  disconnect: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock('./generate.ts', () => ({
+  generate: vi.fn().mockResolvedValue(undefined),
+}))
+
+// Config resolution runs for real. It reaches outside the process in two ways — `import()`-ing a
+// plugin package and `import()`-ing the adapter package — so those packages are what gets stubbed.
+vi.mock('@kubb/plugin-ts', () => ({ pluginTs: (options: unknown) => ({ name: 'plugin-ts', options }) }))
+vi.mock('@kubb/plugin-zod', () => ({ pluginZod: (options: unknown) => ({ name: 'plugin-zod', options }) }))
+vi.mock('@kubb/adapter-oas', () => ({ adapterOas: (options: unknown) => ({ name: 'oas', options, parse: vi.fn() }) }))
+vi.mock('../package.json', () => ({
+  default: { version: '5.0.0-test' },
+  version: '5.0.0-test',
+}))
+vi.mock('@kubb/core/package.json', () => ({
+  default: { version: '5.1.0-core-test' },
+  version: '5.1.0-core-test',
+}))
+
+// `setupHookListener` spawns the formatter, the linter, and postGenerate commands through tinyexec.
+vi.mock('tinyexec', () => ({ x: vi.fn(() => Object.assign(Promise.resolve({ exitCode: 0 }), { [Symbol.asyncIterator]: async function* () {} })) }))
+
+vi.mock('./ws.ts', () => ({
+  createWebsocket: vi.fn(),
+  sendAgentMessage: vi.fn(),
+  setupEventsStream: vi.fn(),
+}))
+
+import { createAgentSession, disconnect } from './api.ts'
+import { generate } from './generate.ts'
+
+import { createWebsocket, sendAgentMessage, setupEventsStream } from './ws.ts'
+
+// Shared test helpers
+
+const consoleSpy = spyOnConsole()
+
+/**
+ * Records the `studio:*` session events through the same `installLogger` hook a host uses, so a
+ * test asserts the event and its context rather than a formatted console string.
+ */
+function recordSessionEvents() {
+  type Recorded = { [K in keyof StudioHooks]: { name: K; ctx: StudioHooks[K][0] } }[keyof StudioHooks]
+  const events: Array<Recorded> = []
+
+  return {
+    installLogger(hooks: Hookable<AgentHooks>) {
+      for (const name of [
+        'studio:connecting',
+        'studio:connected',
+        'studio:disconnected',
+        'studio:command:start',
+        'studio:command:end',
+        'studio:warn',
+        'studio:error',
+      ] as const) {
+        hooks.hook(name, (ctx) => events.push({ name, ctx } as Recorded))
+      }
+    },
+    warnings(): Array<string> {
+      return events.flatMap((event) => (event.name === 'studio:warn' ? [event.ctx.message] : []))
+    },
+    errors(): Array<Error> {
+      return events.flatMap((event) => (event.name === 'studio:error' ? [event.ctx.error] : []))
+    },
+    named<K extends keyof StudioHooks>(name: K) {
+      return events.filter((event): event is Extract<Recorded, { name: K }> => event.name === name)
+    },
+  }
+}
+
+const loadConfig = vi.fn()
+
+const makeSession = (overrides: Partial<AgentConnectResponse> = {}): AgentConnectResponse => ({
+  sessionId: 'session-abc',
+  slug: 'brave-otter',
+  wsUrl: 'ws://localhost:3000/ws/session-abc',
+  isSandbox: false,
+  expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+  revokedAt: null,
+  ...overrides,
+})
+
+const makeConfig = (overrides = {}) => ({
+  name: 'test',
+  input: 'spec.yaml',
+  output: { path: './gen', write: false },
+  plugins: [],
+  ...overrides,
+})
+
+describe('connectToStudio', () => {
+  let mockWs: MockWebSocket
+  let options: ConnectToStudioOptions
+  let controller: AbortController
+  let session: ReturnType<typeof recordSessionEvents>
+
+  beforeEach(() => {
+    mockWs = new MockWebSocket()
+    session = recordSessionEvents()
+    controller = new AbortController()
+    vi.mocked(createWebsocket).mockReturnValue(mockWs as any)
+    vi.mocked(createAgentSession).mockResolvedValue(makeSession())
+    loadConfig.mockResolvedValue(makeConfig() as any)
+
+    options = {
+      token: 'my-token',
+      studioUrl: 'https://kubb.studio',
+      configPath: 'kubb.config.ts',
+      loadConfig,
+      version: '1.0.0',
+      signal: controller.signal,
+      allowWrite: false,
+      allowInput: false,
+      root: '/project',
+      retryInterval: 100,
+      installLogger: session.installLogger,
+    }
+  })
+
+  afterEach(() => {
+    // `connectToStudio` retries forever until its signal aborts, so a test that leaves a failed
+    // connection behind would keep reconnecting into the next one.
+    controller.abort()
+    vi.clearAllMocks()
+    vi.useRealTimers()
+  })
+
+  afterAll(() => {
+    Object.values(consoleSpy).forEach((spy) => spy.mockRestore())
+  })
+
+  // Session creation
+
+  it('creates an agent session with the provided credentials', async () => {
+    await connectToStudio(options)
+
+    expect(createAgentSession).toHaveBeenCalledWith({
+      token: 'my-token',
+      studioUrl: 'https://kubb.studio',
+    })
+  })
+
+  it('installs the host renderer on the session emitter and on every generation', async () => {
+    const emitters: Array<Hookable<AgentHooks>> = []
+
+    await connectToStudio({ ...options, installLogger: (hooks) => void emitters.push(hooks) })
+
+    // The session emitter, installed before the socket exists so a failed connect still reports.
+    expect(emitters).toHaveLength(1)
+
+    await mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:generate', payload: { plugins: [] } }),
+    })
+
+    // The generation gets its own emitter, so its events cannot bleed into another session's.
+    expect(emitters).toHaveLength(2)
+    expect(emitters[0]).not.toBe(emitters[1])
+  })
+
+  it('creates a WebSocket with the session wsUrl and Bearer auth header', async () => {
+    await connectToStudio(options)
+
+    expect(createWebsocket).toHaveBeenCalledWith('ws://localhost:3000/ws/session-abc', {
+      headers: { Authorization: 'Bearer my-token' },
+    })
+  })
+
+  // Studio being unreachable at startup is temporary (a 502 mid-deploy), and no socket exists yet,
+  // so none of the socket-driven reconnect paths can fire. Giving up here would drop the pool slot
+  // for the lifetime of the process.
+  it('retries instead of giving up when the session cannot be created', async () => {
+    vi.useFakeTimers()
+    vi.mocked(createAgentSession).mockRejectedValueOnce(new Error('Network error'))
+
+    await connectToStudio(options)
+
+    expect(session.errors().map((error) => error.message)).toContainEqual(expect.stringContaining('Network error'))
+
+    await vi.advanceTimersByTimeAsync(options.retryInterval!)
+
+    expect(createAgentSession).toHaveBeenCalledTimes(2)
+  })
+
+  // Studio counts an agent offline once its ping is older than its liveness window, so the clamp
+  // is a protocol contract. It lives here because every host goes through this function.
+  it('clamps a heartbeat interval above the ceiling Studio allows', async () => {
+    vi.useFakeTimers()
+
+    await connectToStudio({ ...options, heartbeatInterval: 10 * 60_000 })
+    await mockWs.trigger('open')
+    vi.mocked(sendAgentMessage).mockClear()
+
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    expect(sendAgentMessage).toHaveBeenCalledWith(mockWs, { type: 'agent:ping' })
+  })
+
+  it('stops retrying once the signal aborts', async () => {
+    vi.useFakeTimers()
+    vi.mocked(createAgentSession).mockRejectedValueOnce(new Error('Network error'))
+
+    await connectToStudio(options)
+    controller.abort()
+
+    await vi.advanceTimersByTimeAsync(options.retryInterval! * 3)
+
+    expect(createAgentSession).toHaveBeenCalledTimes(1)
+  })
+
+  // WebSocket messages
+
+  it('accepts a pong without treating it as an unknown message', async () => {
+    await connectToStudio(options)
+
+    await mockWs.trigger('message', { data: JSON.stringify({ type: 'studio:ping' }) })
+
+    expect(session.warnings()).not.toContainEqual(expect.stringContaining('unknown message'))
+  })
+
+  it('logs a warning for unknown message types', async () => {
+    await connectToStudio(options)
+
+    await mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'unknown' }),
+    })
+
+    expect(session.warnings()).toContainEqual(expect.stringContaining('unknown message'))
+  })
+
+  // Handshake and liveness
+
+  it('sends the connected payload when the WebSocket opens', async () => {
+    await connectToStudio(options)
+
+    await mockWs.trigger('open')
+
+    // onOpen sends the connected payload without awaiting it, and it now reads storage first,
+    // so let the fire-and-forget send settle before asserting.
+    await vi.waitFor(() => expect(sendAgentMessage).toHaveBeenCalledWith(mockWs, expect.objectContaining({ type: 'agent:connect' })))
+  })
+
+  it('logs the slug when the WebSocket opens', async () => {
+    await connectToStudio(options)
+
+    await mockWs.trigger('open')
+
+    expect(session.named('studio:connected')).toStrictEqual([
+      { name: 'studio:connected', ctx: { url: 'https://kubb.studio', versions: { studio: undefined, kubb: '5.0.0-test', agent: '1.0.0' } } },
+    ])
+  })
+
+  it('logs the slug when the WebSocket errors', async () => {
+    await connectToStudio(options)
+
+    await mockWs.trigger('error')
+
+    expect(session.named('studio:error')).toStrictEqual([
+      { name: 'studio:error', ctx: { error: expect.objectContaining({ message: 'Failed to connect to Kubb Studio' }) } },
+    ])
+  })
+
+  it('terminates the connection when no pong arrives within two heartbeat intervals', async () => {
+    vi.useFakeTimers()
+    options.heartbeatInterval = 1_000
+
+    await connectToStudio(options)
+    await mockWs.trigger('open')
+
+    await vi.advanceTimersByTimeAsync(3_000)
+
+    expect(mockWs.terminated).toBe(true)
+  })
+
+  it('keeps the connection alive while pongs keep arriving', async () => {
+    vi.useFakeTimers()
+    options.heartbeatInterval = 1_000
+
+    await connectToStudio(options)
+    await mockWs.trigger('open')
+
+    for (const _ of Array.from({ length: 5 })) {
+      await vi.advanceTimersByTimeAsync(1_000)
+      await mockWs.trigger('message', { data: JSON.stringify({ type: 'studio:ping' }) })
+    }
+
+    expect(mockWs.terminated).toBe(false)
+  })
+
+  // save command
+
+  describe('save', () => {
+    const original = [
+      `import { defineConfig } from 'kubb/config'`,
+      `import { pluginTs } from '@kubb/plugin-ts'`,
+      ``,
+      `// Keep the enum shape stable for consumers.`,
+      `export default defineConfig({`,
+      `  input: './openapi.yaml',`,
+      `  plugins: [pluginTs({ enum: { type: 'asConst' }, group: { type: 'tag', name: ({ group }) => group } })],`,
+      `})`,
+      ``,
+    ].join('\n')
+
+    let projectRoot: string
+    let configFile: string
+
+    /**
+     * The `kubb:config-saved` reply the agent sent, if any.
+     */
+    const reply = () =>
+      vi
+        .mocked(sendAgentMessage)
+        .mock.calls.map(([, message]) => message)
+        .find((message) => message.type === 'agent:save')
+
+    beforeEach(() => {
+      projectRoot = mkdtempSync(path.join(tmpdir(), 'kubb-studio-'))
+      configFile = path.join(projectRoot, 'kubb.config.ts')
+      writeFileSync(configFile, original, 'utf-8')
+      options = { ...options, root: projectRoot }
+    })
+
+    afterEach(() => {
+      rmSync(projectRoot, { recursive: true, force: true })
+    })
+
+    const write = async (edits: Array<unknown>) => mockWs.trigger('message', { data: JSON.stringify({ type: 'studio:save', edits }) })
+
+    it('writes a literal option and leaves the rest of the file alone', async () => {
+      await connectToStudio({ ...options, allowConfigEdit: true })
+
+      await write([{ operation: 'set', plugin: '@kubb/plugin-ts', path: ['enum', 'type'], value: 'enum' }])
+
+      expect(readFileSync(configFile, 'utf-8')).toBe(original.replace("'asConst'", "'enum'"))
+      expect(reply()).toMatchObject({ payload: { changed: true, outcomes: [{ applied: true }] } })
+    })
+
+    it('comments a plugin out on disable and restores it on enable, keeping every other line', async () => {
+      // A plugin needs its own line to be commented out safely, unlike `original` above where a
+      // single call shares its line with `plugins: [`.
+      const multiline = [
+        `import { defineConfig } from 'kubb/config'`,
+        `import { pluginTs } from '@kubb/plugin-ts'`,
+        `import { pluginZod } from '@kubb/plugin-zod'`,
+        ``,
+        `export default defineConfig({`,
+        `  plugins: [`,
+        `    pluginTs({ enum: { type: 'asConst' } }),`,
+        `    pluginZod({`,
+        `      inferred: true,`,
+        `    }),`,
+        `  ],`,
+        `})`,
+        ``,
+      ].join('\n')
+      writeFileSync(configFile, multiline, 'utf-8')
+
+      await connectToStudio({ ...options, allowConfigEdit: true })
+
+      await write([{ operation: 'disable-plugin', plugin: '@kubb/plugin-zod' }])
+      const disabled = readFileSync(configFile, 'utf-8')
+      expect(disabled).toContain('// kubb:disabled @kubb/plugin-zod')
+      expect(disabled).toContain('//   inferred: true,')
+      expect(disabled).toContain("pluginTs({ enum: { type: 'asConst' } }),")
+
+      await write([{ operation: 'enable-plugin', plugin: '@kubb/plugin-zod' }])
+      expect(readFileSync(configFile, 'utf-8')).toBe(multiline)
+    })
+
+    it('refuses every edit when editing the config was not granted', async () => {
+      await connectToStudio({ ...options, allowConfigEdit: false })
+
+      await write([{ operation: 'set', plugin: '@kubb/plugin-ts', path: ['enum', 'type'], value: 'enum' }])
+
+      expect(readFileSync(configFile, 'utf-8')).toBe(original)
+      expect(reply()?.payload).toMatchObject({ changed: false, outcomes: [{ applied: false }] })
+    })
+
+    it('refuses in sandbox mode even when the host granted it', async () => {
+      vi.mocked(createAgentSession).mockResolvedValue(makeSession({ isSandbox: true }))
+
+      await connectToStudio({ ...options, allowConfigEdit: true })
+
+      await write([{ operation: 'set', plugin: '@kubb/plugin-ts', path: ['enum', 'type'], value: 'enum' }])
+
+      expect(readFileSync(configFile, 'utf-8')).toBe(original)
+    })
+
+    it('leaves an option customized in code untouched', async () => {
+      await connectToStudio({ ...options, allowConfigEdit: true })
+
+      await write([{ operation: 'set', plugin: '@kubb/plugin-ts', path: ['group', 'name'], value: 'x' }])
+
+      expect(readFileSync(configFile, 'utf-8')).toBe(original)
+      expect(reply()?.payload.outcomes[0]?.reason).toBe('group.name is customized in code')
+    })
+
+    // Studio only ever saw the file as it was on connect. Re-reading it right before the patch is
+    // what saves an edit the user made in their editor since then.
+    it('patches the file as it is on disk, not as it was on connect', async () => {
+      await connectToStudio({ ...options, allowConfigEdit: true })
+
+      const editedByHand = original.replace("'./openapi.yaml'", "'./petstore.yaml'")
+      writeFileSync(configFile, editedByHand, 'utf-8')
+
+      await write([{ operation: 'set', plugin: '@kubb/plugin-ts', path: ['enum', 'type'], value: 'enum' }])
+
+      expect(readFileSync(configFile, 'utf-8')).toBe(editedByHand.replace("'asConst'", "'enum'"))
+    })
+
+    // Studio waits on the reply, so a failure that produced none would hang its UI.
+    it('still replies when the config file cannot be read', async () => {
+      await connectToStudio({ ...options, allowConfigEdit: true })
+
+      rmSync(configFile)
+      await write([{ operation: 'set', plugin: '@kubb/plugin-ts', path: ['enum', 'type'], value: 'enum' }])
+
+      expect(reply()?.payload).toMatchObject({ changed: false, outcomes: [{ applied: false }] })
+    })
+
+    it('still replies when the message carries no edits', async () => {
+      await connectToStudio({ ...options, allowConfigEdit: true })
+
+      await mockWs.trigger('message', { data: JSON.stringify({ type: 'studio:save' }) })
+
+      expect(reply()?.payload).toMatchObject({ changed: false, outcomes: [] })
+    })
+
+    it('reports what the file holds on connect so Studio can disable the right controls', async () => {
+      await connectToStudio({ ...options, allowConfigEdit: true })
+
+      await mockWs.trigger('message', { data: JSON.stringify({ type: 'studio:connect' }) })
+
+      const connected = vi
+        .mocked(sendAgentMessage)
+        .mock.calls.map(([, message]) => message)
+        .find((message) => message.type === 'agent:connect')
+
+      expect(connected?.type === 'agent:connect' && connected.payload.config.file).toStrictEqual({
+        configs: [
+          {
+            name: undefined,
+            plugins: [
+              {
+                importName: 'pluginTs',
+                options: {
+                  enum: {
+                    literal: true,
+                    value: {
+                      type: 'asConst',
+                    },
+                  },
+                  group: {
+                    literal: false,
+                  },
+                },
+                packageName: '@kubb/plugin-ts',
+              },
+            ],
+          },
+        ],
+        managed: true,
+      })
+    })
+  })
+
+  // generate command
+
+  it('calls generate with the resolved config on a generate command', async () => {
+    await connectToStudio(options)
+
+    await mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:generate' }),
+    })
+
+    expect(generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({ name: 'test' }),
+      }),
+    )
+  })
+
+  it('generates with the plugins the payload names', async () => {
+    const payload = { plugins: [{ name: '@kubb/plugin-ts', options: {} }] }
+
+    await connectToStudio(options)
+
+    await mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:generate', payload }),
+    })
+
+    expect(generate).toHaveBeenCalledWith(
+      expect.objectContaining({ config: expect.objectContaining({ plugins: [expect.objectContaining({ name: 'plugin-ts' })] }) }),
+    )
+  })
+
+  it('disables write in sandbox mode even when allowWrite is true', async () => {
+    vi.mocked(createAgentSession).mockResolvedValue(makeSession({ isSandbox: true }))
+
+    await connectToStudio({ ...options, allowWrite: true })
+
+    await mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:generate' }),
+    })
+
+    expect(generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          output: expect.objectContaining({ write: false }),
+        }),
+      }),
+    )
+  })
+
+  it('uses inline input from payload in sandbox mode', async () => {
+    // Use a fresh connectToStudio call with isSandbox=true baked into the session
+    vi.mocked(createAgentSession).mockResolvedValue(makeSession({ isSandbox: true }))
+    const sandboxWs = new MockWebSocket()
+    vi.mocked(createWebsocket).mockReturnValue(sandboxWs as any)
+
+    const payload = { input: 'openapi: "3.0.0"', plugins: [] }
+
+    await connectToStudio(options)
+
+    await sandboxWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:generate', payload }),
+    })
+
+    expect(generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          input: 'openapi: "3.0.0"',
+        }),
+      }),
+    )
+  })
+
+  it('ignores inline input from payload for a local agent that has not opted in', async () => {
+    const payload = { input: 'openapi: "3.0.0"', plugins: [] }
+
+    await connectToStudio(options) // allowInput: false
+
+    await mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:generate', payload }),
+    })
+
+    // Without allowInput the spec stays the on-disk config.input
+    expect(generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({ input: 'spec.yaml' }),
+      }),
+    )
+    expect(session.warnings()).toContainEqual(expect.stringContaining('KUBB_AGENT_ALLOW_INPUT'))
+  })
+
+  it('tells a CLI host to use --allowInput instead of the Docker-only env var', async () => {
+    const payload = { input: 'openapi: "3.0.0"', plugins: [] }
+
+    await connectToStudio({ ...options, client: { kind: 'cli' } }) // allowInput: false
+
+    await mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:generate', payload }),
+    })
+
+    expect(session.warnings()).toContainEqual(expect.stringContaining('--allowInput'))
+    expect(session.warnings()).not.toContainEqual(expect.stringContaining('KUBB_AGENT_ALLOW_INPUT'))
+  })
+
+  it('uses inline input from payload for a local agent when allowInput is enabled', async () => {
+    const payload = { input: 'openapi: "3.0.0"', plugins: [] }
+
+    await connectToStudio({ ...options, allowInput: true })
+
+    await mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:generate', payload }),
+    })
+
+    expect(generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({ input: 'openapi: "3.0.0"' }),
+      }),
+    )
+  })
+
+  it('falls back to the on-disk input for a local agent when allowInput is enabled but no spec is sent', async () => {
+    const payload = { plugins: [] }
+
+    await connectToStudio({ ...options, allowInput: true })
+
+    await mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:generate', payload }),
+    })
+
+    expect(generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({ input: 'spec.yaml' }),
+      }),
+    )
+  })
+
+  it('skips the formatter, the linter, and postGenerate when exec is not allowed', async () => {
+    loadConfig.mockResolvedValue(makeConfig({ output: { path: './gen', format: 'auto', lint: 'auto', postGenerate: ['echo hi'] } }))
+
+    await connectToStudio({ ...options, allowExec: false })
+
+    await mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:generate', payload: { plugins: [] } }),
+    })
+
+    expect(generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({ output: expect.objectContaining({ format: false, lint: false, postGenerate: [] }) }),
+      }),
+    )
+  })
+
+  it('rejects a payload naming a plugin outside the allow-list instead of importing it', async () => {
+    await connectToStudio({ ...options, allowedPlugins: ['@kubb/plugin-ts'] })
+
+    await mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:generate', payload: { plugins: [{ name: 'evil-module', options: {} }] } }),
+    })
+
+    expect(generate).not.toHaveBeenCalled()
+    expect(session.errors().map((error) => error.message)).toContainEqual(expect.stringContaining('evil-module'))
+  })
+
+  // An adapter instance carries closures that cannot survive JSON, so the payload is an options
+  // patch: the adapter factory is re-invoked with the merged options rather than replaced by the
+  // plain object Studio sent.
+  it('re-invokes the adapter factory with the payload options merged in', async () => {
+    loadConfig.mockResolvedValueOnce(makeConfig({ adapter: { name: 'oas', options: { validate: true } } }) as any)
+    const payload = { adapter: { server: { index: 1 } }, plugins: [] }
+
+    await connectToStudio(options)
+
+    await mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:generate', payload }),
+    })
+
+    const adapter = vi.mocked(generate).mock.calls[0]?.[0].config.adapter
+
+    expect(adapter?.options).toStrictEqual({ validate: true, server: { index: 1 } })
+    expect(adapter).toHaveProperty('parse')
+  })
+
+  it('preserves the disk config adapter when payload has no adapter', async () => {
+    const diskAdapter = { name: 'oas', options: {}, parse: vi.fn() }
+    loadConfig.mockResolvedValueOnce(makeConfig({ adapter: diskAdapter }) as any)
+    const payload = { plugins: [] }
+
+    await connectToStudio(options)
+
+    await mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:generate', payload }),
+    })
+
+    const call = vi.mocked(generate).mock.calls[0]?.[0]
+    expect(call?.config).toHaveProperty('adapter', diskAdapter)
+  })
+
+  it('ignores a second generate command while one is already in progress', async () => {
+    let resolveGenerate: () => void = () => {}
+    vi.mocked(generate).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveGenerate = resolve
+        }),
+    )
+
+    await connectToStudio(options)
+
+    const first = mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:generate' }),
+    })
+
+    // Wait until `generate()` is actually in flight (loadConfig/mergePlugins/etc. resolve
+    // over several microtasks) before firing the second command, so it reliably lands
+    // while the first generation is still running.
+    await vi.waitFor(() => expect(generate).toHaveBeenCalledTimes(1))
+
+    const second = mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:generate' }),
+    })
+
+    resolveGenerate()
+    await Promise.all([first, second])
+
+    expect(generate).toHaveBeenCalledTimes(1)
+    expect(session.warnings()).toContainEqual(expect.stringContaining('already in progress'))
+  })
+
+  it('allows a new generate command once the previous one has finished', async () => {
+    await connectToStudio(options)
+
+    await mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:generate' }),
+    })
+    await mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:generate' }),
+    })
+
+    expect(generate).toHaveBeenCalledTimes(2)
+  })
+
+  // The event stream is wired to the generation emitter only. The connection emitter carries just
+  // `kubb:error`, so two generations can never interleave their events on one socket.
+  it('uses an isolated hooks emitter for each generate command', async () => {
+    await connectToStudio(options)
+
+    await mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:generate', payload: { plugins: [] } }),
+    })
+
+    const generationHooks = vi.mocked(setupEventsStream).mock.calls[0]?.[1]
+    const generateHooks = vi.mocked(generate).mock.calls[0]?.[0].hooks
+
+    expect(setupEventsStream).toHaveBeenCalledTimes(1)
+    expect(generateHooks).toBe(generationHooks)
+  })
+
+  // connect command
+
+  it('sends a connected message with agent info on a connect command', async () => {
+    await connectToStudio(options)
+
+    await mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:connect' }),
+    })
+
+    expect(sendAgentMessage).toHaveBeenCalledWith(
+      mockWs,
+      expect.objectContaining({
+        type: 'agent:connect',
+        payload: expect.objectContaining({
+          versions: {
+            kubb: '5.0.0-test',
+            agent: '1.0.0',
+          },
+          root: '/project',
+          config: expect.objectContaining({ path: 'kubb.config.ts' }),
+        }),
+      }),
+    )
+  })
+
+  it('announces a shutdown so Studio does not wait out the heartbeat window', async () => {
+    await connectToStudio(options)
+
+    controller.abort()
+    await vi.waitFor(() => expect(sendAgentMessage).toHaveBeenCalledWith(mockWs, { type: 'agent:disconnect', reason: 'shutdown' }))
+  })
+
+  it('stays quiet when Studio is the one ending the session', async () => {
+    await connectToStudio(options)
+
+    // Studio decided this, so echoing it back would say nothing new.
+    await mockWs.trigger('message', { data: JSON.stringify({ type: 'studio:disconnect', reason: 'revoked' }) })
+
+    expect(sendAgentMessage).not.toHaveBeenCalledWith(mockWs, expect.objectContaining({ type: 'agent:disconnect' }))
+  })
+
+  // Studio's UI only sends `studio:connect` from its own socket's `open`, so it always lands after
+  // the agent has already announced itself. The version has to come off the session response, or
+  // the connect line can never name both sides.
+  it('names Studio from the session response, before any command arrives', async () => {
+    vi.mocked(createAgentSession).mockResolvedValue(makeSession({ version: '9.9.9' }))
+
+    await connectToStudio(options)
+    await mockWs.trigger('open')
+
+    expect(session.named('studio:connected').at(-1)?.ctx).toStrictEqual({
+      url: 'https://kubb.studio',
+      versions: { studio: '9.9.9', kubb: '5.0.0-test', agent: '1.0.0' },
+    })
+  })
+
+  // `addEventListener` drops the promise its listener returns, so a throwing logger used to reach
+  // the process as an unhandled rejection.
+  it('survives a logger that throws while announcing the connection', async () => {
+    const rejections: Array<unknown> = []
+    const onUnhandled = (reason: unknown) => rejections.push(reason)
+    const processEvents = process as unknown as NodeJS.EventEmitter
+    processEvents.on('unhandledRejection', onUnhandled)
+
+    try {
+      await connectToStudio({
+        ...options,
+        installLogger: (hooks) => {
+          hooks.hook('studio:connected', () => {
+            throw new Error('broken logger')
+          })
+        },
+      })
+
+      await mockWs.trigger('open')
+      await new Promise((resolve) => setImmediate(resolve))
+
+      expect(rejections).toStrictEqual([])
+    } finally {
+      processEvents.off('unhandledRejection', onUnhandled)
+    }
+  })
+
+  it('refreshes the Studio version from a later studio:connect', async () => {
+    vi.mocked(createAgentSession).mockResolvedValue(makeSession({ version: '9.9.9' }))
+
+    await connectToStudio(options)
+    await mockWs.trigger('message', { data: JSON.stringify({ type: 'studio:connect', version: '10.0.0' }) })
+    await mockWs.trigger('open')
+
+    expect(session.named('studio:connected').at(-1)?.ctx.versions).toStrictEqual({ studio: '10.0.0', kubb: '5.0.0-test', agent: '1.0.0' })
+  })
+
+  it('reflects allowWrite in permissions on connect command', async () => {
+    await connectToStudio({ ...options, allowWrite: true })
+
+    await mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:connect' }),
+    })
+
+    expect(sendAgentMessage).toHaveBeenCalledWith(
+      mockWs,
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          permissions: {
+            allowWrite: true,
+            allowConfigEdit: false,
+            allowInput: false,
+            allowExec: false,
+          },
+        }),
+      }),
+    )
+  })
+
+  it('advertises allowInput in permissions when the agent opts in', async () => {
+    await connectToStudio({ ...options, allowInput: true })
+
+    await mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:connect' }),
+    })
+
+    expect(sendAgentMessage).toHaveBeenCalledWith(
+      mockWs,
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          permissions: {
+            allowWrite: false,
+            allowConfigEdit: false,
+            allowInput: true,
+            allowExec: false,
+          },
+        }),
+      }),
+    )
+  })
+
+  it('disables write in sandbox mode but still accepts input', async () => {
+    vi.mocked(createAgentSession).mockResolvedValue(makeSession({ isSandbox: true }))
+    const sandboxWs = new MockWebSocket()
+    vi.mocked(createWebsocket).mockReturnValue(sandboxWs as any)
+
+    await connectToStudio({ ...options, allowWrite: true })
+
+    await sandboxWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:connect' }),
+    })
+
+    expect(sendAgentMessage).toHaveBeenCalledWith(
+      sandboxWs,
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          permissions: {
+            allowWrite: false,
+            allowConfigEdit: false,
+            allowInput: true,
+            allowExec: false,
+          },
+        }),
+      }),
+    )
+  })
+
+  // Reconnect on close / error
+
+  it('calls disconnect when the WebSocket closes', async () => {
+    vi.useFakeTimers()
+
+    await connectToStudio(options)
+
+    await mockWs.trigger('close')
+
+    expect(disconnect).toHaveBeenCalledWith({
+      sessionId: 'session-abc',
+      studioUrl: 'https://kubb.studio',
+      token: 'my-token',
+      slug: 'brave-otter',
+    })
+  })
+
+  it('closes the WebSocket without reconnecting when a disconnect message with reason "revoked" is received', async () => {
+    vi.useFakeTimers()
+
+    await connectToStudio(options)
+
+    await mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:disconnect', reason: 'revoked' }),
+    })
+
+    expect(session.named('studio:disconnected')).toStrictEqual([{ name: 'studio:disconnected', ctx: { reason: 'revoked' } }])
+    expect(mockWs.closed).toBe(true)
+    // disconnect API must NOT be called — server already knows about the closure
+    expect(disconnect).not.toHaveBeenCalled()
+    // revoked sessions must NOT trigger a reconnect
+    expect(consoleSpy.info).not.toHaveBeenCalledWith(expect.stringContaining('Retrying connection'))
+  })
+
+  it('cleans up and reconnects when a disconnect message with reason "expired" is received', async () => {
+    vi.useFakeTimers()
+
+    await connectToStudio(options)
+
+    await mockWs.trigger('message', {
+      data: JSON.stringify({ type: 'studio:disconnect', reason: 'expired' }),
+    })
+
+    expect(session.named('studio:disconnected')).toStrictEqual([{ name: 'studio:disconnected', ctx: { reason: 'expired' } }])
+    expect(mockWs.closed).toBe(true)
+    expect(disconnect).not.toHaveBeenCalled()
+    // expired sessions trigger a reconnect (unlike revoked)
+    expect(consoleSpy.info).toHaveBeenCalledWith(expect.stringContaining('Retrying connection'))
+  })
+
+  it('logs and retries instead of crashing when a reconnect attempt fails to reach Studio', async () => {
+    vi.useFakeTimers()
+    const unhandledRejections: Array<unknown> = []
+    const onUnhandledRejection = (reason: unknown) => unhandledRejections.push(reason)
+    // `bun-types` narrows `process.on` to its own event union, which omits Node's process events.
+    const processEvents = process as unknown as NodeJS.EventEmitter
+    processEvents.on('unhandledRejection', onUnhandledRejection)
+
+    try {
+      await connectToStudio(options)
+
+      await mockWs.trigger('close')
+
+      // The reconnect attempt scheduled after close fails to reach Studio (e.g. a 502)
+      vi.mocked(createAgentSession).mockRejectedValueOnce(new Error('502 Bad Gateway'))
+      vi.mocked(createAgentSession).mockResolvedValueOnce(makeSession())
+
+      await vi.advanceTimersByTimeAsync(options.retryInterval!)
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(session.errors().map((error) => error.message)).toContainEqual(expect.stringContaining('502 Bad Gateway'))
+      // the failed attempt schedules another reconnect rather than giving up
+      await vi.advanceTimersByTimeAsync(options.retryInterval!)
+      expect(createAgentSession).toHaveBeenCalledTimes(3)
+      expect(unhandledRejections).toStrictEqual([])
+    } finally {
+      processEvents.off('unhandledRejection', onUnhandledRejection)
+    }
+  })
+})

--- a/packages/studio/src/connectStudio.test.ts
+++ b/packages/studio/src/connectStudio.test.ts
@@ -6,7 +6,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vites
 import { spyOnConsole } from './console.mock.ts'
 import { MockWebSocket } from './websocket.mock.ts'
 import type { AgentConnectResponse } from './protocol/index.ts'
-import type { Hookable, StudioHooks } from '@kubb/core'
+import type { Hookable } from '@kubb/core'
 import type { AgentHooks } from './hooks.ts'
 import type { ConnectToStudioOptions } from './connectStudio.ts'
 import { connectToStudio } from './connectStudio.ts'
@@ -57,8 +57,17 @@ const consoleSpy = spyOnConsole()
  * Records the `studio:*` session events through the same `installLogger` hook a host uses, so a
  * test asserts the event and its context rather than a formatted console string.
  */
+type StudioEventName =
+  | 'studio:connecting'
+  | 'studio:connected'
+  | 'studio:disconnected'
+  | 'studio:command:start'
+  | 'studio:command:end'
+  | 'studio:warn'
+  | 'studio:error'
+
 function recordSessionEvents() {
-  type Recorded = { [K in keyof StudioHooks]: { name: K; ctx: StudioHooks[K][0] } }[keyof StudioHooks]
+  type Recorded = { [K in StudioEventName]: { name: K; ctx: AgentHooks[K][0] } }[StudioEventName]
   const events: Array<Recorded> = []
 
   return {
@@ -81,7 +90,7 @@ function recordSessionEvents() {
     errors(): Array<Error> {
       return events.flatMap((event) => (event.name === 'studio:error' ? [event.ctx.error] : []))
     },
-    named<K extends keyof StudioHooks>(name: K) {
+    named<K extends StudioEventName>(name: K) {
       return events.filter((event): event is Extract<Recorded, { name: K }> => event.name === name)
     },
   }

--- a/packages/studio/src/connectStudio.test.ts
+++ b/packages/studio/src/connectStudio.test.ts
@@ -6,8 +6,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vites
 import { spyOnConsole } from './console.mock.ts'
 import { MockWebSocket } from './websocket.mock.ts'
 import type { AgentConnectResponse } from './protocol/index.ts'
-import type { Hookable } from '@kubb/core'
-import type { AgentHooks } from './hooks.ts'
+import type { Hookable, KubbHooks } from '@kubb/core'
 import type { ConnectToStudioOptions } from './connectStudio.ts'
 import { connectToStudio } from './connectStudio.ts'
 
@@ -67,11 +66,11 @@ type StudioEventName =
   | 'studio:error'
 
 function recordSessionEvents() {
-  type Recorded = { [K in StudioEventName]: { name: K; ctx: AgentHooks[K][0] } }[StudioEventName]
+  type Recorded = { [K in StudioEventName]: { name: K; ctx: KubbHooks[K][0] } }[StudioEventName]
   const events: Array<Recorded> = []
 
   return {
-    installLogger(hooks: Hookable<AgentHooks>) {
+    installLogger(hooks: Hookable<KubbHooks>) {
       for (const name of [
         'studio:connecting',
         'studio:connected',
@@ -169,7 +168,7 @@ describe('connectToStudio', () => {
   })
 
   it('installs the host renderer on the session emitter and on every generation', async () => {
-    const emitters: Array<Hookable<AgentHooks>> = []
+    const emitters: Array<Hookable<KubbHooks>> = []
 
     await connectToStudio({ ...options, installLogger: (hooks) => void emitters.push(hooks) })
 

--- a/packages/studio/src/connectStudio.test.ts
+++ b/packages/studio/src/connectStudio.test.ts
@@ -21,8 +21,8 @@ vi.mock('./generate.ts', () => ({
   generate: vi.fn().mockResolvedValue(undefined),
 }))
 
-// Config resolution runs for real. It reaches outside the process in two ways — `import()`-ing a
-// plugin package and `import()`-ing the adapter package — so those packages are what gets stubbed.
+// Config resolution runs for real. It reaches outside the process in two ways, `import()`-ing a
+// plugin package and `import()`-ing the adapter package, so those packages are what gets stubbed.
 vi.mock('@kubb/plugin-ts', () => ({ pluginTs: (options: unknown) => ({ name: 'plugin-ts', options }) }))
 vi.mock('@kubb/plugin-zod', () => ({ pluginZod: (options: unknown) => ({ name: 'plugin-zod', options }) }))
 vi.mock('@kubb/adapter-oas', () => ({ adapterOas: (options: unknown) => ({ name: 'oas', options, parse: vi.fn() }) }))
@@ -929,9 +929,9 @@ describe('connectToStudio', () => {
 
     expect(session.named('studio:disconnected')).toStrictEqual([{ name: 'studio:disconnected', ctx: { reason: 'revoked' } }])
     expect(mockWs.closed).toBe(true)
-    // disconnect API must NOT be called — server already knows about the closure
+    // The server already knows about the closure, so the disconnect API is not called.
     expect(disconnect).not.toHaveBeenCalled()
-    // revoked sessions must NOT trigger a reconnect
+    // A revoked session does not trigger a reconnect.
     expect(consoleSpy.info).not.toHaveBeenCalledWith(expect.stringContaining('Retrying connection'))
   })
 
@@ -947,7 +947,7 @@ describe('connectToStudio', () => {
     expect(session.named('studio:disconnected')).toStrictEqual([{ name: 'studio:disconnected', ctx: { reason: 'expired' } }])
     expect(mockWs.closed).toBe(true)
     expect(disconnect).not.toHaveBeenCalled()
-    // expired sessions trigger a reconnect (unlike revoked)
+    // Unlike a revoked session, an expired one triggers a reconnect.
     expect(consoleSpy.info).toHaveBeenCalledWith(expect.stringContaining('Retrying connection'))
   })
 
@@ -972,7 +972,7 @@ describe('connectToStudio', () => {
       await vi.advanceTimersByTimeAsync(0)
 
       expect(session.errors().map((error) => error.message)).toContainEqual(expect.stringContaining('502 Bad Gateway'))
-      // the failed attempt schedules another reconnect rather than giving up
+      // The failed attempt schedules another reconnect rather than giving up.
       await vi.advanceTimersByTimeAsync(options.retryInterval!)
       expect(createAgentSession).toHaveBeenCalledTimes(3)
       expect(unhandledRejections).toStrictEqual([])

--- a/packages/studio/src/connectStudio.test.ts
+++ b/packages/studio/src/connectStudio.test.ts
@@ -641,17 +641,6 @@ describe('connectToStudio', () => {
     )
   })
 
-  it('rejects a payload naming a plugin outside the allow-list instead of importing it', async () => {
-    await connectToStudio({ ...options, allowedPlugins: ['@kubb/plugin-ts'] })
-
-    await mockWs.trigger('message', {
-      data: JSON.stringify({ type: 'studio:generate', payload: { plugins: [{ name: 'evil-module', options: {} }] } }),
-    })
-
-    expect(generate).not.toHaveBeenCalled()
-    expect(session.errors().map((error) => error.message)).toContainEqual(expect.stringContaining('evil-module'))
-  })
-
   // An adapter instance carries closures that cannot survive JSON, so the payload is an options
   // patch: the adapter factory is re-invoked with the merged options rather than replaced by the
   // plain object Studio sent.

--- a/packages/studio/src/connectStudio.ts
+++ b/packages/studio/src/connectStudio.ts
@@ -3,9 +3,9 @@ import path from 'node:path'
 import process from 'node:process'
 import { styleText } from 'node:util'
 import { getErrorMessage, toError } from '@internals/utils'
-import { type Config, fsStorage, Hookable, memoryStorage } from '@kubb/core'
+import { type Config, fsStorage, Hookable, type KubbHooks, memoryStorage } from '@kubb/core'
 import { version as kubbVersion } from '../package.json'
-import { type AgentHooks, setupHookListener } from './hooks.ts'
+import { setupHookListener } from './hooks.ts'
 import { type AgentMessage, type ClientInfo, type ConfigFileView, isCommandMessage, isDisconnectMessage, isStudioPingMessage } from './protocol/index.ts'
 import { createAgentSession, disconnect, InvalidAgentTokenError } from './api.ts'
 import { generate } from './generate.ts'
@@ -69,7 +69,7 @@ export type ConnectToStudioOptions = {
    * Installs listeners on an event emitter, once for the session and once per generation. Left out,
    * the runtime prints nothing, which is what a library should default to.
    */
-  installLogger?: (hooks: Hookable<AgentHooks>) => void | Promise<void>
+  installLogger?: (hooks: Hookable<KubbHooks>) => void | Promise<void>
 }
 
 /**
@@ -142,7 +142,7 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
 
   // Each connection gets its own isolated event emitter so generation events
   // from one session do not bleed into another session's WebSocket stream.
-  const hooks = new Hookable<AgentHooks>()
+  const hooks = new Hookable<KubbHooks>()
   await installLogger?.(hooks)
 
   try {
@@ -405,7 +405,7 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
                 await hooks.callHook('studio:warn', { message: `Ignored the spec from Studio; set ${remedy} to generate from it` })
               }
 
-              const generationHooks = new Hookable<AgentHooks>()
+              const generationHooks = new Hookable<KubbHooks>()
               await installLogger?.(generationHooks)
               setupHookListener(generationHooks, root)
               setupEventsStream(ws, generationHooks)

--- a/packages/studio/src/connectStudio.ts
+++ b/packages/studio/src/connectStudio.ts
@@ -1,0 +1,540 @@
+import { readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import { styleText } from 'node:util'
+import { getErrorMessage, toError } from '@internals/utils'
+import { type Config, fsStorage, Hookable, memoryStorage } from '@kubb/core'
+import { version as kubbVersion } from '../package.json'
+import { type AgentHooks, setupHookListener } from './hooks.ts'
+import { type AgentMessage, type ClientInfo, type ConfigFileView, isCommandMessage, isDisconnectMessage, isStudioPingMessage } from './protocol/index.ts'
+import { createAgentSession, disconnect, InvalidAgentTokenError } from './api.ts'
+import { generate } from './generate.ts'
+import { agentDefaults } from './constants.ts'
+import { assertAllowedPlugins, mergeAdapter, mergePlugins } from './resolveConfig.ts'
+import type WebSocket from 'ws'
+import { createWebsocket, sendAgentMessage, sendErrorMessage, setupEventsStream } from './ws.ts'
+
+export type ConnectToStudioOptions = {
+  token: string
+  studioUrl?: string
+  configPath: string
+  /**
+   * Loads the on-disk Kubb config. Injected so each host resolves config its own way: the Docker
+   * agent from an explicit `KUBB_AGENT_CONFIG` path, the CLI through the same discovery
+   * `kubb generate` uses.
+   */
+  loadConfig: () => Promise<Config>
+  /**
+   * The runtime's own version, reported to Studio next to the `kubb` version.
+   */
+  version: string
+  /**
+   * Identifies the host to Studio, so the UI can badge a CLI connection and show the real project.
+   */
+  client?: ClientInfo
+  allowWrite?: boolean
+  /**
+   * Whether Studio may edit the project's `kubb.config.ts`. Granted separately from `allowWrite`,
+   * which only covers generated output: this rewrites a file the user wrote by hand.
+   */
+  allowConfigEdit?: boolean
+  allowInput?: boolean
+  /**
+   * Whether the formatter, the linter, and `output.postGenerate` may run as child processes.
+   * Defaults to true, which is what the Docker agent has always done. The CLI runs in the user's
+   * own project, so it defaults this off and asks before granting it.
+   */
+  allowExec?: boolean
+  /**
+   * Module specifiers Studio may name in a `generate` payload. When set, a payload naming anything
+   * else is rejected instead of imported. `resolvePlugins` does a bare `await import(name)`, so
+   * without this Studio can execute any module reachable from the project's `node_modules`.
+   * Unset means no restriction, matching the Docker image where the plugin set is fixed at build time.
+   */
+  allowedPlugins?: ReadonlyArray<string>
+  root?: string
+  retryInterval?: number
+  heartbeatInterval?: number
+  /**
+   * Number of pool sessions this agent serves. Read by `createClient`, which opens one
+   * `connectToStudio` per slot, and reported to Studio at registration.
+   */
+  poolSize?: number
+  /**
+   * Aborting this disconnects the session and stops the reconnect loop. Hosts wire it to their own
+   * shutdown: Nitro's `close` hook, or `SIGINT`/`SIGTERM` in the CLI.
+   */
+  signal?: AbortSignal
+  /**
+   * Installs listeners on an event emitter, once for the session and once per generation. Left out,
+   * the runtime prints nothing, which is what a library should default to.
+   */
+  installLogger?: (hooks: Hookable<AgentHooks>) => void | Promise<void>
+}
+
+/**
+ * Schedules another connection attempt.
+ *
+ * Hoisted out of `connectToStudio` on purpose: a pending retry timer reaches its whole enclosing
+ * scope, so keeping it inside would pin the closed socket, the hook emitter, and the session id
+ * alive for the length of every retry interval.
+ */
+function reconnect(options: ConnectToStudioOptions): void {
+  const { signal, retryInterval = agentDefaults.retryIntervalMs } = options
+
+  if (signal?.aborted) {
+    return
+  }
+
+  console.info(styleText('dim', `Retrying connection in ${retryInterval}ms to Kubb Studio ...`))
+
+  const cancel = () => clearTimeout(timer)
+  const timer = setTimeout(() => {
+    // Removed here rather than left to `{ once: true }`: the signal only aborts at shutdown, so one
+    // listener per retry would accumulate for the whole life of a down-Studio retry loop.
+    signal?.removeEventListener('abort', cancel)
+
+    if (signal?.aborted) {
+      return
+    }
+
+    // The rejection is never awaited, so it has to be caught here or it surfaces as an
+    // unhandledRejection that kills the retry loop instead of trying again.
+    connectToStudio(options).catch((error: unknown) => {
+      console.error(styleText('red', `Reconnect attempt to Kubb Studio failed: ${getErrorMessage(error)}`))
+
+      // A rejected token stays rejected, so retrying only spams 401s until the process is killed.
+      if (error instanceof InvalidAgentTokenError) {
+        return
+      }
+
+      reconnect(options)
+    })
+  }, retryInterval)
+
+  signal?.addEventListener('abort', cancel, { once: true })
+}
+
+export async function connectToStudio(options: ConnectToStudioOptions): Promise<void> {
+  const {
+    token,
+    studioUrl = agentDefaults.studioUrl,
+    configPath,
+    loadConfig,
+    version,
+    client,
+    // Every permission is off unless the host grants it.
+    allowWrite = false,
+    allowConfigEdit = false,
+    allowInput = false,
+    allowExec = false,
+    allowedPlugins,
+    root = process.cwd(),
+    heartbeatInterval: requestedHeartbeatInterval = agentDefaults.heartbeatIntervalMs,
+    signal,
+    installLogger,
+  } = options
+
+  // Studio counts an agent offline once its last ping is older than its liveness window, so a
+  // slower cadence would make a healthy agent invisible. Clamped here rather than in a host's env
+  // parsing, so every host is held to the contract.
+  const heartbeatInterval = Math.min(requestedHeartbeatInterval, agentDefaults.heartbeatIntervalMs)
+
+  // Each connection gets its own isolated event emitter so generation events
+  // from one session do not bleed into another session's WebSocket stream.
+  const hooks = new Hookable<AgentHooks>()
+  await installLogger?.(hooks)
+
+  try {
+    // Before the session exists, so a host can cover the wait: `createAgentSession` is a round
+    // trip and the socket after it opens without being awaited.
+    await hooks.callHook('studio:connecting', { url: studioUrl })
+
+    const { sessionId, slug, wsUrl, isSandbox, version: sessionStudioVersion } = await createAgentSession({ token, studioUrl })
+
+    // Known before the agent announces itself, and refreshed by a later `studio:connect`, so both
+    // sides can be named from the first connect on.
+    let studioVersion = sessionStudioVersion
+    const ws = createWebsocket(wsUrl, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+
+    // Effective permissions: always disabled in sandbox mode
+    const canWrite = isSandbox ? false : allowWrite
+    // A sandbox has no user project to edit, so a config edit is never granted there.
+    const canEditConfig = isSandbox ? false : allowConfigEdit
+    // `configPath` is relative to the agent's root unless it is already absolute, which is what
+    // `resolve` does on its own.
+    const configFilePath = path.resolve(root, configPath)
+    // A sandbox agent always generates from the spec Studio supplies; a local agent only when opted in.
+    const canUseInput = isSandbox || allowInput
+    // Tracks whether the studio server explicitly disconnected us (no reconnect needed)
+    let serverDisconnected = false
+    // Guards against a second `generate` command starting while one is already running.
+    // Without this, two concurrent `generate()` calls share this socket via `setupEventsStream`,
+    // and their events interleave with no way for Studio to tell the two runs apart.
+    let isGenerating = false
+    let heartbeatTimer: ReturnType<typeof setInterval> | undefined
+    // Tracks socket liveness: Studio replies to every ping with a pong. When pongs stop
+    // arriving the connection is half-open (e.g. dropped during a Studio deploy) and must
+    // be terminated so the reconnect loop can establish a fresh session.
+    let lastPongAt = Date.now()
+
+    const onAbort = () => void teardown({ reason: 'shutdown', retry: false })
+
+    function cleanup(reason = 'cleanup') {
+      clearInterval(heartbeatTimer)
+      heartbeatTimer = undefined
+
+      // This connection is over, so its shutdown listener must go with it. Otherwise every
+      // reconnect leaves one behind on a signal that only fires at process exit.
+      signal?.removeEventListener('abort', onAbort)
+
+      hooks.removeAllHooks()
+
+      try {
+        ws.close(1000, reason)
+      } catch {}
+
+      ws.removeEventListener('open', onOpen)
+      ws.removeEventListener('close', onClose)
+      ws.removeEventListener('error', onError)
+      ws.removeEventListener('message', onMessage)
+    }
+
+    /**
+     * Reads `kubb.config.ts` and reports which plugin options Studio may edit.
+     *
+     * Skipped when the host did not grant `allowConfigEdit`. The patcher pulls in `magicast`
+     * (~25ms, ~55MB RSS), so read-only agents never import it.
+     *
+     * Not cached: the user can edit the file between two Studio actions.
+     */
+    async function readConfigFileView(source?: string): Promise<ConfigFileView | undefined> {
+      if (!canEditConfig) {
+        return undefined
+      }
+
+      try {
+        const { readConfig } = await import('./configFile.ts')
+
+        return readConfig(source ?? (await readFile(configFilePath, 'utf-8')))
+      } catch (error) {
+        await hooks.callHook('studio:warn', { message: `Could not read ${configFilePath}: ${getErrorMessage(error)}` })
+
+        return undefined
+      }
+    }
+
+    async function sendConnectedPayload() {
+      const config = await loadConfig()
+
+      sendAgentMessage(ws, {
+        type: 'agent:connect',
+        payload: {
+          versions: { kubb: kubbVersion, agent: version },
+          root,
+          config: {
+            path: configPath,
+            file: await readConfigFileView(),
+            plugins: config.plugins.map((plugin) => ({
+              name: `@kubb/${plugin.name}`,
+              // Functions and symbols in plugin options are dropped by `JSON.stringify` on the way out.
+              options: plugin.options ?? {},
+            })),
+          },
+          permissions: {
+            allowWrite: canWrite,
+            allowInput: canUseInput,
+            allowExec,
+            allowConfigEdit: canEditConfig,
+          },
+        },
+      })
+    }
+
+    async function handleOpen() {
+      lastPongAt = Date.now()
+      await hooks.callHook('studio:connected', { url: studioUrl, versions: { studio: studioVersion, kubb: kubbVersion, agent: version } })
+
+      // Announce readiness without waiting for a `studio:connect` command. The command from the
+      // Studio UI is lost when it is sent while the agent is not attached to the session
+      // (e.g. reconnecting after a deploy), so the agent introduces itself on every open.
+      try {
+        await sendConnectedPayload()
+      } catch (error) {
+        await hooks.callHook('studio:warn', { message: `Failed to send the connect payload: ${getErrorMessage(error)}` })
+      }
+    }
+
+    // `addEventListener` drops the returned promise, so a host whose logger throws would take the
+    // process down with an unhandled rejection instead of just losing a line of output. Nothing is
+    // left to report it with at that point, which is why this swallows.
+    const onOpen = () => void handleOpen().catch(() => {})
+
+    /**
+     * Drops the socket and tells Studio the session is over. `serverDisconnected` guards against
+     * the close event running this a second time, and against a shutdown reconnecting.
+     */
+    async function teardown({ reason, retry }: { reason?: string; retry: boolean }) {
+      if (serverDisconnected) {
+        return
+      }
+      serverDisconnected = true
+
+      // Announce the shutdown while the socket is still open, so Studio marks the session offline
+      // now instead of waiting out the heartbeat window. `sendAgentMessage` is a no-op on a socket
+      // that has already closed, which is every other way we get here.
+      if (reason === 'shutdown') {
+        sendAgentMessage(ws, { type: 'agent:disconnect', reason: 'shutdown' })
+      }
+
+      cleanup(reason)
+      // Already tearing down, so a failed disconnect changes nothing.
+      await disconnect({ sessionId, studioUrl, token, slug }).catch(() => {})
+
+      if (retry) {
+        reconnect(options)
+      }
+    }
+
+    const onClose = () => teardown({ retry: true })
+
+    const onError = () => {
+      void hooks.callHook('studio:error', { error: new Error('Failed to connect to Kubb Studio') })
+
+      return onClose()
+    }
+
+    ws.addEventListener('open', onOpen)
+    ws.addEventListener('close', onClose)
+    ws.addEventListener('error', onError)
+    // The socket's own close event fires after this, and `teardown` is idempotent, so the shutdown
+    // path cannot be turned into a reconnect by the close that follows it.
+    signal?.addEventListener('abort', onAbort, { once: true })
+
+    heartbeatTimer = setInterval(() => {
+      // Two consecutive missed pongs mean the socket is dead even though no close event
+      // arrived. Terminate (not close) so a half-open TCP connection can't linger. The
+      // resulting close event triggers cleanup and the reconnect loop.
+      if (Date.now() - lastPongAt > heartbeatInterval * 2) {
+        void hooks.callHook('studio:warn', { message: 'No reply from Kubb Studio, terminating the stale connection' })
+        // Stop the timer here rather than waiting for cleanup(), since the close event can lag,
+        // and until it runs this interval would re-terminate and re-log every tick.
+        clearInterval(heartbeatTimer)
+        heartbeatTimer = undefined
+        ws.terminate()
+
+        return
+      }
+
+      sendAgentMessage(ws, { type: 'agent:ping' })
+    }, heartbeatInterval)
+
+    // Only `kubb:error` is ever fired on the connection emitter. Every generation event goes
+    // through its own emitter below, so it gets that one listener rather than the full stream.
+    hooks.hook('kubb:error', ({ error }) => sendErrorMessage(ws, error))
+
+    const onMessage = async (message: WebSocket.MessageEvent) => {
+      try {
+        const data = JSON.parse(message.data as string) as AgentMessage
+
+        if (isStudioPingMessage(data)) {
+          lastPongAt = Date.now()
+
+          return
+        }
+
+        if (isDisconnectMessage(data)) {
+          await hooks.callHook('studio:disconnected', { reason: data.reason })
+
+          if (data.reason === 'revoked') {
+            cleanup(`session_${data.reason}`)
+            return
+          }
+
+          if (data.reason === 'expired') {
+            cleanup()
+            reconnect(options)
+
+            return
+          }
+
+          return
+        }
+
+        if (isCommandMessage(data)) {
+          // Every command type is `studio:<verb>`, so the verb alone is what a host wants to show.
+          const command = data.type.slice('studio:'.length)
+
+          await hooks.callHook('studio:command:start', { command })
+
+          if (data.type === 'studio:generate') {
+            if (isGenerating) {
+              await hooks.callHook('studio:warn', { message: 'Ignored generate: a generation is already in progress' })
+
+              await Promise.resolve(
+                hooks.callHook('kubb:error', { error: new Error('A generation is already in progress, please wait for it to finish') }),
+              ).catch(() => {})
+
+              return
+            }
+
+            isGenerating = true
+
+            try {
+              const config = await loadConfig()
+              const patch = data.payload
+              assertAllowedPlugins(patch?.plugins, allowedPlugins)
+
+              const plugins = await mergePlugins(config.plugins, patch?.plugins)
+              const adapter = await mergeAdapter(config.adapter, patch?.adapter)
+
+              // A sandbox agent always uses the inline spec (empty string included, since it has no disk
+              // file); a local agent only when opted in, and an empty or absent spec falls back to disk.
+              const inputOverride = isSandbox ? (patch?.input ?? '') : (allowInput && patch?.input) || undefined
+
+              if (allowWrite && isSandbox) {
+                await hooks.callHook('studio:warn', { message: 'Running in a sandbox, so writing files is disabled' })
+              }
+
+              if (patch?.input && !canUseInput) {
+                // The Docker agent reads `allowInput` from `KUBB_AGENT_ALLOW_INPUT`. The CLI grants it
+                // through `--allowInput` or the per-project prompt instead, so each host gets its own remedy.
+                const remedy = client?.kind === 'cli' ? '--allowInput, or answer yes when kubb studio asks,' : 'KUBB_AGENT_ALLOW_INPUT=true'
+                await hooks.callHook('studio:warn', { message: `Ignored the spec from Studio; set ${remedy} to generate from it` })
+              }
+
+              const generationHooks = new Hookable<AgentHooks>()
+              await installLogger?.(generationHooks)
+              setupHookListener(generationHooks, root)
+              setupEventsStream(ws, generationHooks)
+
+              const resolvedPlugins = plugins ?? config.plugins
+
+              await generate({
+                config: {
+                  ...config,
+                  root,
+                  input: inputOverride ?? config.input,
+                  storage: canWrite ? fsStorage() : memoryStorage(),
+                  output: allowExec ? { ...config.output } : { ...config.output, format: false, lint: false, postGenerate: [] },
+                  plugins: resolvedPlugins,
+                  adapter,
+                },
+                hooks: generationHooks,
+              })
+
+              await hooks.callHook('studio:command:end', {
+                command,
+                info: `${resolvedPlugins.length} plugin${resolvedPlugins.length === 1 ? '' : 's'}, ${canWrite ? 'written to disk' : 'in memory'}${inputOverride !== undefined ? ', from a Studio spec' : ''}`,
+              })
+            } finally {
+              isGenerating = false
+            }
+
+            return
+          }
+
+          if (data.type === 'studio:connect') {
+            studioVersion = data.version ?? studioVersion
+            await sendConnectedPayload()
+
+            await hooks.callHook('studio:command:end', { command })
+
+            return
+          }
+
+          if (data.type === 'studio:save') {
+            // Studio waits on an `agent:save` for every `studio:save`, so every path out of this
+            // branch sends one. `edits` is checked before it is walked: the message crosses the same
+            // trust boundary as the values inside it.
+            if (!Array.isArray(data.edits)) {
+              await hooks.callHook('studio:warn', { message: 'Ignored save: the message carried no edits' })
+
+              sendAgentMessage(ws, { type: 'agent:save', payload: { outcomes: [], changed: false } })
+
+              return
+            }
+
+            const edits = data.edits
+            const refuse = (reason: string) =>
+              sendAgentMessage(ws, {
+                type: 'agent:save',
+                payload: { outcomes: edits.map((edit) => ({ edit, applied: false, reason })), changed: false },
+              })
+
+            if (!canEditConfig) {
+              await hooks.callHook('studio:warn', { message: 'Ignored save: editing kubb.config.ts was not granted' })
+
+              refuse('the agent was not granted permission to edit kubb.config.ts')
+
+              return
+            }
+
+            // A generation reloads the config while it runs, so rewriting the file underneath it
+            // would leave that run working from half the change.
+            if (isGenerating) {
+              refuse('a generation is in progress')
+
+              return
+            }
+
+            try {
+              // Read straight before the patch rather than reusing what went out on connect. The user
+              // may have edited the file since, and since every untouched node keeps its own text,
+              // patching what is on disk right now preserves that edit.
+              const { applyConfigEdits } = await import('./configFile.ts')
+              const current = await readFile(configFilePath, 'utf-8')
+              const { source: patched, outcomes, changed } = applyConfigEdits(current, edits)
+
+              if (changed) {
+                await writeFile(configFilePath, patched, 'utf-8')
+              }
+
+              sendAgentMessage(ws, {
+                type: 'agent:save',
+                payload: { outcomes, changed, file: changed ? await readConfigFileView(patched) : undefined },
+              })
+
+              const applied = outcomes.filter((outcome) => outcome.applied).length
+              await hooks.callHook('studio:command:end', { command, info: `applied ${applied}/${outcomes.length} edits to ${configPath}` })
+            } catch (error) {
+              // An unreadable config, a read-only filesystem. Reported as a refusal of every edit so
+              // Studio hears back rather than waiting on a reply that never comes.
+              await hooks.callHook('studio:error', { error: toError(error) })
+
+              refuse(getErrorMessage(error))
+            }
+
+            return
+          }
+
+          return
+        }
+
+        await hooks.callHook('studio:warn', { message: `Ignored an unknown message from Kubb Studio: ${data.type}` })
+      } catch (error) {
+        await hooks.callHook('studio:error', { error: toError(error) })
+
+        // Errors thrown before `generate()` runs (e.g. config loading, plugin resolution)
+        // never reach `generate()`'s own `kubb:error` emission, so without this the Studio
+        // UI shows nothing while the agent silently fails. Forward them on the connection-level
+        // `hooks` emitter, already wired to this socket via `setupEventsStream`.
+        await Promise.resolve(hooks.callHook('kubb:error', { error: error instanceof Error ? error : new Error(String(error)) })).catch(() => {})
+      }
+    }
+    ws.addEventListener('message', onMessage)
+  } catch (error) {
+    // Reaching here means the session was never created (Studio down, a 502 mid-deploy), so no
+    // socket exists and none of the socket-driven reconnect paths can fire. Retry from here or the
+    // slot is dropped for the lifetime of the process.
+    await hooks.callHook('studio:error', { error: toError(error) })
+
+    if (error instanceof InvalidAgentTokenError) {
+      throw error
+    }
+
+    reconnect(options)
+  }
+}

--- a/packages/studio/src/connectStudio.ts
+++ b/packages/studio/src/connectStudio.ts
@@ -10,7 +10,7 @@ import { type AgentMessage, type ClientInfo, type ConfigFileView, isCommandMessa
 import { createAgentSession, disconnect, InvalidAgentTokenError } from './api.ts'
 import { generate } from './generate.ts'
 import { agentDefaults } from './constants.ts'
-import { assertAllowedPlugins, mergeAdapter, mergePlugins } from './resolveConfig.ts'
+import { mergeAdapter, mergePlugins } from './resolveConfig.ts'
 import type WebSocket from 'ws'
 import { createWebsocket, sendAgentMessage, sendErrorMessage, setupEventsStream } from './ws.ts'
 
@@ -45,13 +45,6 @@ export type ConnectToStudioOptions = {
    * own project, so it defaults this off and asks before granting it.
    */
   allowExec?: boolean
-  /**
-   * Module specifiers Studio may name in a `generate` payload. When set, a payload naming anything
-   * else is rejected instead of imported. `resolvePlugins` does a bare `await import(name)`, so
-   * without this Studio can execute any module reachable from the project's `node_modules`.
-   * Unset means no restriction, matching the Docker image where the plugin set is fixed at build time.
-   */
-  allowedPlugins?: ReadonlyArray<string>
   root?: string
   retryInterval?: number
   heartbeatInterval?: number
@@ -128,7 +121,6 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
     allowConfigEdit = false,
     allowInput = false,
     allowExec = false,
-    allowedPlugins,
     root = process.cwd(),
     heartbeatInterval: requestedHeartbeatInterval = agentDefaults.heartbeatIntervalMs,
     signal,
@@ -385,8 +377,6 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
             try {
               const config = await loadConfig()
               const patch = data.payload
-              assertAllowedPlugins(patch?.plugins, allowedPlugins)
-
               const plugins = await mergePlugins(config.plugins, patch?.plugins)
               const adapter = await mergeAdapter(config.adapter, patch?.adapter)
 

--- a/packages/studio/src/connectStudio.ts
+++ b/packages/studio/src/connectStudio.ts
@@ -521,7 +521,7 @@ export async function connectToStudio(options: ConnectToStudioOptions): Promise<
         // never reach `generate()`'s own `kubb:error` emission, so without this the Studio
         // UI shows nothing while the agent silently fails. Forward them on the connection-level
         // `hooks` emitter, already wired to this socket via `setupEventsStream`.
-        await Promise.resolve(hooks.callHook('kubb:error', { error: error instanceof Error ? error : new Error(String(error)) })).catch(() => {})
+        await Promise.resolve(hooks.callHook('kubb:error', { error: toError(error) })).catch(() => {})
       }
     }
     ws.addEventListener('message', onMessage)

--- a/packages/studio/src/generate.ts
+++ b/packages/studio/src/generate.ts
@@ -2,7 +2,7 @@ import { hash } from 'node:crypto'
 import path from 'node:path'
 import process from 'node:process'
 import { styleText } from 'node:util'
-import { type Config, createKubb, type Diagnostic, Diagnostics, type Hookable } from '@kubb/core'
+import { type Config, createKubb, type Diagnostic, Diagnostics, type Hookable, type KubbHooks } from '@kubb/core'
 import {
   FORMATTER_PREFERENCE,
   LINTER_PREFERENCE,
@@ -13,7 +13,7 @@ import {
   type ToolCommand,
   detectTool as detectUncachedTool,
 } from '@internals/utils'
-import { type AgentHooks, waitForHookEnd } from './hooks.ts'
+import { waitForHookEnd } from './hooks.ts'
 
 /**
  * `isToolAvailable` spawns a process, and a long-lived connection generates repeatedly, so each
@@ -46,7 +46,7 @@ function outputPath(config: Config): string {
 }
 
 type RunHookProps = {
-  hooks: Hookable<AgentHooks>
+  hooks: Hookable<KubbHooks>
   /**
    * Stable identity for the command, hashed so the `kubb:hook:*` events for concurrent commands
    * can be told apart.
@@ -74,7 +74,7 @@ async function runHook({ hooks, id, command, args }: RunHookProps): Promise<void
 
 type GenerateProps = {
   config: Config
-  hooks: Hookable<AgentHooks>
+  hooks: Hookable<KubbHooks>
 }
 
 function isProblemErrorDiagnostic(diagnostic: Diagnostic): diagnostic is Diagnostic & { plugin?: string; message: string } {

--- a/packages/studio/src/hooks.test.ts
+++ b/packages/studio/src/hooks.test.ts
@@ -1,5 +1,4 @@
-import { Hookable } from '@kubb/core'
-import type { AgentHooks } from './hooks.ts'
+import { Hookable, type KubbHooks } from '@kubb/core'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setupHookListener } from './hooks.ts'
 
@@ -34,10 +33,10 @@ function fakeProc({ lines = [], exitCode = 0, stdout = '', stderr = '' }: FakePr
 }
 
 describe('setupHookListener', () => {
-  let hooks: Hookable<AgentHooks>
+  let hooks: Hookable<KubbHooks>
 
   beforeEach(() => {
-    hooks = new Hookable<AgentHooks>()
+    hooks = new Hookable<KubbHooks>()
     vi.clearAllMocks()
   })
 

--- a/packages/studio/src/hooks.ts
+++ b/packages/studio/src/hooks.ts
@@ -91,18 +91,11 @@ declare global {
 }
 
 /**
- * Event bus shared with `createKubb`. Core emits its generation lifecycle events here, and the
- * `studio:*` session events this package adds to {@link KubbHooks} ride alongside them, so one
- * logger renders the whole connection.
- */
-export type AgentHooks = KubbHooks
-
-/**
  * Register a `kubb:hook:start` listener that spawns the requested command via tinyexec,
  * streams each stdout line as a `kubb:hook:line` event, and calls `kubb:hook:end` with the result.
  * Streaming the output lets Kubb Studio render live hook progress over the WebSocket connection.
  */
-export function setupHookListener(hooks: Hookable<AgentHooks>, root: string): void {
+export function setupHookListener(hooks: Hookable<KubbHooks>, root: string): void {
   hooks.hook('kubb:hook:start', async (ctx) => {
     const { id, command, args } = ctx
     // No id means nothing is waiting on the result (benchmarks, tests).
@@ -148,7 +141,7 @@ export function setupHookListener(hooks: Hookable<AgentHooks>, root: string): vo
  * `callHook` awaits its listeners, and {@link setupHookListener} calls `kubb:hook:end` from inside
  * that same listener, so a handler added afterward would already have missed it.
  */
-export function waitForHookEnd(hooks: Hookable<AgentHooks>, hookId: string): Promise<void> {
+export function waitForHookEnd(hooks: Hookable<KubbHooks>, hookId: string): Promise<void> {
   return new Promise((resolve, reject) => {
     const handleHookEnd = (ctx: { id?: string; success: boolean; error?: Error | null }) => {
       if (ctx.id !== hookId) return

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -1,3 +1,4 @@
+export { createClient, type Client, type ClientOptions } from './client.ts'
 export type {
   AgentHooks,
   StudioCommandEndContext,
@@ -8,7 +9,7 @@ export type {
   StudioErrorContext,
   StudioWarnContext,
 } from './hooks.ts'
+export { InvalidAgentTokenError } from './api.ts'
 export { defaultStudioUrl } from './constants.ts'
 export { createFileStorage, setStorage } from './machine.ts'
-export { InvalidAgentTokenError } from './api.ts'
 export { pollForPairingToken, startPairing } from './pair.ts'

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -1,6 +1,5 @@
 export { createClient, type Client, type ClientOptions } from './client.ts'
 export type {
-  AgentHooks,
   StudioCommandEndContext,
   StudioCommandStartContext,
   StudioConnectedContext,

--- a/packages/studio/src/ws.test.ts
+++ b/packages/studio/src/ws.test.ts
@@ -1,7 +1,6 @@
-import { Hookable, type KubbPluginStartContext } from '@kubb/core'
+import { Hookable, type KubbHooks, type KubbPluginStartContext } from '@kubb/core'
 import type WebSocket from 'ws'
 import { describe, expect, it, vi } from 'vitest'
-import type { AgentHooks } from './hooks.ts'
 import type { AgentMessage } from './protocol/index.ts'
 import { setupEventsStream } from './ws.ts'
 
@@ -24,7 +23,7 @@ function fakeSocket() {
 describe('setupEventsStream', () => {
   it('forwards a generation event as an agent:data envelope around its kubb: payload', async () => {
     const socket = fakeSocket()
-    const hooks = new Hookable<AgentHooks>()
+    const hooks = new Hookable<KubbHooks>()
     setupEventsStream(socket.ws, hooks)
 
     await hooks.callHook('kubb:plugin:start', { plugin: { name: 'plugin-ts' } as unknown as KubbPluginStartContext['plugin'] })
@@ -39,7 +38,7 @@ describe('setupEventsStream', () => {
 
   it('keeps session events off the wire', async () => {
     const socket = fakeSocket()
-    const hooks = new Hookable<AgentHooks>()
+    const hooks = new Hookable<KubbHooks>()
     setupEventsStream(socket.ws, hooks)
 
     // `studio:*` narrates the connection for whoever is running the agent. Studio has its own view

--- a/packages/studio/src/ws.ts
+++ b/packages/studio/src/ws.ts
@@ -1,8 +1,7 @@
 import { getElapsedMs, inParallel } from '@internals/utils'
-import { Diagnostics, type Hookable } from '@kubb/core'
+import { Diagnostics, type Hookable, type KubbHooks } from '@kubb/core'
 import WebSocket from 'ws'
 import type { AgentMessage, DataMessagePayload } from './protocol/index.ts'
-import type { AgentHooks } from './hooks.ts'
 
 type WebSocketOptions = WebSocket.ClientOptions
 
@@ -83,7 +82,7 @@ export function sendErrorMessage(ws: WebSocket, error: Error): void {
 /**
  * Forwards selected Kubb lifecycle events to Studio as data messages for the active session.
  */
-export function setupEventsStream(ws: WebSocket, hooks: Hookable<AgentHooks>): void {
+export function setupEventsStream(ws: WebSocket, hooks: Hookable<KubbHooks>): void {
   function sendDataMessage(payload: Omit<DataMessagePayload, 'seq' | 'timestamp'>) {
     sendAgentMessage(ws, {
       type: 'agent:data',

--- a/packages/studio/tsdown.config.ts
+++ b/packages/studio/tsdown.config.ts
@@ -9,7 +9,6 @@ const shared: Partial<UserConfig> = {
   platform: 'node',
   sourcemap: true,
   shims: true,
-  exports: true,
   deps: {
     neverBundle: [/^@kubb\//],
     alwaysBundle: [/@internals/],

--- a/packages/unplugin-kubb/package.json
+++ b/packages/unplugin-kubb/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unplugin-kubb",
-  "version": "5.1.0",
+  "version": "5.0.35",
   "description": "Integration of Kubb for Vite, Webpack, Rollup, esbuild, Rspack, Nuxt, and Astro.",
   "keywords": [
     "astro",
@@ -146,7 +146,7 @@
     "rolldown": "^1.2.6",
     "rollup": "^4.63.1",
     "vite": "^8.2.2",
-    "webpack": "^5.110.1"
+    "webpack": "^5.110.2"
   },
   "peerDependencies": {
     "@farmfe/core": "^1.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,9 @@ importers:
       '@kubb/adapter-oas':
         specifier: workspace:*
         version: link:../adapter-oas
+      '@kubb/studio':
+        specifier: workspace:*
+        version: link:../studio
 
   packages/core:
     dependencies:
@@ -240,13 +243,13 @@ importers:
     devDependencies:
       '@farmfe/core':
         specifier: ^1.7.11
-        version: 1.7.11(@types/node@26.0.1)(supports-color@8.1.1)
+        version: 1.7.11(@types/node@22.20.1)(supports-color@8.1.1)
       '@internals/utils':
         specifier: workspace:*
         version: link:../../internals/utils
       '@nuxt/kit':
         specifier: ^4.5.2
-        version: 4.5.2(magic-string@0.30.21)(magicast@0.5.3)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@26.0.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
+        version: 4.5.2(magic-string@0.30.21)(magicast@0.5.3)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
       '@nuxt/schema':
         specifier: ^4.5.2
         version: 4.5.2
@@ -266,8 +269,8 @@ importers:
         specifier: ^8.2.2
         version: 8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0)
       webpack:
-        specifier: ^5.110.1
-        version: 5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)
+        specifier: ^5.110.2
+        version: 5.110.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)
 
   packages/mcp:
     dependencies:
@@ -394,7 +397,7 @@ importers:
         version: link:../plugin-barrel
       unplugin:
         specifier: ^3.3.0
-        version: 3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+        version: 3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
     devDependencies:
       '@farmfe/core':
         specifier: ^1.7.11
@@ -404,7 +407,7 @@ importers:
         version: link:../ast
       '@nuxt/kit':
         specifier: ^4.5.2
-        version: 4.5.2(magic-string@0.30.21)(magicast@0.5.4)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
+        version: 4.5.2(magic-string@0.30.21)(magicast@0.5.4)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
       '@nuxt/schema':
         specifier: ^4.5.2
         version: 4.5.2
@@ -421,8 +424,8 @@ importers:
         specifier: ^8.2.2
         version: 8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0)
       webpack:
-        specifier: ^5.110.1
-        version: 5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)
+        specifier: ^5.110.2
+        version: 5.110.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)
 
   tools/claude: {}
 
@@ -599,15 +602,6 @@ packages:
   '@clack/prompts@1.7.0':
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
-
-  '@emnapi/core@2.0.0-alpha.3':
-    resolution: {integrity: sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==}
-
-  '@emnapi/runtime@2.0.0-alpha.3':
-    resolution: {integrity: sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==}
-
-  '@emnapi/wasi-threads@2.0.1':
-    resolution: {integrity: sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==}
 
   '@esbuild/aix-ppc64@0.28.2':
     resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
@@ -915,13 +909,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@napi-rs/wasm-runtime@1.2.2':
-    resolution: {integrity: sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
-    peerDependencies:
-      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.3
-      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.3
-
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -941,9 +928,6 @@ packages:
   '@nuxt/schema@4.5.2':
     resolution: {integrity: sha512-h9g1kt9O2iU9nX6HDFu9gvwtpn+8oSJX0RSTWRBnEx/Pkz+WlOHtjuS0SbkTAXw5aT1+H1GysWVwNTjJfBY/0w==}
     engines: {node: ^14.18.0 || >=16.10.0}
-
-  '@oxc-project/types@0.142.0':
-    resolution: {integrity: sha512-7W+2q5AKQVU36fkaryontrHn3YDt1RyUYXatw9i5H8ocYe2sPKSFB6eS8WNPeRKiN1qAWWZUPm7gwFzJGrccqQ==}
 
   '@oxc-project/types@0.147.0':
     resolution: {integrity: sha512-IJ3s6ltHLp45S0bh7phkX+gJO7A1Wuz2EaqpAhb8WjqDwbzMiWKHhyyT42tskaWjEYXtHtVCPpnBJVT9+dcRLg==}
@@ -1224,34 +1208,16 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@rolldown/binding-android-arm64@1.2.1':
-    resolution: {integrity: sha512-02hOeOSryYxVrOIphmLAsqnCJWxwlzFk+pEt/N/i6OgT3lShHO7xGCU5cpgchRDHboAEbSjzgGh+O/u1GswQmA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [android]
-
   '@rolldown/binding-android-arm64@1.2.6':
     resolution: {integrity: sha512-lkWU8ZJaRk9q3CIEY1Tc7vIFALp3Xw5NfGJo2hQg5oIqNgxWi1zI+IiDEK3r70BF5Dzol1tcXsnzsRc8NLhG+Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.2.1':
-    resolution: {integrity: sha512-fMsTOnN0OjFm3CyppWPitKnc8UlliVARUULW6cfU6AIqjdtgmSFWSk9vecHzZduv/yMWIHDlRhM1e8Iff9uAfA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [darwin]
-
   '@rolldown/binding-darwin-arm64@1.2.6':
     resolution: {integrity: sha512-dgR56NYnvAszm7Ob1B2/Vn0e8bUQYZH2UjVaMMtMVOCKFSfjhfLmuA/9+O+F+ajUdG6B/bSssrKW6JJYASa8jA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [darwin]
-
-  '@rolldown/binding-darwin-x64@1.2.1':
-    resolution: {integrity: sha512-1wjKdz/XLGKHaTNHjQveQ/B23TKx4ItAqm1JbyVuvNPc4Ze0Fb48s49TAd/2zcplPl8okE/UbTgmlVfwT7eFeQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
     os: [darwin]
 
   '@rolldown/binding-darwin-x64@1.2.6':
@@ -1260,36 +1226,17 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.2.1':
-    resolution: {integrity: sha512-Fa0jHR07E7YBN4vOEsbVf2briYNsuOowfLJaXULZM0ldMlaCaj2LJgLMbMe4iacRyZmvR8efFhgR9wKuGclQUg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [freebsd]
-
   '@rolldown/binding-freebsd-x64@1.2.6':
     resolution: {integrity: sha512-h1wG6Y6K3JlRswxsI64qQJqBAy4vrLuHgRbc8CZMGSWTOFRY6ghMApM1NKzB2I0n5xV1fjkE18SuVl2QpLeNpA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.2.1':
-    resolution: {integrity: sha512-pzkgu1SSHGgRRyRZ4fbmSgmajbVt+epaLP99NDjFft69v/ypfTi6swBMiVdh2EkQ0OSnHE1lZDM7DRGkyAzUpA==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm]
-    os: [linux]
-
   '@rolldown/binding-linux-arm-gnueabihf@1.2.6':
     resolution: {integrity: sha512-tbCiqub0q2MVWJKgF5PoAlNWCtQydiOYSLIkd8sByqK/6MMYLJRcSXSYodqYtd0O+Fw7QaVmKKlS4oL94YRZ0w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
-
-  '@rolldown/binding-linux-arm64-gnu@1.2.1':
-    resolution: {integrity: sha512-QI5SEDY8cbiYWHx0VO4vIc3UlS6a32vXHjU8Qy/17adEmZIPuByJg13UEvo9c/UCiUkdcVWY83C+b+JrwnNyUg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.2.6':
     resolution: {integrity: sha512-oxK9+baEBPhZG5HB4URY+uU04zJWeZlH6Tb9rB5DK4DF9XR1uXNLXt5Q5ZsugTKayNCNLhkcwz/ye74hRI98dg==}
@@ -1298,13 +1245,6 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.2.1':
-    resolution: {integrity: sha512-Sm41FyCeXqmYcERoYOCbGIL5hNfd8w9LQ7Y61Bev48HkcjaJqV/iiVOaiDxjVTRMS+QKrZmD8cfPt4uMVnvM+A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
   '@rolldown/binding-linux-arm64-musl@1.2.6':
     resolution: {integrity: sha512-muWCk27FVBEZtv0MsK8gnfSmgczA8KQ0uRVJbTABKhkRfQc38aUrcb7fhi3BNiyseFmgcRsoMfQsSNJ+DbZdSw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1312,24 +1252,10 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.2.1':
-    resolution: {integrity: sha512-2x+WhXTGl9yJYPbltW/BSEPTVz9OIWQyER4N+gJEDWkkn904eRcBzELqh/Hf7K0w/ubGbKNMv0ZC+94QK/IFEg==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-ppc64-gnu@1.2.6':
     resolution: {integrity: sha512-eWDoSfU7Co2qj3vgB3Dt4lj1mG6CoWbcJQkRMP3XJplyCMtuaq3LHvPFjS9QIPvMGWVadJC04Xiy0IdcVPtnwQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@rolldown/binding-linux-s390x-gnu@1.2.1':
-    resolution: {integrity: sha512-eEjmQpuRQayHPWWnywaWHkFT3ToPbP3RYy42VVd/B9aBGDA+Ol25EIWHxKQST3IiWJjikCWUF7KtbfqwZrzVwQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
@@ -1340,26 +1266,12 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.2.1':
-    resolution: {integrity: sha512-/Orga1fZYkLc/56jBICcHrKchl8Z2UKdDSr3LG9ToWO1lQ6a4Livk9Xz+9WN91zsz5QR3XQz2NNoSDEvP6qadw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
   '@rolldown/binding-linux-x64-gnu@1.2.6':
     resolution: {integrity: sha512-KekI0gS0wLxe1UBSQSjenBVwou/JkcQPDzBPICGZjxUv9k3RteHDPBQaiOicZUFKRIH2wKEimGwVpnJsbPzu7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
-
-  '@rolldown/binding-linux-x64-musl@1.2.1':
-    resolution: {integrity: sha512-xxBJRL+0q0Kce7orznGWLuylHDY65vuARXZRpX+hPdv+DqK2c3NlCsVA98tlWzWNEE7yPqA/1NQ5nnCrj49Y5A==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.2.6':
     resolution: {integrity: sha512-TvtPnfVr+HtyGiDmPK4VWmlNm7QhNNAcK5Q9A7aOXsI8545yCyaoMaicXrFZ72JzeYjaUVk7yT243zT0jzjFKQ==}
@@ -1368,38 +1280,16 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.2.1':
-    resolution: {integrity: sha512-M6AdXIXw3s+/8XpKMzdGDEXGS1S7kwUsy+rcTIUIOx5Ge4nXKCtAFHFV9YKkXvGcC5WMoTjAteLzlsQROVI0Yw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [openharmony]
-
   '@rolldown/binding-openharmony-arm64@1.2.6':
     resolution: {integrity: sha512-iOo0VEay2XFhaCcH0sps5XIimkSuOnNaZrf6+ZkoSOQBJPKNU48RkmJv0/lSpipexu5P+ouFgafe5IGr/DiQfg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.2.1':
-    resolution: {integrity: sha512-/TX0SoRGojHzSAHpfVBbavRVSazg5U3h3Y3VXfcc0cdugq6kxdqw8LPGFiPr+/7gE/60zRcsOY2Vi9b9eT0jww==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
-
-  '@rolldown/binding-win32-arm64-msvc@1.2.1':
-    resolution: {integrity: sha512-EvRrivJieyHG+AO9lleZWgq+g0+S7oV2C51yuqlcyU/R9net+sI4Pj0F+lUoP2bEr6TWX3SqFaaS0SzfLxSzkw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [arm64]
-    os: [win32]
-
   '@rolldown/binding-win32-arm64-msvc@1.2.6':
     resolution: {integrity: sha512-y5NTmmasMS455JlOCO4ZM9krIchv3Mvm1crL1iUPGOPgEzSkves9n0SdC5Sjz6+qWDFhd8/JpfWMH8NSWNHe+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
-    os: [win32]
-
-  '@rolldown/binding-win32-x64-msvc@1.2.1':
-    resolution: {integrity: sha512-Z4eCmn5QJ/5+azF9knpLWKfVd9aidn0mAe9TpJgvBLId9Ax3t0+JVxBmT25Bv7NBbVW1TZyKjQjQReouMeH5UQ==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    cpu: [x64]
     os: [win32]
 
   '@rolldown/binding-win32-x64-msvc@1.2.6':
@@ -1608,9 +1498,6 @@ packages:
     resolution: {integrity: sha512-0i0mVUa4kKk+/B3RwEwPMf9CB+T7ul56hn5FFHNA4VUNTOoLBEd6aNf3FaKfCatDNZ6cicCEf6if9QUTVyzzcA==}
     cpu: [arm64]
     os: [win32]
-
-  '@tybys/wasm-util@0.10.3':
-    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -3214,11 +3101,6 @@ packages:
       vue-tsc:
         optional: true
 
-  rolldown@1.2.1:
-    resolution: {integrity: sha512-4FKJhg8d3OiyQOA6Q1Q0hoFFpW9/OoX+VsHzpECsdsIZoOArrAK90gl59YK/Z+gnDel45bgJZK03ozH/9bCqEw==}
-    engines: {node: ^20.19.0 || >=22.12.0}
-    hasBin: true
-
   rolldown@1.2.6:
     resolution: {integrity: sha512-vMM4q3aixf46GiF1Kok8jDPFsEpXgFWGjUHXNkNHNm+Y2adXAG2dbX91jkti3i0ZRsOlcmbuzAz1poObSHCmUA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3374,10 +3256,6 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
-
-  tinyexec@1.2.4:
-    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
-    engines: {node: '>=18'}
 
   tinyexec@1.3.0:
     resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
@@ -3750,8 +3628,8 @@ packages:
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
-  webpack@5.110.1:
-    resolution: {integrity: sha512-gInQB+jxXxgnZyvPwuzT5NGQmECDqeu85oxcrjinrYHqPoBex0hCAN2SFTJVyPVrK0Pq9E44VFP+e89fAc10/w==}
+  webpack@5.110.2:
+    resolution: {integrity: sha512-TciLrfM7zgEjqGdY851HkirDsSPQgTFsWQpl9oHqMAMYsHhEC0bKjscvjpnz+pzx10hLC8qISApGrsnrCP4UtQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -3947,37 +3825,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@changesets/cli@2.31.1(@types/node@26.0.1)':
-    dependencies:
-      '@changesets/apply-release-plan': 7.1.1
-      '@changesets/assemble-release-plan': 6.0.10
-      '@changesets/changelog-git': 0.2.1
-      '@changesets/config': 3.1.4
-      '@changesets/errors': 0.2.0
-      '@changesets/get-dependents-graph': 2.1.4
-      '@changesets/get-release-plan': 4.0.16
-      '@changesets/git': 3.0.4
-      '@changesets/logger': 0.1.1
-      '@changesets/pre': 2.0.2
-      '@changesets/read': 0.6.7
-      '@changesets/should-skip-package': 0.1.2
-      '@changesets/types': 6.1.0
-      '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@26.0.1)
-      '@manypkg/get-packages': 1.1.3
-      ansi-colors: 4.1.3
-      enquirer: 2.4.1
-      fs-extra: 7.0.1
-      mri: 1.2.0
-      package-manager-detector: 0.2.11
-      picocolors: 1.1.1
-      resolve-from: 5.0.0
-      semver: 7.8.5
-      spawndamnit: 3.0.1
-      term-size: 2.2.1
-    transitivePeerDependencies:
-      - '@types/node'
-
   '@changesets/cli@3.0.1':
     dependencies:
       '@changesets/apply-release-plan': 8.0.0
@@ -4158,22 +4005,6 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@emnapi/core@2.0.0-alpha.3':
-    dependencies:
-      '@emnapi/wasi-threads': 2.0.1
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@2.0.0-alpha.3':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@2.0.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@esbuild/aix-ppc64@0.28.2':
     optional: true
 
@@ -4324,51 +4155,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@farmfe/core@1.7.11(@types/node@26.0.1)(supports-color@8.1.1)':
-    dependencies:
-      '@farmfe/runtime': 0.12.10
-      '@farmfe/runtime-plugin-hmr': 3.5.10
-      '@farmfe/runtime-plugin-import-meta': 0.2.3
-      '@farmfe/utils': 0.1.0
-      '@koa/cors': 5.0.0
-      '@swc/helpers': 0.5.23
-      chokidar: 3.6.0
-      deepmerge: 4.3.1
-      dotenv: 16.6.1
-      dotenv-expand: 11.0.7
-      execa: 7.2.0
-      farm-browserslist-generator: 1.0.5
-      farm-plugin-replace-dirname: 0.2.1(@types/node@26.0.1)
-      fast-glob: 3.3.3
-      fs-extra: 11.3.5
-      http-proxy-middleware: 3.0.7(supports-color@8.1.1)
-      is-plain-object: 5.0.0
-      koa: 2.16.4(supports-color@8.1.1)
-      koa-compress: 5.2.2
-      koa-connect: 2.1.1
-      koa-static: 5.0.0(supports-color@8.1.1)
-      lodash.debounce: 4.0.8
-      loglevel: 1.9.2
-      open: 9.1.0
-      ws: 8.21.0
-      zod: 3.25.76
-      zod-validation-error: 1.5.0(zod@3.25.76)
-    optionalDependencies:
-      '@farmfe/core-darwin-arm64': 1.7.11
-      '@farmfe/core-darwin-x64': 1.7.11
-      '@farmfe/core-linux-arm64-gnu': 1.7.11
-      '@farmfe/core-linux-arm64-musl': 1.7.11
-      '@farmfe/core-linux-x64-gnu': 1.7.11
-      '@farmfe/core-linux-x64-musl': 1.7.11
-      '@farmfe/core-win32-arm64-msvc': 1.7.11
-      '@farmfe/core-win32-ia32-msvc': 1.7.11
-      '@farmfe/core-win32-x64-msvc': 1.7.11
-    transitivePeerDependencies:
-      - '@types/node'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   '@farmfe/runtime-plugin-hmr@3.5.10':
     dependencies:
       core-js: 3.49.0
@@ -4401,13 +4187,6 @@ snapshots:
       iconv-lite: 0.7.2
     optionalDependencies:
       '@types/node': 22.20.1
-
-  '@inquirer/external-editor@1.0.3(@types/node@26.0.1)':
-    dependencies:
-      chardet: 2.2.0
-      iconv-lite: 0.7.2
-    optionalDependencies:
-      '@types/node': 26.0.1
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -4473,13 +4252,6 @@ snapshots:
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
 
-  '@napi-rs/wasm-runtime@1.2.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
-    dependencies:
-      '@emnapi/core': 2.0.0-alpha.3
-      '@emnapi/runtime': 2.0.0-alpha.3
-      '@tybys/wasm-util': 0.10.3
-    optional: true
-
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -4492,7 +4264,7 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@nuxt/kit@4.5.2(magic-string@0.30.21)(magicast@0.5.3)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@26.0.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))':
+  '@nuxt/kit@4.5.2(magic-string@0.30.21)(magicast@0.5.3)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))':
     dependencies:
       c12: 3.3.4(magicast@0.5.3)
       consola: 3.4.2
@@ -4512,7 +4284,7 @@ snapshots:
       scule: 1.3.0
       tinyglobby: 0.2.17
       ufo: 1.6.4
-      unctx: 3.0.0(magic-string@0.30.21)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@26.0.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
+      unctx: 3.0.0(magic-string@0.30.21)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
       untyped: 2.0.0
       verkit: 0.3.2
     transitivePeerDependencies:
@@ -4522,7 +4294,7 @@ snapshots:
       - rolldown
       - unplugin
 
-  '@nuxt/kit@4.5.2(magic-string@0.30.21)(magicast@0.5.4)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))':
+  '@nuxt/kit@4.5.2(magic-string@0.30.21)(magicast@0.5.4)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))':
     dependencies:
       c12: 3.3.4(magicast@0.5.4)
       consola: 3.4.2
@@ -4542,7 +4314,7 @@ snapshots:
       scule: 1.3.0
       tinyglobby: 0.2.17
       ufo: 1.6.4
-      unctx: 3.0.0(magic-string@0.30.21)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
+      unctx: 3.0.0(magic-string@0.30.21)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
       untyped: 2.0.0
       verkit: 0.3.2
     transitivePeerDependencies:
@@ -4560,8 +4332,6 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 2.3.1
       std-env: 4.2.0
-
-  '@oxc-project/types@0.142.0': {}
 
   '@oxc-project/types@0.147.0': {}
 
@@ -4714,92 +4484,43 @@ snapshots:
   '@rolldown/binding-android-arm-eabi@1.2.6':
     optional: true
 
-  '@rolldown/binding-android-arm64@1.2.1':
-    optional: true
-
   '@rolldown/binding-android-arm64@1.2.6':
-    optional: true
-
-  '@rolldown/binding-darwin-arm64@1.2.1':
     optional: true
 
   '@rolldown/binding-darwin-arm64@1.2.6':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.2.1':
-    optional: true
-
   '@rolldown/binding-darwin-x64@1.2.6':
-    optional: true
-
-  '@rolldown/binding-freebsd-x64@1.2.1':
     optional: true
 
   '@rolldown/binding-freebsd-x64@1.2.6':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.2.1':
-    optional: true
-
   '@rolldown/binding-linux-arm-gnueabihf@1.2.6':
-    optional: true
-
-  '@rolldown/binding-linux-arm64-gnu@1.2.1':
     optional: true
 
   '@rolldown/binding-linux-arm64-gnu@1.2.6':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.2.1':
-    optional: true
-
   '@rolldown/binding-linux-arm64-musl@1.2.6':
-    optional: true
-
-  '@rolldown/binding-linux-ppc64-gnu@1.2.1':
     optional: true
 
   '@rolldown/binding-linux-ppc64-gnu@1.2.6':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.2.1':
-    optional: true
-
   '@rolldown/binding-linux-s390x-gnu@1.2.6':
-    optional: true
-
-  '@rolldown/binding-linux-x64-gnu@1.2.1':
     optional: true
 
   '@rolldown/binding-linux-x64-gnu@1.2.6':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.2.1':
-    optional: true
-
   '@rolldown/binding-linux-x64-musl@1.2.6':
-    optional: true
-
-  '@rolldown/binding-openharmony-arm64@1.2.1':
     optional: true
 
   '@rolldown/binding-openharmony-arm64@1.2.6':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.2.1':
-    dependencies:
-      '@emnapi/core': 2.0.0-alpha.3
-      '@emnapi/runtime': 2.0.0-alpha.3
-      '@napi-rs/wasm-runtime': 1.2.2(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
-    optional: true
-
-  '@rolldown/binding-win32-arm64-msvc@1.2.1':
-    optional: true
-
   '@rolldown/binding-win32-arm64-msvc@1.2.6':
-    optional: true
-
-  '@rolldown/binding-win32-x64-msvc@1.2.1':
     optional: true
 
   '@rolldown/binding-win32-x64-msvc@1.2.6':
@@ -4927,11 +4648,6 @@ snapshots:
     optional: true
 
   '@turbo/windows-arm64@2.10.12':
-    optional: true
-
-  '@tybys/wasm-util@0.10.3':
-    dependencies:
-      tslib: 2.8.1
     optional: true
 
   '@types/chai@5.2.3':
@@ -5638,24 +5354,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  farm-plugin-replace-dirname@0.2.1(@types/node@26.0.1):
-    dependencies:
-      '@changesets/cli': 2.31.1(@types/node@26.0.1)
-      '@farmfe/utils': 0.0.1
-      cac: 6.7.14
-    optionalDependencies:
-      farm-plugin-replace-dirname-darwin-arm64: 0.2.1
-      farm-plugin-replace-dirname-darwin-x64: 0.2.1
-      farm-plugin-replace-dirname-linux-arm64-gnu: 0.2.1
-      farm-plugin-replace-dirname-linux-arm64-musl: 0.2.1
-      farm-plugin-replace-dirname-linux-x64-gnu: 0.2.1
-      farm-plugin-replace-dirname-linux-x64-musl: 0.2.1
-      farm-plugin-replace-dirname-win32-arm64-msvc: 0.2.1
-      farm-plugin-replace-dirname-win32-ia32-msvc: 0.2.1
-      farm-plugin-replace-dirname-win32-x64-msvc: 0.2.1
-    transitivePeerDependencies:
-      - '@types/node'
-
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -6176,13 +5874,13 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  minimizer-webpack-plugin@5.8.0(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)):
+  minimizer-webpack-plugin@5.8.0(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)(webpack@5.110.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.51.2
-      webpack: 5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)
+      webpack: 5.110.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)
     optionalDependencies:
       esbuild: 0.28.2
       lightningcss: 1.33.0
@@ -6432,12 +6130,12 @@ snapshots:
 
   reusify@1.1.0: {}
 
-  rolldown-plugin-dts@0.27.14(rolldown@1.2.1)(typescript@6.0.3):
+  rolldown-plugin-dts@0.27.14(rolldown@1.2.6)(typescript@6.0.3):
     dependencies:
       dts-resolver: 3.0.0
       get-tsconfig: 5.0.0-beta.5
       obug: 2.1.4
-      rolldown: 1.2.1
+      rolldown: 1.2.6
       yuku-ast: 0.8.1
       yuku-codegen: 0.8.1
       yuku-parser: 0.8.1
@@ -6445,27 +6143,6 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - oxc-resolver
-
-  rolldown@1.2.1:
-    dependencies:
-      '@oxc-project/types': 0.142.0
-      '@rolldown/pluginutils': 1.0.1
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.2.1
-      '@rolldown/binding-darwin-arm64': 1.2.1
-      '@rolldown/binding-darwin-x64': 1.2.1
-      '@rolldown/binding-freebsd-x64': 1.2.1
-      '@rolldown/binding-linux-arm-gnueabihf': 1.2.1
-      '@rolldown/binding-linux-arm64-gnu': 1.2.1
-      '@rolldown/binding-linux-arm64-musl': 1.2.1
-      '@rolldown/binding-linux-ppc64-gnu': 1.2.1
-      '@rolldown/binding-linux-s390x-gnu': 1.2.1
-      '@rolldown/binding-linux-x64-gnu': 1.2.1
-      '@rolldown/binding-linux-x64-musl': 1.2.1
-      '@rolldown/binding-openharmony-arm64': 1.2.1
-      '@rolldown/binding-wasm32-wasi': 1.2.1
-      '@rolldown/binding-win32-arm64-msvc': 1.2.1
-      '@rolldown/binding-win32-x64-msvc': 1.2.1
 
   rolldown@1.2.6:
     dependencies:
@@ -6651,8 +6328,6 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.2.4: {}
-
   tinyexec@1.3.0: {}
 
   tinyglobby@0.2.17:
@@ -6696,9 +6371,9 @@ snapshots:
       import-without-cache: 0.4.0
       obug: 2.1.4
       picomatch: 4.0.5
-      rolldown: 1.2.1
-      rolldown-plugin-dts: 0.27.14(rolldown@1.2.1)(typescript@6.0.3)
-      tinyexec: 1.2.4
+      rolldown: 1.2.6
+      rolldown-plugin-dts: 0.27.14(rolldown@1.2.6)(typescript@6.0.3)
+      tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tree-kill: 1.2.2
       unconfig-core: 7.5.0
@@ -6750,17 +6425,11 @@ snapshots:
 
   uncrypto@0.1.3: {}
 
-  unctx@3.0.0(magic-string@0.30.21)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))):
+  unctx@3.0.0(magic-string@0.30.21)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))):
     optionalDependencies:
       magic-string: 0.30.21
       rolldown: 1.2.6
-      unplugin: 3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-
-  unctx@3.0.0(magic-string@0.30.21)(rolldown@1.2.6)(unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@26.0.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))):
-    optionalDependencies:
-      magic-string: 0.30.21
-      rolldown: 1.2.6
-      unplugin: 3.3.0(@farmfe/core@1.7.11(@types/node@26.0.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      unplugin: 3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
 
   undici-types@6.21.0: {}
 
@@ -6772,7 +6441,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)):
+  unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@22.20.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
       '@jridgewell/remapping': 2.3.5
       picomatch: 4.0.5
@@ -6783,21 +6452,7 @@ snapshots:
       rolldown: 1.2.6
       rollup: 4.63.1
       vite: 8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0)
-      webpack: 5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)
-
-  unplugin@3.3.0(@farmfe/core@1.7.11(@types/node@26.0.1)(supports-color@8.1.1))(esbuild@0.28.2)(rolldown@1.2.6)(rollup@4.63.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)):
-    dependencies:
-      '@jridgewell/remapping': 2.3.5
-      picomatch: 4.0.5
-      webpack-virtual-modules: 0.6.2
-    optionalDependencies:
-      '@farmfe/core': 1.7.11(@types/node@26.0.1)(supports-color@8.1.1)
-      esbuild: 0.28.2
-      rolldown: 1.2.6
-      rollup: 4.63.1
-      vite: 8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0)
-      webpack: 5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)
-    optional: true
+      webpack: 5.110.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)
 
   unstorage@1.17.5:
     dependencies:
@@ -6890,7 +6545,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26):
+  webpack@5.110.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26):
     dependencies:
       '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
@@ -6905,7 +6560,7 @@ snapshots:
       events: 3.3.0
       graceful-fs: 4.2.11
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.8.0(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)(webpack@5.110.1(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      minimizer-webpack-plugin: 5.8.0(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)(webpack@5.110.2(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3


### PR DESCRIPTION
## 🎯 Changes

Final PR of a 5-PR stack splitting up #3936 by concept. Base is PR4
(#3971) so it only shows the diff for this slice. Wires the finished `@kubb/studio` package into
the CLI, the PR that actually makes the feature reachable by a user.

- `connectStudio.ts` orchestrates a session: registers the agent, opens the socket, dispatches
  Studio's `studio:generate`/`studio:connect`/`studio:save` commands, and reports progress through
  the `AgentHooks` from PR2. `client.ts` is the public `createClient` entry point, tying
  registration, storage, and the connection together.
- `kubb studio login|logout|status` manage pairing (PR3); `kubb studio` connects and streams
  generation events, read-only by default. `--allowWrite` writes generated files, `--allowInput`
  accepts a spec from Studio, `--allowExec` runs the formatter/linter/`postGenerate`, and
  `--allowConfigEdit` (PR4) lets Studio edit `kubb.config.ts`. Each is asked for once per project
  and left off in CI.
- The CLI's `clackLogger` and `plainLogger` render `studio:*` session events here rather than in
  PR1: PR1 carries no Studio code, and the `studio:*` hook names only resolve once `@kubb/studio`
  (which extends `KubbHooks` with them, see PR2) is actually in the program — true from this PR
  onward, since it's the first to import `@kubb/studio`. A Studio-driven generation gets the same
  spinners, progress bars, and summary as `kubb generate`.
- `kubb mcp`, `kubb validate`, and now `kubb studio` all lazy-load their optional peer, so
  `kubb --help` and `kubb generate` never touch `@kubb/studio`.

Verified this branch reproduces #3936's head exactly (diffed against it directly), aside from one
intentionally dropped stale changeset (`olive-parrots-shake.md`, superseded by
`studio-directional-protocol.md` in PR2) and the `StudioHooks` → `Kubb.KubbHooksRegistry` merge
described above, which is a type-location refactor with no behavior change.

**Code-review fixes** (latest commit): a self-review surfaced five real issues, all in files that
only exist on this PR:
- `client.ts` fired each pool slot's `connectToStudio()` without awaiting it, so a token that went
  bad after registration (not just at registration) never reached `run()`'s re-pair path — the
  process just hung on a silent warning instead of clearing the credential and pairing again. Now
  awaited; `connectToStudio()` only rejects for `InvalidAgentTokenError`, so this doesn't block
  startup on a down Studio.
- `login()`'s spinner checked `canUseTTY()` instead of `isRichOutput()`, so it rendered raw
  terminal escape sequences under an AI coding agent's pseudo-TTY instead of falling back to plain
  text like the rest of the command.
- `configPath` stayed absolute past the banner, leaking the local filesystem layout into both the
  permission confirm prompt and the payload Studio receives over the wire. Relativized once in
  `loadConfigs()`.
- `connectStudio.ts` reimplemented the already-imported `toError` helper inline.
- The credentials file was written with default permissions and `chmod`'d to `0600` afterward,
  leaving a brief window where a freshly paired bearer token was world/group-readable. Now written
  with mode `0600` set at creation.

Stack: PR1 (#3968) → PR2 (#3969) → PR3 (#3970) → PR4 (#3971) → **PR5 (this PR)**.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018oTZxx4JE5oY1Wb6NC4ojP

---
_Generated by [Claude Code](https://claude.ai/code/session_018oTZxx4JE5oY1Wb6NC4ojP)_