### PR TITLE
fix(cli): check for kubb.config.ts before pairing with Studio

### DIFF
--- a/.changeset/quick-plums-jump.md
+++ b/.changeset/quick-plums-jump.md
@@ -1,0 +1,7 @@
+---
+'@kubb/cli': patch
+---
+
+Fix `kubb studio` to check for a `kubb.config.ts` before pairing with Studio, instead of after. A
+project with no config now fails fast instead of starting a device-authorization flow it can
+never use.

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -203,6 +203,10 @@ async function loadConfigs(options: StudioOptions): Promise<{ configPath: string
  * Connects this project to Studio and streams generation events until the process is stopped.
  */
 async function connect(options: StudioOptions, retryPairing = true): Promise<void> {
+  // Resolved before any network call to Studio (pairing included), so a project with no config
+  // fails fast instead of starting a device-authorization flow it can never use.
+  const { configPath } = await loadConfigs(options)
+
   const envToken = process.env.KUBB_AGENT_TOKEN
   const stored = envToken ? null : await readCredentials()
 
@@ -225,8 +229,6 @@ async function connect(options: StudioOptions, retryPairing = true): Promise<voi
 
     return login(options)
   })()
-
-  const { configPath } = await loadConfigs(options)
   const { allowWrite, allowConfigEdit, allowInput, allowExec } = await resolvePermissions(options, credentials, configPath, !envToken)
   const granted = { allowWrite, allowConfigEdit, allowInput, allowExec }
 


### PR DESCRIPTION
## 🎯 Changes

`kubb studio` started pairing with Studio (a device-authorization network call) before checking
the project had a `kubb.config.ts`. A project with no config would open a browser approval prompt
it could never finish, since `loadConfigs` throws right after.

`connect()` in `packages/cli/src/runners/studio/run.ts` now resolves the config first and only
starts credential resolution (which may call `login`) after that succeeds.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VCW7o66vAWDM8nomqDXL7u

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCW7o66vAWDM8nomqDXL7u)_