### PR TITLE
feat(studio,cli): reauthenticate automatically when Studio rejects a live token

### DIFF
--- a/.changeset/olive-pandas-write.md
+++ b/.changeset/olive-pandas-write.md
@@ -1,0 +1,7 @@
+---
+'@kubb/cli': patch
+---
+
+`kubb init` and `kubb generate --watch` now print plain lines when the terminal cannot carry
+clack's gutter, such as a piped run or CI. They wrote box-drawing and cursor escapes into the
+output before. Spinner steps print as lines there instead of disappearing with the animation.

--- a/.changeset/silver-frogs-listen.md
+++ b/.changeset/silver-frogs-listen.md
@@ -2,15 +2,11 @@
 '@kubb/cli': minor
 ---
 
-`kubb studio` reconnects on its own when Studio rejects the agent token while the session is
-already live, not only at startup. It explains what happened, reopens the browser approval flow,
-and reconnects with the new token, keeping saved project permissions when the reauthenticated
-agent has the same identity and Studio URL.
+`kubb studio` now recovers when Studio rejects the agent token while a session is already live,
+not only at startup: it explains what happened, reopens the browser approval flow, and reconnects
+with the new token. Saved project permissions carry over when the reauthenticated agent keeps the
+same identity and Studio URL.
 
-An operator-supplied `KUBB_AGENT_TOKEN` is never replaced automatically: a rejection there tells
-the operator to update it. In CI or without a browser, `kubb studio` exits with instructions to run
-`kubb studio login`. A newly approved token rejected again immediately is treated as a hard
-failure instead of pairing forever.
-
-Ctrl+C now cancels an in-flight pairing or reconnect instead of leaving it running, and no longer
-leaves behind a duplicate shutdown handler across a reauth.
+An operator-supplied `KUBB_AGENT_TOKEN` is never replaced automatically, and CI or a run without a
+browser exits with instructions to run `kubb studio login`. Ctrl+C now cancels an in-flight
+pairing cleanly instead of leaving it running.

--- a/.changeset/silver-frogs-listen.md
+++ b/.changeset/silver-frogs-listen.md
@@ -1,0 +1,16 @@
+---
+'@kubb/cli': minor
+---
+
+`kubb studio` reconnects on its own when Studio rejects the agent token while the session is
+already live, not only at startup. It explains what happened, reopens the browser approval flow,
+and reconnects with the new token, keeping saved project permissions when the reauthenticated
+agent has the same identity and Studio URL.
+
+An operator-supplied `KUBB_AGENT_TOKEN` is never replaced automatically: a rejection there tells
+the operator to update it. In CI or without a browser, `kubb studio` exits with instructions to run
+`kubb studio login`. A newly approved token rejected again immediately is treated as a hard
+failure instead of pairing forever.
+
+Ctrl+C now cancels an in-flight pairing or reconnect instead of leaving it running, and no longer
+leaves behind a duplicate shutdown handler across a reauth.

--- a/.changeset/silver-frogs-listen.md
+++ b/.changeset/silver-frogs-listen.md
@@ -5,7 +5,7 @@
 `kubb studio` now recovers when Studio rejects the agent token while a session is already live,
 not only at startup: it explains what happened, reopens the browser approval flow, and reconnects
 with the new token. Saved project permissions carry over when the reauthenticated agent keeps the
-same identity and Studio URL.
+same identity and Studio URL, and are asked again when it does not.
 
 An operator-supplied `KUBB_AGENT_TOKEN` is never replaced automatically, and CI or a run without a
 browser exits with instructions to run `kubb studio login`. Ctrl+C now cancels an in-flight

--- a/.changeset/tame-otters-reconnect.md
+++ b/.changeset/tame-otters-reconnect.md
@@ -1,0 +1,14 @@
+---
+'@kubb/studio': minor
+---
+
+`createClient` gains an optional `onAuthRequired` callback, called once a live pool's token is
+rejected during background reconnect. The whole pool is already stopped by the time it fires, so a
+host only needs to obtain a replacement token and start a new client with it.
+
+It never fires for a token rejected at startup, which `connect()` already reports by throwing, nor
+for an ordinary session expiry or a revoked session, both of which keep reconnecting on their own.
+
+`startPairing` and `pollForPairingToken` take an optional `signal` too, so a host can cancel an
+in-flight pairing or poll. Aborting rejects with the new `PairingCanceledError`, exported from the
+package, so a canceled pairing is distinguishable from a denial or an expired code.

--- a/.changeset/tame-otters-reconnect.md
+++ b/.changeset/tame-otters-reconnect.md
@@ -2,13 +2,9 @@
 '@kubb/studio': minor
 ---
 
-`createClient` gains an optional `onAuthRequired` callback, called once a live pool's token is
-rejected during background reconnect. The whole pool is already stopped by the time it fires, so a
-host only needs to obtain a replacement token and start a new client with it.
+`createClient` now accepts an `onAuthRequired` callback, fired once when Studio rejects a live
+pool's token during background reconnect, after every session in the pool has already stopped. It
+never fires for a token rejected at startup or an ordinary session expiry.
 
-It never fires for a token rejected at startup, which `connect()` already reports by throwing, nor
-for an ordinary session expiry or a revoked session, both of which keep reconnecting on their own.
-
-`startPairing` and `pollForPairingToken` take an optional `signal` too, so a host can cancel an
-in-flight pairing or poll. Aborting rejects with the new `PairingCanceledError`, exported from the
-package, so a canceled pairing is distinguishable from a denial or an expired code.
+`startPairing` and `pollForPairingToken` accept an optional `signal` to cancel an in-flight
+pairing or poll, rejecting with the new `PairingCanceledError`.

--- a/packages/cli/src/loggers/output.test.ts
+++ b/packages/cli/src/loggers/output.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest'
+import * as prompts from '@clack/prompts'
+import * as env from '../utils/env.ts'
+import { createSpinner, logIntro, logInfo, logOutro } from './output.ts'
+
+vi.mock('@clack/prompts', () => ({
+  intro: vi.fn(),
+  outro: vi.fn(),
+  spinner: vi.fn(),
+  log: { message: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(), step: vi.fn() },
+}))
+
+/**
+ * Captures what the plain writers print, with rich output turned off.
+ */
+function capturePlain(run: () => void): Array<string> {
+  const lines: Array<string> = []
+  using _rich = vi.spyOn(env, 'isRichOutput').mockReturnValue(false)
+  using _log = vi.spyOn(console, 'log').mockImplementation((line = '') => void lines.push(String(line)))
+  using _warn = vi.spyOn(console, 'warn').mockImplementation((line = '') => void lines.push(String(line)))
+
+  run()
+
+  return lines
+}
+
+describe('plain output', () => {
+  it('prefixes a message with the same symbol the plain logger uses', () => {
+    expect(capturePlain(() => logInfo('Detected pnpm'))).toEqual(['ℹ Detected pnpm'])
+  })
+
+  it('prints the title and its warning instead of opening a block', () => {
+    expect(capturePlain(() => logIntro({ title: 'Kubb Studio', warning: 'Use with caution' }))).toEqual(['Kubb Studio', 'Use with caution', ''])
+  })
+
+  it('prints every step the spinner was given, so nothing is lost without an animation', () => {
+    const lines = capturePlain(() => {
+      const spinner = createSpinner()
+      spinner.start('Installing packages')
+      spinner.stop('Installed packages')
+    })
+
+    expect(lines).toEqual(['Installing packages', 'Installed packages'])
+  })
+})
+
+describe('rich output', () => {
+  it('hands the text to clack', () => {
+    using _rich = vi.spyOn(env, 'isRichOutput').mockReturnValue(true)
+
+    logOutro('Disconnected')
+    logInfo('Connected')
+
+    expect(prompts.outro).toHaveBeenCalledWith('Disconnected')
+    expect(prompts.log.info).toHaveBeenCalledWith('Connected')
+  })
+})

--- a/packages/cli/src/loggers/output.ts
+++ b/packages/cli/src/loggers/output.ts
@@ -1,0 +1,66 @@
+import * as prompts from '@clack/prompts'
+import { isRichOutput } from '../utils/env.ts'
+
+type IntroOptions = {
+  title: string
+  /**
+   * Printed under the title, in the logger's warning style.
+   */
+  warning: string
+  /**
+   * Whether to open a clack block that a later {@link logOutro} closes. Off for a command that
+   * prints and exits, since nothing would ever close the block.
+   */
+  block: boolean
+}
+
+/**
+ * Opens the command's output with a title and a warning under it.
+ */
+export function logIntro({ title, warning, block }: IntroOptions): void {
+  if (block && isRichOutput()) {
+    prompts.intro(title)
+    prompts.log.warn(warning)
+
+    return
+  }
+
+  console.log(title)
+  console.warn(warning)
+  console.log()
+}
+
+/**
+ * Prints one block of lines: clack's gutter when the terminal can carry it, plain lines otherwise.
+ */
+export function logBlock(lines: string | Array<string>): void {
+  if (isRichOutput()) {
+    prompts.log.message(lines)
+
+    return
+  }
+
+  console.log([lines].flat().join('\n'))
+}
+
+/**
+ * Closes the block {@link logIntro} opened. `outro` is the closing gutter rather than a written
+ * line, so plain output prints the text on its own.
+ */
+export function logOutro(text: string): void {
+  if (isRichOutput()) {
+    prompts.outro(text)
+
+    return
+  }
+
+  console.log(text)
+}
+
+/**
+ * A spinner, or null when the terminal cannot animate one. Callers drive it with `spinner?.start()`
+ * so the same code path works either way.
+ */
+export function createSpinner(): ReturnType<typeof prompts.spinner> | null {
+  return isRichOutput() ? prompts.spinner() : null
+}

--- a/packages/cli/src/loggers/output.ts
+++ b/packages/cli/src/loggers/output.ts
@@ -1,51 +1,65 @@
 import * as prompts from '@clack/prompts'
 import { isRichOutput } from '../utils/env.ts'
 
+/**
+ * Prefixes the plain writers use, the same ones `plainLogger` prints, so a command's own output
+ * and the hook output around it read as one stream.
+ */
+const SYMBOLS = { info: 'ℹ', warn: '⚠', error: '✗', step: '◇' } as const
+
+type Level = keyof typeof SYMBOLS
+
+function write(level: Level, message: string): void {
+  if (isRichOutput()) {
+    prompts.log[level](message)
+
+    return
+  }
+
+  console.log(`${SYMBOLS[level]} ${message}`)
+}
+
 type IntroOptions = {
   title: string
   /**
-   * Printed under the title, in the logger's warning style.
+   * Printed under the title, for a command that has a caveat to lead with.
    */
-  warning: string
+  warning?: string
   /**
-   * Whether to open a clack block that a later {@link logOutro} closes. Off for a command that
+   * Whether to open a block a later {@link logOutro} closes. Pass `false` for a command that
    * prints and exits, since nothing would ever close the block.
+   *
+   * @default true
    */
-  block: boolean
+  block?: boolean
 }
 
 /**
- * Opens the command's output with a title and a warning under it.
+ * Opens a command's output with its title.
  */
-export function logIntro({ title, warning, block }: IntroOptions): void {
+export function logIntro({ title, warning, block = true }: IntroOptions): void {
   if (block && isRichOutput()) {
     prompts.intro(title)
-    prompts.log.warn(warning)
+
+    if (warning) {
+      prompts.log.warn(warning)
+    }
 
     return
   }
 
   console.log(title)
-  console.warn(warning)
+
+  if (warning) {
+    console.warn(warning)
+  }
+
   console.log()
 }
 
 /**
- * Prints one block of lines: clack's gutter when the terminal can carry it, plain lines otherwise.
- */
-export function logBlock(lines: string | Array<string>): void {
-  if (isRichOutput()) {
-    prompts.log.message(lines)
-
-    return
-  }
-
-  console.log([lines].flat().join('\n'))
-}
-
-/**
- * Closes the block {@link logIntro} opened. `outro` is the closing gutter rather than a written
- * line, so plain output prints the text on its own.
+ * Closes the block {@link logIntro} opened. The closing gutter is not a written line, so plain
+ * output prints the text on its own.
  */
 export function logOutro(text: string): void {
   if (isRichOutput()) {
@@ -58,9 +72,57 @@ export function logOutro(text: string): void {
 }
 
 /**
- * A spinner, or null when the terminal cannot animate one. Callers drive it with `spinner?.start()`
- * so the same code path works either way.
+ * Prints lines as one block, without a symbol in front of them.
  */
-export function createSpinner(): ReturnType<typeof prompts.spinner> | null {
-  return isRichOutput() ? prompts.spinner() : null
+export function logBlock(lines: string | Array<string>): void {
+  if (isRichOutput()) {
+    prompts.log.message(lines)
+
+    return
+  }
+
+  console.log([lines].flat().join('\n'))
+}
+
+export function logInfo(message: string): void {
+  write('info', message)
+}
+
+export function logWarn(message: string): void {
+  write('warn', message)
+}
+
+export function logError(message: string): void {
+  write('error', message)
+}
+
+/**
+ * Reports a step the command is taking, rather than something it found.
+ */
+export function logStep(message: string): void {
+  write('step', message)
+}
+
+type Spinner = {
+  start: (message?: string) => void
+  stop: (message?: string, code?: number) => void
+  message: (message?: string) => void
+}
+
+/**
+ * A progress spinner, or a writer that prints each message it is given when the terminal cannot
+ * animate one. Callers drive both the same way.
+ */
+export function createSpinner(): Spinner {
+  if (isRichOutput()) {
+    return prompts.spinner()
+  }
+
+  const print = (message?: string) => {
+    if (message) {
+      console.log(message)
+    }
+  }
+
+  return { start: print, stop: print, message: print }
 }

--- a/packages/cli/src/runners/generate/run.ts
+++ b/packages/cli/src/runners/generate/run.ts
@@ -3,7 +3,6 @@ import { existsSync } from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
 import { styleText } from 'node:util'
-import * as clack from '@clack/prompts'
 import { toError } from '@internals/utils'
 import {
   Hookable,
@@ -24,6 +23,7 @@ import { version } from '../../../package.json'
 import { KUBB_NPM_PACKAGE_URL, UPDATE_CHECK_TIMEOUT_MS } from '../../constants.ts'
 import { buildTelemetryEvent, sendTelemetry } from '../../Telemetry.ts'
 import setupReporters, { selectReporters } from '../../loggers/utils.ts'
+import { logError, logInfo, logStep } from '../../loggers/output.ts'
 import { getConfigs, isNewerVersion, runHook, runPostGenerate, startWatcher } from './utils.ts'
 import { FORMATTER_PREFERENCE, LINTER_PREFERENCE } from '@internals/utils'
 import { detectTool, formatters, linters } from '../../tools.ts'
@@ -325,7 +325,7 @@ export async function run({ input, configPath, logLevel: logLevelKey, watch, rep
         // in its finally block, so re-running generate() on the same hooks emitter is safe.
         const build = async (paths: Array<string>) => {
           await generate({ input, config, logLevel, hooks, dryRun })
-          clack.log.step(styleText('yellow', `Watching for changes in ${paths.join(' and ')}`))
+          logStep(styleText('yellow', `Watching for changes in ${paths.join(' and ')}`))
         }
 
         // The watcher ignores chokidar's startup events, so run the first build here. A failing
@@ -336,7 +336,7 @@ export async function run({ input, configPath, logLevel: logLevelKey, watch, rep
           await hooks.callHook('kubb:error', { error: toError(buildError) })
         }
 
-        await startWatcher(watchedPaths, build, { info: (msg) => clack.log.info(msg), error: (msg) => clack.log.error(msg) })
+        await startWatcher(watchedPaths, build, { info: logInfo, error: logError })
       } else {
         try {
           const succeeded = await generate({ input, config, logLevel, hooks, dryRun })

--- a/packages/cli/src/runners/init/run.ts
+++ b/packages/cli/src/runners/init/run.ts
@@ -14,6 +14,7 @@ import {
   resolveInstallVersions,
   resolvePlugins,
 } from '@internals/shared'
+import { createSpinner, logError, logInfo, logIntro, logOutro, logWarn } from '../../loggers/output.ts'
 import { hasPackageJson, initPackageJson, installPackages } from './utils.ts'
 import { detectPackageManager } from '../../tools.ts'
 
@@ -58,7 +59,7 @@ type InitOptions = {
 export async function run({ yes, version, input: inputFlag, output: outputFlag, plugins: pluginsFlag, dryRun }: InitOptions): Promise<void> {
   const cwd = process.cwd()
 
-  clack.intro(styleText('bgCyan', styleText('black', ' Kubb Init ')))
+  logIntro({ title: styleText('bgCyan', styleText('black', ' Kubb Init ')) })
 
   /**
    * Returns `flag` when provided, the `defaultValue` when `yes` is set,
@@ -66,11 +67,11 @@ export async function run({ yes, version, input: inputFlag, output: outputFlag, 
    */
   async function resolveOrPrompt<T>(flag: T | undefined, defaultValue: T, logLabel: string, prompt: () => Promise<T | symbol>): Promise<T> {
     if (flag !== undefined) {
-      clack.log.info(`${logLabel}: ${styleText('cyan', String(flag))}`)
+      logInfo(`${logLabel}: ${styleText('cyan', String(flag))}`)
       return flag
     }
     if (yes) {
-      clack.log.info(`${logLabel}: ${styleText('cyan', String(defaultValue))}`)
+      logInfo(`${logLabel}: ${styleText('cyan', String(defaultValue))}`)
       return defaultValue
     }
     const result = await prompt()
@@ -93,7 +94,7 @@ export async function run({ yes, version, input: inputFlag, output: outputFlag, 
       }
 
       const packageManager = detectPackageManager(cwd)
-      const spinner = clack.spinner()
+      const spinner = createSpinner()
       spinner.start(`Initializing package.json with ${packageManager.name}`)
       await initPackageJson(cwd, packageManager)
       spinner.stop(`Created package.json with ${packageManager.name}`)
@@ -101,7 +102,7 @@ export async function run({ yes, version, input: inputFlag, output: outputFlag, 
 
     const packageManager = detectPackageManager(cwd)
     if (hasPackageJson(cwd)) {
-      clack.log.info(`Detected package manager: ${styleText('cyan', packageManager.name)}`)
+      logInfo(`Detected package manager: ${styleText('cyan', packageManager.name)}`)
     }
 
     // Prompt for OpenAPI spec path
@@ -136,14 +137,14 @@ export async function run({ yes, version, input: inputFlag, output: outputFlag, 
       if (pluginsFlag) {
         const plugins = resolvePlugins(pluginsFlag)
         if (plugins.length === 0) {
-          clack.log.warn(`No valid plugins found in --plugins value; falling back to default: ${pluginLabel(defaultPlugins)}`)
+          logWarn(`No valid plugins found in --plugins value; falling back to default: ${pluginLabel(defaultPlugins)}`)
           return defaultPlugins
         }
-        clack.log.info(`Using plugins: ${pluginLabel(plugins)}`)
+        logInfo(`Using plugins: ${pluginLabel(plugins)}`)
         return plugins
       }
       if (yes) {
-        clack.log.info(`Using plugins: ${pluginLabel(defaultPlugins)}`)
+        logInfo(`Using plugins: ${pluginLabel(defaultPlugins)}`)
         return defaultPlugins
       }
       const values = await clack.multiselect({
@@ -159,7 +160,7 @@ export async function run({ yes, version, input: inputFlag, output: outputFlag, 
     // Install packages, matching the release of the running CLI
     const packagesToInstall = resolveInstallVersions({ packages: [KUBB_PACKAGE_NAME, ...selectedPlugins.map((p) => p.packageName)], version })
 
-    const spinner = clack.spinner()
+    const spinner = createSpinner()
     spinner.start(`Installing ${packagesToInstall.length} packages with ${packageManager.name}`)
 
     try {
@@ -173,7 +174,7 @@ export async function run({ yes, version, input: inputFlag, output: outputFlag, 
     }
 
     // Generate config file
-    const configSpinner = clack.spinner()
+    const configSpinner = createSpinner()
     configSpinner.start(`Creating ${KUBB_CONFIG_FILENAME}`)
 
     const configContent = generateConfigFile({ selectedPlugins, inputPath, outputPath })
@@ -200,7 +201,7 @@ export async function run({ yes, version, input: inputFlag, output: outputFlag, 
 
     configSpinner.stop(`Created ${KUBB_CONFIG_FILENAME}`)
 
-    clack.outro(
+    logOutro(
       styleText('green', '✓ All set!') +
         '\n\n' +
         styleText('dim', 'Next steps:') +
@@ -214,9 +215,9 @@ export async function run({ yes, version, input: inputFlag, output: outputFlag, 
         styleText('dim', `Using ${packageManager.name} • Kubb v${version}`),
     )
   } catch (error) {
-    clack.log.error(styleText('red', 'An error occurred during initialization'))
+    logError(styleText('red', 'An error occurred during initialization'))
     if (error instanceof Error) {
-      clack.log.error(error.message)
+      logError(error.message)
     }
     process.exit(1)
   }

--- a/packages/cli/src/runners/studio/run.test.ts
+++ b/packages/cli/src/runners/studio/run.test.ts
@@ -257,6 +257,11 @@ describe('connect', () => {
       .mock.calls.map(([call]) => call)
       .find((call) => call.token === 'new-token')
     expect(written?.projects).toBeUndefined()
+
+    // The permissions were granted to the previous agent, so the new one is asked again rather
+    // than inheriting them.
+    expect(vi.mocked(createClient).mock.calls[0]?.[0]).toMatchObject({ allowWrite: true })
+    expect(vi.mocked(createClient).mock.calls[1]?.[0]).toMatchObject({ allowWrite: false })
   })
 
   it('exits cleanly instead of throwing when the user cancels pairing during a live reauth', async () => {

--- a/packages/cli/src/runners/studio/run.test.ts
+++ b/packages/cli/src/runners/studio/run.test.ts
@@ -1,20 +1,46 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as prompts from '@clack/prompts'
+import { InvalidAgentTokenError, PairingCanceledError } from '@kubb/studio'
 import type { Credentials } from './credentials.ts'
-import { formatPermissionRows, resolvePermissions, type StudioOptions } from './run.ts'
+import { connect, formatPermissionRows, resolvePermissions, type StudioOptions } from './run.ts'
 
-vi.mock('@clack/prompts', () => ({ confirm: vi.fn() }))
+vi.mock('@clack/prompts', () => ({
+  confirm: vi.fn(),
+  spinner: vi.fn(() => ({ start: vi.fn(), stop: vi.fn() })),
+  log: { message: vi.fn() },
+  intro: vi.fn(),
+  outro: vi.fn(),
+}))
 vi.mock('../../utils/env.ts', async (importOriginal) => ({
   ...(await importOriginal<typeof import('../../utils/env.ts')>()),
-  isCIEnvironment: () => false,
-  canUseTTY: () => true,
+  isCIEnvironment: vi.fn(() => false),
+  canUseTTY: vi.fn(() => true),
 }))
 vi.mock('./credentials.ts', async (importOriginal) => ({
   ...(await importOriginal<typeof import('./credentials.ts')>()),
+  readCredentials: vi.fn().mockResolvedValue(null),
   writeCredentials: vi.fn().mockResolvedValue(undefined),
+  clearCredentials: vi.fn().mockResolvedValue(undefined),
 }))
+vi.mock('../generate/utils.ts', () => ({
+  getConfigs: vi.fn().mockResolvedValue({
+    configPath: '/project/kubb.config.ts',
+    configs: [{ name: 'test', input: 'spec.yaml', output: { path: './gen' }, plugins: [] }],
+  }),
+}))
+vi.mock('@kubb/studio', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@kubb/studio')>()),
+  createClient: vi.fn(),
+  startPairing: vi.fn(),
+  pollForPairingToken: vi.fn(),
+  setStorage: vi.fn(),
+  createFileStorage: vi.fn(),
+}))
+
 const confirm = vi.mocked(prompts.confirm)
-const { writeCredentials } = await import('./credentials.ts')
+const { readCredentials, writeCredentials, clearCredentials } = await import('./credentials.ts')
+const { createClient, startPairing, pollForPairingToken } = await import('@kubb/studio')
+const { isCIEnvironment, canUseTTY } = await import('../../utils/env.ts')
 
 const options: StudioOptions = {
   action: 'connect',
@@ -29,11 +55,41 @@ const credentials: Credentials = { studioUrl: options.studioUrl, token: 'token',
 beforeEach(() => {
   confirm.mockReset()
   vi.mocked(writeCredentials).mockClear()
+  vi.mocked(readCredentials).mockReset().mockResolvedValue(null)
+  vi.mocked(clearCredentials).mockReset().mockResolvedValue(undefined)
+  vi.mocked(createClient).mockReset()
+  vi.mocked(startPairing).mockReset()
+  vi.mocked(pollForPairingToken).mockReset()
+  vi.mocked(isCIEnvironment).mockReset().mockReturnValue(false)
+  vi.mocked(canUseTTY).mockReset().mockReturnValue(true)
+  delete process.env.KUBB_AGENT_TOKEN
 })
 
 afterEach(() => {
   vi.restoreAllMocks()
 })
+
+/**
+ * A `createClient` stand-in whose `connect()` and `disconnect()` behavior each test controls, and
+ * that records the options every call was created with so a test can trigger `onAuthRequired` the
+ * way a live background rejection would.
+ */
+function mockClient(connectImpl: () => Promise<void>) {
+  const disconnect = vi.fn()
+  let onAuthRequired: ((error: InvalidAgentTokenError) => void) | undefined
+
+  vi.mocked(createClient).mockImplementationOnce((clientOptions) => {
+    onAuthRequired = clientOptions.onAuthRequired
+    return { connect: connectImpl, disconnect }
+  })
+
+  return {
+    disconnect,
+    triggerAuthRequired(error: InvalidAgentTokenError) {
+      onAuthRequired?.(error)
+    },
+  }
+}
 
 describe('resolvePermissions', () => {
   it('asks for every permission and stores the answers', async () => {
@@ -111,5 +167,157 @@ describe('formatPermissionRows', () => {
       '✔ use a Studio spec',
       '✘ run formatter, linter, postGenerate',
     ])
+  })
+})
+
+describe('connect', () => {
+  it('tells the operator to update KUBB_AGENT_TOKEN when a live rejection hits an env-sourced token, without touching stored credentials', async () => {
+    process.env.KUBB_AGENT_TOKEN = 'env-token'
+    const client = mockClient(() => Promise.resolve())
+
+    const promise = connect(options)
+    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(1))
+    client.triggerAuthRequired(new InvalidAgentTokenError(options.studioUrl))
+
+    await expect(promise).rejects.toThrow(/update KUBB_AGENT_TOKEN/)
+    expect(clearCredentials).not.toHaveBeenCalled()
+    expect(writeCredentials).not.toHaveBeenCalled()
+    expect(client.disconnect).toHaveBeenCalled()
+  })
+
+  it('tells the operator to run kubb studio login when a live rejection hits a CI run, without touching stored credentials', async () => {
+    vi.mocked(readCredentials).mockResolvedValue(credentials)
+    vi.mocked(isCIEnvironment).mockReturnValue(true)
+    const client = mockClient(() => Promise.resolve())
+
+    const promise = connect(options)
+    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(1))
+    client.triggerAuthRequired(new InvalidAgentTokenError(options.studioUrl))
+
+    await expect(promise).rejects.toThrow(/kubb studio login/)
+    expect(clearCredentials).not.toHaveBeenCalled()
+    expect(writeCredentials).not.toHaveBeenCalled()
+  })
+
+  it('reauthenticates interactively on a live rejection and carries saved permissions forward for the same agent identity', async () => {
+    vi.mocked(readCredentials).mockResolvedValue({ ...credentials, projects: { [process.cwd()]: { allowWrite: true } } })
+    vi.mocked(startPairing).mockResolvedValue({
+      device_code: 'device',
+      user_code: 'ABCD-EFGH',
+      verification_uri: 'https://studio/pair',
+      verification_uri_complete: 'https://studio/pair?user_code=ABCD-EFGH',
+      expires_in: 60,
+      interval: 1,
+    })
+    // Same agentId as the stored credential, so the reauth keeps the identity.
+    vi.mocked(pollForPairingToken).mockResolvedValue({ token: 'new-token', agent: { id: credentials.agentId, slug: 'slug', name: 'demo' } })
+
+    const first = mockClient(() => Promise.resolve())
+    mockClient(() => Promise.resolve())
+
+    const promise = connect(options)
+    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(1))
+    first.triggerAuthRequired(new InvalidAgentTokenError(options.studioUrl))
+
+    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(2))
+    // Second client is live: end the run the same way Ctrl+C would.
+    process.emit('SIGINT' as never)
+
+    await promise
+
+    expect(writeCredentials).toHaveBeenCalledWith(expect.objectContaining({ token: 'new-token', projects: { [process.cwd()]: { allowWrite: true } } }))
+  })
+
+  it('does not carry saved permissions forward when the reauthenticated agent identity differs', async () => {
+    vi.mocked(readCredentials).mockResolvedValue({ ...credentials, projects: { [process.cwd()]: { allowWrite: true } } })
+    vi.mocked(startPairing).mockResolvedValue({
+      device_code: 'device',
+      user_code: 'ABCD-EFGH',
+      verification_uri: 'https://studio/pair',
+      verification_uri_complete: 'https://studio/pair?user_code=ABCD-EFGH',
+      expires_in: 60,
+      interval: 1,
+    })
+    // A different agentId than the stored credential.
+    vi.mocked(pollForPairingToken).mockResolvedValue({ token: 'new-token', agent: { id: 'a-different-agent', slug: 'slug', name: 'demo' } })
+
+    const first = mockClient(() => Promise.resolve())
+    mockClient(() => Promise.resolve())
+
+    const promise = connect(options)
+    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(1))
+    first.triggerAuthRequired(new InvalidAgentTokenError(options.studioUrl))
+
+    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(2))
+    process.emit('SIGINT' as never)
+
+    await promise
+
+    const written = vi
+      .mocked(writeCredentials)
+      .mock.calls.map(([call]) => call)
+      .find((call) => call.token === 'new-token')
+    expect(written?.projects).toBeUndefined()
+  })
+
+  it('exits cleanly instead of throwing when the user cancels pairing during a live reauth', async () => {
+    vi.mocked(readCredentials).mockResolvedValue(credentials)
+    vi.mocked(startPairing).mockImplementation(
+      ({ signal }) =>
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener('abort', () => reject(new PairingCanceledError()))
+        }),
+    )
+
+    const client = mockClient(() => Promise.resolve())
+
+    const promise = connect(options)
+    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(1))
+    client.triggerAuthRequired(new InvalidAgentTokenError(options.studioUrl))
+
+    await vi.waitFor(() => expect(startPairing).toHaveBeenCalledTimes(1))
+    process.emit('SIGINT' as never)
+
+    await expect(promise).resolves.toBeUndefined()
+    // Only one client was ever created: cancellation during the reauth stops before a new one connects.
+    expect(createClient).toHaveBeenCalledTimes(1)
+  })
+
+  it('stops after one automatic reauth instead of pairing forever when the newly approved token is rejected again', async () => {
+    vi.mocked(readCredentials).mockResolvedValue(credentials)
+    vi.mocked(startPairing).mockResolvedValue({
+      device_code: 'device',
+      user_code: 'ABCD-EFGH',
+      verification_uri: 'https://studio/pair',
+      verification_uri_complete: 'https://studio/pair?user_code=ABCD-EFGH',
+      expires_in: 60,
+      interval: 1,
+    })
+    vi.mocked(pollForPairingToken).mockResolvedValue({ token: 'new-token', agent: { id: credentials.agentId, slug: 'slug', name: 'demo' } })
+
+    const first = mockClient(() => Promise.resolve())
+    const second = mockClient(() => Promise.resolve())
+
+    const promise = connect(options)
+    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(1))
+    first.triggerAuthRequired(new InvalidAgentTokenError(options.studioUrl))
+
+    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(2))
+    // The freshly approved token is rejected again immediately.
+    second.triggerAuthRequired(new InvalidAgentTokenError(options.studioUrl))
+
+    await expect(promise).rejects.toThrow(/rejected the newly approved token/)
+    // No third client: one automatic reauth is all this ever attempts.
+    expect(createClient).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps retrying an ordinary network failure without reauthenticating, since only an InvalidAgentTokenError triggers pairing', async () => {
+    vi.mocked(readCredentials).mockResolvedValue(credentials)
+    // A plain connection failure at startup is not InvalidAgentTokenError, so it should surface as-is.
+    mockClient(() => Promise.reject(new Error('ECONNREFUSED')))
+
+    await expect(connect(options)).rejects.toThrow('ECONNREFUSED')
+    expect(startPairing).not.toHaveBeenCalled()
+    expect(clearCredentials).not.toHaveBeenCalled()
   })
 })

--- a/packages/cli/src/runners/studio/run.test.ts
+++ b/packages/cli/src/runners/studio/run.test.ts
@@ -91,6 +91,22 @@ function mockClient(connectImpl: () => Promise<void>) {
   }
 }
 
+/**
+ * Mocks a browser pairing the user approves. `agentId` is what decides whether the reauthenticated
+ * agent keeps the stored credential's identity, and so its saved project permissions.
+ */
+function mockPairing(agentId: string = credentials.agentId) {
+  vi.mocked(startPairing).mockResolvedValue({
+    device_code: 'device',
+    user_code: 'ABCD-EFGH',
+    verification_uri: 'https://studio/pair',
+    verification_uri_complete: 'https://studio/pair?user_code=ABCD-EFGH',
+    expires_in: 60,
+    interval: 1,
+  })
+  vi.mocked(pollForPairingToken).mockResolvedValue({ token: 'new-token', agent: { id: agentId, slug: 'slug', name: 'demo' } })
+}
+
 describe('resolvePermissions', () => {
   it('asks for every permission and stores the answers', async () => {
     confirm.mockResolvedValueOnce(true).mockResolvedValueOnce(false).mockResolvedValueOnce(false).mockResolvedValueOnce(true)
@@ -201,16 +217,8 @@ describe('connect', () => {
 
   it('reauthenticates interactively on a live rejection and carries saved permissions forward for the same agent identity', async () => {
     vi.mocked(readCredentials).mockResolvedValue({ ...credentials, projects: { [process.cwd()]: { allowWrite: true } } })
-    vi.mocked(startPairing).mockResolvedValue({
-      device_code: 'device',
-      user_code: 'ABCD-EFGH',
-      verification_uri: 'https://studio/pair',
-      verification_uri_complete: 'https://studio/pair?user_code=ABCD-EFGH',
-      expires_in: 60,
-      interval: 1,
-    })
-    // Same agentId as the stored credential, so the reauth keeps the identity.
-    vi.mocked(pollForPairingToken).mockResolvedValue({ token: 'new-token', agent: { id: credentials.agentId, slug: 'slug', name: 'demo' } })
+    // The same agentId as the stored credential, so the reauth keeps the identity.
+    mockPairing()
 
     const first = mockClient(() => Promise.resolve())
     mockClient(() => Promise.resolve())
@@ -230,16 +238,7 @@ describe('connect', () => {
 
   it('does not carry saved permissions forward when the reauthenticated agent identity differs', async () => {
     vi.mocked(readCredentials).mockResolvedValue({ ...credentials, projects: { [process.cwd()]: { allowWrite: true } } })
-    vi.mocked(startPairing).mockResolvedValue({
-      device_code: 'device',
-      user_code: 'ABCD-EFGH',
-      verification_uri: 'https://studio/pair',
-      verification_uri_complete: 'https://studio/pair?user_code=ABCD-EFGH',
-      expires_in: 60,
-      interval: 1,
-    })
-    // A different agentId than the stored credential.
-    vi.mocked(pollForPairingToken).mockResolvedValue({ token: 'new-token', agent: { id: 'a-different-agent', slug: 'slug', name: 'demo' } })
+    mockPairing('a-different-agent')
 
     const first = mockClient(() => Promise.resolve())
     mockClient(() => Promise.resolve())
@@ -285,15 +284,7 @@ describe('connect', () => {
 
   it('stops after one automatic reauth instead of pairing forever when the newly approved token is rejected again', async () => {
     vi.mocked(readCredentials).mockResolvedValue(credentials)
-    vi.mocked(startPairing).mockResolvedValue({
-      device_code: 'device',
-      user_code: 'ABCD-EFGH',
-      verification_uri: 'https://studio/pair',
-      verification_uri_complete: 'https://studio/pair?user_code=ABCD-EFGH',
-      expires_in: 60,
-      interval: 1,
-    })
-    vi.mocked(pollForPairingToken).mockResolvedValue({ token: 'new-token', agent: { id: credentials.agentId, slug: 'slug', name: 'demo' } })
+    mockPairing()
 
     const first = mockClient(() => Promise.resolve())
     const second = mockClient(() => Promise.resolve())

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -235,7 +235,7 @@ async function loadConfigs(options: StudioOptions): Promise<{ configPath: string
  * browser is available to re-pair with, or the token this run already re-paired for was rejected
  * again.
  */
-type RejectedTokenReason = 'envToken' | 'nonInteractive' | 'exhausted'
+type RejectedTokenReason = 'envToken' | 'nonInteractive' | 'reauthExhausted'
 
 /**
  * Explains a rejected token to the operator. Never touches stored or environment credentials
@@ -246,7 +246,7 @@ function explainRejectedToken(error: InvalidAgentTokenError, reason: RejectedTok
     return new Error(`${error.message} Pair again and update KUBB_AGENT_TOKEN.`)
   }
 
-  if (reason === 'exhausted') {
+  if (reason === 'reauthExhausted') {
     return new Error(`${error.message} Studio rejected the newly approved token too. Run \`kubb studio login\` and try again.`)
   }
 
@@ -401,7 +401,7 @@ export async function connect(options: StudioOptions): Promise<void> {
         await clearCredentials()
 
         if (state.hasReauthenticated) {
-          throw explainRejectedToken(error, 'exhausted')
+          throw explainRejectedToken(error, 'reauthExhausted')
         }
 
         if (isCIEnvironment() || !canUseTTY()) {
@@ -453,7 +453,7 @@ export async function connect(options: StudioOptions): Promise<void> {
       }
 
       if (state.hasReauthenticated) {
-        throw explainRejectedToken(error, 'exhausted')
+        throw explainRejectedToken(error, 'reauthExhausted')
       }
 
       if (isCIEnvironment() || !canUseTTY()) {

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -7,7 +7,16 @@ import { KUBB_CONFIG_FILENAME } from '@internals/shared'
 import { toError } from '@internals/utils'
 import type { CLIOptions, Config } from '@kubb/core'
 import { cliReporter, logLevel as logLevelMap } from '@kubb/core'
-import { createFileStorage, createClient, defaultStudioUrl, InvalidAgentTokenError, pollForPairingToken, setStorage, startPairing } from '@kubb/studio'
+import {
+  createFileStorage,
+  createClient,
+  defaultStudioUrl,
+  InvalidAgentTokenError,
+  PairingCanceledError,
+  pollForPairingToken,
+  setStorage,
+  startPairing,
+} from '@kubb/studio'
 import { x } from 'tinyexec'
 import type { CommandRunner } from 'gunshi'
 import { buildTelemetryEvent, sendTelemetry } from '../../Telemetry.ts'
@@ -65,6 +74,21 @@ async function openInBrowser(url: string): Promise<void> {
   } catch {}
 }
 
+type LoginOptions = {
+  /**
+   * Aborting this cancels an in-flight pairing request or poll and rejects with
+   * {@link PairingCanceledError}. Wired to `kubb studio`'s shutdown signal, so Ctrl+C during
+   * pairing cancels it instead of leaving the poll running.
+   */
+  signal?: AbortSignal
+  /**
+   * Credentials from before this login. When the fresh pairing resolves to the same agent on the
+   * same Studio, its saved project permissions carry forward instead of being asked again.
+   * Left out for an explicitly requested `kubb studio login`, which always starts clean.
+   */
+  previousCredentials?: Credentials | null
+}
+
 /**
  * Pairs this machine with Studio and stores the resulting token.
  *
@@ -72,8 +96,8 @@ async function openInBrowser(url: string): Promise<void> {
  * the UI. The token comes back over the CLI's own HTTPS POST, so it never lands in a URL, a
  * server log, or a `Referer` header.
  */
-async function login({ studioUrl, autoOpen }: StudioOptions): Promise<Credentials> {
-  const session = await startPairing({ studioUrl, name: path.basename(process.cwd()), hostname: hostname() })
+async function login({ studioUrl, autoOpen }: StudioOptions, { signal, previousCredentials }: LoginOptions = {}): Promise<Credentials> {
+  const session = await startPairing({ studioUrl, name: path.basename(process.cwd()), hostname: hostname(), signal })
 
   console.log(`\nOpen ${styleText('cyan', session.verification_uri)} and approve the code ${styleText('bold', session.user_code)}`)
 
@@ -85,17 +109,24 @@ async function login({ studioUrl, autoOpen }: StudioOptions): Promise<Credential
   spinner?.start('Waiting for approval')
 
   try {
-    const { token, agent } = await pollForPairingToken({ studioUrl, session })
+    const { token, agent } = await pollForPairingToken({ studioUrl, session, signal })
     spinner?.stop(`Paired as ${agent.name}`)
 
-    const credentials: Credentials = { studioUrl, token, agentId: agent.id, agentSlug: agent.slug }
+    const keepsIdentity = previousCredentials?.studioUrl === studioUrl && previousCredentials.agentId === agent.id
+    const credentials: Credentials = {
+      studioUrl,
+      token,
+      agentId: agent.id,
+      agentSlug: agent.slug,
+      ...(keepsIdentity && previousCredentials?.projects ? { projects: previousCredentials.projects } : {}),
+    }
     await writeCredentials(credentials)
 
     console.log(`Credentials stored in ${getCredentialsPath()}`)
 
     return credentials
   } catch (error) {
-    spinner?.stop('Pairing failed')
+    spinner?.stop(error instanceof PairingCanceledError ? 'Pairing canceled' : 'Pairing failed')
     throw error
   }
 }
@@ -200,131 +231,278 @@ async function loadConfigs(options: StudioOptions): Promise<{ configPath: string
 }
 
 /**
- * Connects this project to Studio and streams generation events until the process is stopped.
+ * Why a rejected token could not be recovered automatically, so {@link explainRejectedToken} can
+ * pick the one instruction that actually applies.
  */
-async function connect(options: StudioOptions, retryPairing = true): Promise<void> {
+type RejectedTokenReason =
+  /**
+   * The dead token came from `KUBB_AGENT_TOKEN`. Never overwritten or replaced automatically: an
+   * operator-managed credential stays the operator's to manage.
+   */
+  | 'envToken'
+  /**
+   * CI or no TTY: there is no browser to approve a pairing code in.
+   */
+  | 'nonInteractive'
+  /**
+   * A token this run already re-paired for was rejected again, so another automatic attempt would
+   * just repeat the same failure.
+   */
+  | 'exhausted'
+
+/**
+ * Explains a rejected token to the operator and says what to do about it. Never touches stored or
+ * environment credentials itself, since a message-only path must not have side effects the caller
+ * did not ask for.
+ */
+function explainRejectedToken(error: InvalidAgentTokenError, reason: RejectedTokenReason): Error {
+  if (reason === 'envToken') {
+    return new Error(`${error.message} Pair again and update KUBB_AGENT_TOKEN.`)
+  }
+
+  if (reason === 'exhausted') {
+    return new Error(`${error.message} Studio rejected the newly approved token too. Run \`kubb studio login\` and try again.`)
+  }
+
+  return new Error(`${error.message} Run \`kubb studio login\` to pair again.`)
+}
+
+/**
+ * Connects this project to Studio and streams generation events until the process is stopped or
+ * Studio rejects the token.
+ *
+ * One `AbortController` covers the whole call: it cancels an in-flight pairing poll on Ctrl+C, and
+ * lets a live token rejection win a race against shutdown instead of waiting for the next signal.
+ * It is armed once and torn down in `finally`, so retrying pairing in the loop below never leaves
+ * behind a duplicate `SIGINT`/`SIGTERM` listener.
+ */
+export async function connect(options: StudioOptions): Promise<void> {
   // Resolved before any network call to Studio (pairing included), so a project with no config
   // fails fast instead of starting a device-authorization flow it can never use.
   const { configPath } = await loadConfigs(options)
 
-  const envToken = process.env.KUBB_AGENT_TOKEN
-  const stored = envToken ? null : await readCredentials()
-
-  const credentials: Credentials = await (async () => {
-    // A credential is only reused for the Studio it was issued by, so switching `--url` re-pairs
-    // instead of sending one instance's token to another.
-    const resolved = envToken
-      ? { studioUrl: options.studioUrl, token: envToken, agentId: '', agentSlug: '' }
-      : stored?.studioUrl === options.studioUrl
-        ? stored
-        : null
-
-    if (resolved) {
-      return resolved
-    }
-
-    if (isCIEnvironment()) {
-      throw new Error(`Not paired with ${options.studioUrl}. Set KUBB_AGENT_TOKEN, or run \`kubb studio login\` on a machine with a browser.`)
-    }
-
-    return login(options)
-  })()
-  const { allowWrite, allowConfigEdit, allowInput, allowExec } = await resolvePermissions(options, credentials, configPath, !envToken)
-  const granted = { allowWrite, allowConfigEdit, allowInput, allowExec }
+  const shutdown = new AbortController()
+  const requestShutdown = () => shutdown.abort()
+  // `bun-types` narrows `process.on`/`process.off` to its own event union, which omits Node's
+  // process signal events, so the listener is installed and removed through the plain emitter API.
+  const processEvents = process as unknown as NodeJS.EventEmitter
+  processEvents.once('SIGINT', requestShutdown)
+  processEvents.once('SIGTERM', requestShutdown)
 
   const logLevel = logLevelMap[options.logLevel ?? 'info']
   const isRich = isRichOutput()
   // One clack gutter block, or the same lines plainly.
   const say = (lines: string | Array<string>) => (isRich ? prompts.log.message(lines) : console.log([lines].flat().join('\n')))
-  const detail = (label: string, value: string) => `${styleText('dim', label.padEnd(7))}  ${value}`
-  let hinted = false
-
-  if (options.logLevel !== 'silent') {
-    say([
-      detail('Studio', styleText('cyan', options.studioUrl)),
-      detail('Project', path.basename(process.cwd())),
-      detail('Config', path.relative(process.cwd(), configPath) || configPath),
-      '',
-      styleText('dim', 'Permissions'),
-      ...formatPermissionRows(granted),
-    ])
+  const reportDisconnected = () => {
+    if (options.logLevel === 'silent') {
+      return
+    }
+    // `outro` closes the block `intro` opened, so it is not a written line.
+    if (isRich) {
+      prompts.outro('Disconnected')
+    } else {
+      console.log('Disconnected')
+    }
   }
-
-  const client = createClient({
-    token: credentials.token,
-    studioUrl: options.studioUrl,
-    configPath,
-    version: options.version,
-    // Reloaded on every generate, so an edit to kubb.config.ts is picked up without reconnecting.
-    loadConfig: async () => (await loadConfigs(options)).config,
-    client: { kind: 'cli' },
-    root: process.cwd(),
-    allowWrite,
-    allowConfigEdit,
-    allowInput,
-    allowExec,
-    // The loggers `kubb generate` installs, on both emitters, so one place renders the session
-    // events and the generations it drives.
-    installLogger: async (hooks) => {
-      await setupReporters(hooks, { logLevel, reporters: [cliReporter] })
-
-      // `client.connect()` resolves once the agent is registered, not once a session is open, so
-      // this is the only point that knows the connection is live. Registered after the loggers so
-      // it lands under their "Connected to ..." line, and once, since every reconnect fires again.
-      hooks.hook('studio:connected', () => {
-        if (hinted || options.logLevel === 'silent') {
-          return
-        }
-        hinted = true
-
-        say(styleText('dim', 'Press Ctrl+C to disconnect'))
-      })
-    },
-  })
 
   try {
-    await client.connect()
-  } catch (error) {
-    if (!(error instanceof InvalidAgentTokenError)) {
-      throw error
-    }
+    const envToken = process.env.KUBB_AGENT_TOKEN
+    const stored = envToken ? null : await readCredentials()
 
-    // The token is dead: the agent was deleted in Studio, or the token was revoked. Keeping it
-    // only produces 401s on every run, so forget it and pair again.
-    if (envToken) {
-      throw new Error(`${error.message} Pair again and update KUBB_AGENT_TOKEN.`)
-    }
+    let credentials: Credentials = await (async () => {
+      // A credential is only reused for the Studio it was issued by, so switching `--url` re-pairs
+      // instead of sending one instance's token to another.
+      const resolved = envToken
+        ? { studioUrl: options.studioUrl, token: envToken, agentId: '', agentSlug: '' }
+        : stored?.studioUrl === options.studioUrl
+          ? stored
+          : null
 
-    await clearCredentials()
-
-    if (isCIEnvironment() || !retryPairing) {
-      throw new Error(`${error.message} Run \`kubb studio login\` to pair again.`)
-    }
-
-    console.log(styleText('yellow', `${error.message} Pairing again...`))
-
-    return connect(options, false)
-  }
-
-  await new Promise<void>((resolve) => {
-    const stop = () => {
-      client.disconnect()
-
-      if (options.logLevel !== 'silent') {
-        // `outro` closes the block `intro` opened, so it is not a written line.
-        if (isRich) {
-          prompts.outro('Disconnected')
-        } else {
-          console.log('Disconnected')
-        }
+      if (resolved) {
+        return resolved
       }
 
-      resolve()
+      if (isCIEnvironment()) {
+        throw new Error(`Not paired with ${options.studioUrl}. Set KUBB_AGENT_TOKEN, or run \`kubb studio login\` on a machine with a browser.`)
+      }
+
+      return login(options, { signal: shutdown.signal })
+    })()
+
+    // `envToken` itself never changes, but once a browser login has replaced the credentials, later
+    // rejections are no longer about the environment variable and need the paired-again message.
+    let usingEnvToken = !!envToken
+
+    const { allowWrite, allowConfigEdit, allowInput, allowExec } = await resolvePermissions(options, credentials, configPath, !usingEnvToken)
+    const granted = { allowWrite, allowConfigEdit, allowInput, allowExec }
+
+    const detail = (label: string, value: string) => `${styleText('dim', label.padEnd(7))}  ${value}`
+    let hinted = false
+
+    if (options.logLevel !== 'silent') {
+      say([
+        detail('Studio', styleText('cyan', options.studioUrl)),
+        detail('Project', path.basename(process.cwd())),
+        detail('Config', path.relative(process.cwd(), configPath) || configPath),
+        '',
+        styleText('dim', 'Permissions'),
+        ...formatPermissionRows(granted),
+      ])
     }
 
-    process.once('SIGINT', stop)
-    process.once('SIGTERM', stop)
-  })
+    // A rejection right after a fresh login means the newly approved token was no good either, so
+    // one automatic re-pair is all this ever attempts, whether the rejection lands at startup or
+    // once the session is already live. A second one is treated as a hard failure instead of
+    // pairing forever.
+    let hasReauthenticated = false
+
+    for (;;) {
+      let notifyAuthRequired: (error: InvalidAgentTokenError) => void = () => {}
+      const authRequired = new Promise<InvalidAgentTokenError>((resolve) => {
+        notifyAuthRequired = resolve
+      })
+
+      const client = createClient({
+        token: credentials.token,
+        studioUrl: options.studioUrl,
+        configPath,
+        version: options.version,
+        // Reloaded on every generate, so an edit to kubb.config.ts is picked up without reconnecting.
+        loadConfig: async () => (await loadConfigs(options)).config,
+        client: { kind: 'cli' },
+        root: process.cwd(),
+        ...granted,
+        // Fires once the pool is already stopped, only for a token rejected during background
+        // reconnect. A startup rejection is handled below through `client.connect()` itself.
+        onAuthRequired: notifyAuthRequired,
+        // The loggers `kubb generate` installs, on both emitters, so one place renders the session
+        // events and the generations it drives.
+        installLogger: async (hooks) => {
+          await setupReporters(hooks, { logLevel, reporters: [cliReporter] })
+
+          // `client.connect()` resolves once the agent is registered, not once a session is open, so
+          // this is the only point that knows the connection is live. Registered after the loggers so
+          // it lands under their "Connected to ..." line, and once, since every reconnect fires again.
+          hooks.hook('studio:connected', () => {
+            if (hinted || options.logLevel === 'silent') {
+              return
+            }
+            hinted = true
+
+            say(styleText('dim', 'Press Ctrl+C to disconnect'))
+          })
+        },
+      })
+
+      try {
+        await client.connect()
+      } catch (error) {
+        if (!(error instanceof InvalidAgentTokenError)) {
+          throw error
+        }
+
+        client.disconnect()
+
+        // The token is dead: the agent was deleted in Studio, or the token was revoked. Keeping it
+        // only produces 401s on every run, so forget it and pair again.
+        if (usingEnvToken) {
+          throw explainRejectedToken(error, 'envToken')
+        }
+
+        await clearCredentials()
+
+        if (hasReauthenticated) {
+          throw explainRejectedToken(error, 'exhausted')
+        }
+
+        if (isCIEnvironment() || !canUseTTY()) {
+          throw explainRejectedToken(error, 'nonInteractive')
+        }
+
+        console.log(styleText('yellow', `${error.message} Pairing again...`))
+
+        try {
+          credentials = await login(options, { signal: shutdown.signal, previousCredentials: credentials })
+        } catch (loginError) {
+          if (loginError instanceof PairingCanceledError) {
+            return
+          }
+          throw loginError
+        }
+
+        usingEnvToken = false
+        hasReauthenticated = true
+
+        continue
+      }
+
+      // Connected. Whichever comes first wins: a shutdown signal, or Studio rejecting the token
+      // while reconnecting in the background, well after this session was already live.
+      const shutdownWait = new Promise<{ kind: 'shutdown' }>((resolve) => {
+        if (shutdown.signal.aborted) {
+          resolve({ kind: 'shutdown' })
+          return
+        }
+        shutdown.signal.addEventListener('abort', () => resolve({ kind: 'shutdown' }), { once: true })
+      })
+      const authRequiredWait = authRequired.then((error) => ({ kind: 'authRequired' as const, error }))
+
+      const outcome = await Promise.race([shutdownWait, authRequiredWait])
+
+      client.disconnect()
+
+      if (outcome.kind === 'shutdown') {
+        reportDisconnected()
+
+        return
+      }
+
+      const { error } = outcome
+
+      if (usingEnvToken) {
+        throw explainRejectedToken(error, 'envToken')
+      }
+
+      if (hasReauthenticated) {
+        throw explainRejectedToken(error, 'exhausted')
+      }
+
+      if (isCIEnvironment() || !canUseTTY()) {
+        throw explainRejectedToken(error, 'nonInteractive')
+      }
+
+      console.log(styleText('yellow', `${error.message} Studio needs you to approve access again.`))
+
+      // Forget the dead token before pairing again, the same as a rejection at startup: `login`
+      // overwrites the file regardless, but a failed re-pair should not leave a rejected token
+      // behind for the next run to try again.
+      await clearCredentials()
+
+      try {
+        credentials = await login(options, { signal: shutdown.signal, previousCredentials: credentials })
+      } catch (loginError) {
+        if (loginError instanceof PairingCanceledError) {
+          reportDisconnected()
+
+          return
+        }
+        throw loginError
+      }
+
+      hasReauthenticated = true
+    }
+  } catch (error) {
+    // Canceling the very first pairing (before anything was ever connected) is Ctrl+C working as
+    // intended, not a failure to report.
+    if (error instanceof PairingCanceledError) {
+      return
+    }
+
+    throw error
+  } finally {
+    processEvents.off('SIGINT', requestShutdown)
+    processEvents.off('SIGTERM', requestShutdown)
+  }
 }
 
 /**

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -452,16 +452,25 @@ class StudioConnection {
       return this.#handleStartupRejection(error)
     }
 
+    // `{ once: true }` only removes the listener once the abort event fires, not once this race is
+    // settled by the other side, so a token rejection that gets reauthenticated would otherwise
+    // leave one behind on `#shutdown.signal` for every reconnect the run makes.
+    let onAbort: (() => void) | undefined
     const shutdownWait = new Promise<{ kind: 'shutdown' }>((resolve) => {
       if (this.#shutdown.signal.aborted) {
         resolve({ kind: 'shutdown' })
         return
       }
-      this.#shutdown.signal.addEventListener('abort', () => resolve({ kind: 'shutdown' }), { once: true })
+      onAbort = () => resolve({ kind: 'shutdown' })
+      this.#shutdown.signal.addEventListener('abort', onAbort, { once: true })
     })
     const authRequiredWait = authRequired.then((error) => ({ kind: 'authRequired' as const, error }))
 
     const outcome = await Promise.race([shutdownWait, authRequiredWait])
+
+    if (onAbort) {
+      this.#shutdown.signal.removeEventListener('abort', onAbort)
+    }
 
     client.disconnect()
 

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -23,7 +23,8 @@ import { buildTelemetryEvent, sendTelemetry } from '../../Telemetry.ts'
 import { version } from '../../../package.json'
 import type { definition } from '../../commands/studio.ts'
 import setupReporters from '../../loggers/utils.ts'
-import { canUseTTY, isCIEnvironment, isRichOutput } from '../../utils/env.ts'
+import { createSpinner, logBlock, logIntro, logOutro } from '../../loggers/output.ts'
+import { canUseTTY, isCIEnvironment } from '../../utils/env.ts'
 import { getConfigs } from '../generate/utils.ts'
 import { clearCredentials, type Credentials, getCredentialsPath, getKubbHome, readCredentials, writeCredentials } from './credentials.ts'
 
@@ -105,7 +106,7 @@ async function login({ studioUrl, autoOpen }: StudioOptions, { signal, previousC
     await openInBrowser(session.verification_uri_complete)
   }
 
-  const spinner = isRichOutput() ? prompts.spinner() : null
+  const spinner = createSpinner()
   spinner?.start('Waiting for approval')
 
   try {
@@ -282,25 +283,12 @@ class StudioConnection {
     this.#configPath = configPath
   }
 
-  // One clack gutter block, or the same lines plainly.
-  #log(lines: string | Array<string>): void {
-    if (isRichOutput()) {
-      prompts.log.message(lines)
-    } else {
-      console.log([lines].flat().join('\n'))
-    }
-  }
-
   #reportDisconnected(): void {
     if (this.#options.logLevel === 'silent') {
       return
     }
-    // `outro` closes the block `intro` opened, so it is not a written line.
-    if (isRichOutput()) {
-      prompts.outro('Disconnected')
-    } else {
-      console.log('Disconnected')
-    }
+
+    logOutro('Disconnected')
   }
 
   /**
@@ -369,7 +357,7 @@ class StudioConnection {
 
     const detail = (label: string, value: string) => `${styleText('dim', label.padEnd(7))}  ${value}`
 
-    this.#log([
+    logBlock([
       detail('Studio', styleText('cyan', this.#options.studioUrl)),
       detail('Project', path.basename(process.cwd())),
       detail('Config', path.relative(process.cwd(), this.#configPath) || this.#configPath),
@@ -423,7 +411,7 @@ class StudioConnection {
           }
           this.#hinted = true
 
-          this.#log(styleText('dim', 'Press Ctrl+C to disconnect'))
+          logBlock(styleText('dim', 'Press Ctrl+C to disconnect'))
         })
       },
     })
@@ -620,17 +608,12 @@ async function run(options: StudioOptions): Promise<void> {
 
   try {
     if (options.logLevel !== 'silent') {
-      const banner = `Kubb Studio  ${styleText('dim', `v${options.version}`)}`
-      const caution = styleText('yellow', 'This feature is still under development, use with caution')
-
-      if (isRichOutput() && options.action === 'connect') {
-        prompts.intro(banner)
-        prompts.log.warn(caution)
-      } else {
-        console.log(banner)
-        console.warn(caution)
-        console.log()
-      }
+      logIntro({
+        title: `Kubb Studio  ${styleText('dim', `v${options.version}`)}`,
+        warning: styleText('yellow', 'This feature is still under development, use with caution'),
+        // Only `connect` stays open long enough to close the block again with `logOutro`.
+        block: options.action === 'connect',
+      })
     }
 
     switch (options.action) {

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -309,7 +309,7 @@ export async function connect(options: StudioOptions): Promise<void> {
     const envToken = process.env.KUBB_AGENT_TOKEN
     const stored = envToken ? null : await readCredentials()
 
-    let credentials: Credentials = await (async () => {
+    const initialCredentials: Credentials = await (async () => {
       // A credential is only reused for the Studio it was issued by, so switching `--url` re-pairs
       // instead of sending one instance's token to another.
       const resolved = envToken
@@ -329,15 +329,25 @@ export async function connect(options: StudioOptions): Promise<void> {
       return login(options, { signal: shutdown.signal })
     })()
 
-    // `envToken` itself never changes, but once a browser login has replaced the credentials, later
-    // rejections are no longer about the environment variable and need the paired-again message.
-    let usingEnvToken = !!envToken
+    // Everything the reconnect loop below mutates, on one object instead of separate `let`s: state.
+    const state = {
+      credentials: initialCredentials,
+      // `envToken` itself never changes, but once a browser login has replaced the credentials,
+      // later rejections are no longer about the environment variable and need the paired-again message.
+      usingEnvToken: !!envToken,
+      // Whether the "Press Ctrl+C" hint already printed, so a reconnect never repeats it.
+      hinted: false,
+      // A rejection right after a fresh login means the newly approved token was no good either, so
+      // one automatic re-pair is all this ever attempts, whether the rejection lands at startup or
+      // once the session is already live. A second one is treated as a hard failure instead of
+      // pairing forever.
+      hasReauthenticated: false,
+    }
 
-    const { allowWrite, allowConfigEdit, allowInput, allowExec } = await resolvePermissions(options, credentials, configPath, !usingEnvToken)
+    const { allowWrite, allowConfigEdit, allowInput, allowExec } = await resolvePermissions(options, state.credentials, configPath, !state.usingEnvToken)
     const granted = { allowWrite, allowConfigEdit, allowInput, allowExec }
 
     const detail = (label: string, value: string) => `${styleText('dim', label.padEnd(7))}  ${value}`
-    let hinted = false
 
     if (options.logLevel !== 'silent') {
       say([
@@ -350,20 +360,14 @@ export async function connect(options: StudioOptions): Promise<void> {
       ])
     }
 
-    // A rejection right after a fresh login means the newly approved token was no good either, so
-    // one automatic re-pair is all this ever attempts, whether the rejection lands at startup or
-    // once the session is already live. A second one is treated as a hard failure instead of
-    // pairing forever.
-    let hasReauthenticated = false
-
-    for (;;) {
+    while (true) {
       let notifyAuthRequired: (error: InvalidAgentTokenError) => void = () => {}
       const authRequired = new Promise<InvalidAgentTokenError>((resolve) => {
         notifyAuthRequired = resolve
       })
 
       const client = createClient({
-        token: credentials.token,
+        token: state.credentials.token,
         studioUrl: options.studioUrl,
         configPath,
         version: options.version,
@@ -384,10 +388,10 @@ export async function connect(options: StudioOptions): Promise<void> {
           // this is the only point that knows the connection is live. Registered after the loggers so
           // it lands under their "Connected to ..." line, and once, since every reconnect fires again.
           hooks.hook('studio:connected', () => {
-            if (hinted || options.logLevel === 'silent') {
+            if (state.hinted || options.logLevel === 'silent') {
               return
             }
-            hinted = true
+            state.hinted = true
 
             say(styleText('dim', 'Press Ctrl+C to disconnect'))
           })
@@ -405,13 +409,13 @@ export async function connect(options: StudioOptions): Promise<void> {
 
         // The token is dead: the agent was deleted in Studio, or the token was revoked. Keeping it
         // only produces 401s on every run, so forget it and pair again.
-        if (usingEnvToken) {
+        if (state.usingEnvToken) {
           throw explainRejectedToken(error, 'envToken')
         }
 
         await clearCredentials()
 
-        if (hasReauthenticated) {
+        if (state.hasReauthenticated) {
           throw explainRejectedToken(error, 'exhausted')
         }
 
@@ -422,7 +426,7 @@ export async function connect(options: StudioOptions): Promise<void> {
         console.log(styleText('yellow', `${error.message} Pairing again...`))
 
         try {
-          credentials = await login(options, { signal: shutdown.signal, previousCredentials: credentials })
+          state.credentials = await login(options, { signal: shutdown.signal, previousCredentials: state.credentials })
         } catch (loginError) {
           if (loginError instanceof PairingCanceledError) {
             return
@@ -430,8 +434,8 @@ export async function connect(options: StudioOptions): Promise<void> {
           throw loginError
         }
 
-        usingEnvToken = false
-        hasReauthenticated = true
+        state.usingEnvToken = false
+        state.hasReauthenticated = true
 
         continue
       }
@@ -459,11 +463,11 @@ export async function connect(options: StudioOptions): Promise<void> {
 
       const { error } = outcome
 
-      if (usingEnvToken) {
+      if (state.usingEnvToken) {
         throw explainRejectedToken(error, 'envToken')
       }
 
-      if (hasReauthenticated) {
+      if (state.hasReauthenticated) {
         throw explainRejectedToken(error, 'exhausted')
       }
 
@@ -479,7 +483,7 @@ export async function connect(options: StudioOptions): Promise<void> {
       await clearCredentials()
 
       try {
-        credentials = await login(options, { signal: shutdown.signal, previousCredentials: credentials })
+        state.credentials = await login(options, { signal: shutdown.signal, previousCredentials: state.credentials })
       } catch (loginError) {
         if (loginError instanceof PairingCanceledError) {
           reportDisconnected()
@@ -489,7 +493,7 @@ export async function connect(options: StudioOptions): Promise<void> {
         throw loginError
       }
 
-      hasReauthenticated = true
+      state.hasReauthenticated = true
     }
   } catch (error) {
     // Canceling the very first pairing (before anything was ever connected) is Ctrl+C working as

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -254,244 +254,319 @@ function explainRejectedToken(error: InvalidAgentTokenError, reason: RejectedTok
 }
 
 /**
- * Connects this project to Studio and streams generation events until the process is stopped or
- * Studio rejects the token.
- *
- * One `AbortController` covers the whole call: it cancels an in-flight pairing poll on Ctrl+C and
- * lets a live token rejection race a shutdown signal, armed once and torn down in `finally` so a
- * retried pairing never leaves behind a duplicate `SIGINT`/`SIGTERM` listener.
+ * One `kubb studio` connect run: pairing if needed, connecting, and reconnecting with a fresh
+ * pairing whenever Studio rejects the token. `connect()` is the module's only entry point; this
+ * class exists so the run's mutable state (credentials, whether the Ctrl+C hint already printed,
+ * whether it already re-paired once) lives as fields instead of one closed-over `state` object
+ * threaded through a `while (true)` loop, the same reasoning behind `@kubb/studio`'s
+ * `StudioSession`.
  */
-export async function connect(options: StudioOptions): Promise<void> {
-  // Resolved before any network call to Studio (pairing included), so a project with no config
-  // fails fast instead of starting a device-authorization flow it can never use.
-  const { configPath } = await loadConfigs(options)
-
-  const shutdown = new AbortController()
-  const requestShutdown = () => shutdown.abort()
+class StudioConnection {
+  readonly #options: StudioOptions
+  readonly #configPath: string
+  readonly #logLevel: number
+  readonly #isRich: boolean
+  readonly #shutdown = new AbortController()
+  readonly #requestShutdown = (): void => this.#shutdown.abort()
   // `bun-types` narrows `process.on`/`process.off` to its own event union, which omits Node's
   // process signal events, so the listener is installed and removed through the plain emitter API.
-  const processEvents = process as unknown as NodeJS.EventEmitter
-  processEvents.once('SIGINT', requestShutdown)
-  processEvents.once('SIGTERM', requestShutdown)
+  readonly #processEvents = process as unknown as NodeJS.EventEmitter
 
-  const logLevel = logLevelMap[options.logLevel ?? 'info']
-  const isRich = isRichOutput()
+  // Known once `run()` resolves the initial credentials, before anything else reads this field.
+  #credentials!: Credentials
+  // `envToken` itself never changes, but once a browser login has replaced the credentials, later
+  // rejections are no longer about the environment variable and need the paired-again message.
+  #usingEnvToken = !!process.env.KUBB_AGENT_TOKEN
+  // Whether the "Press Ctrl+C" hint already printed, so a reconnect never repeats it.
+  #hinted = false
+  // A rejection right after a fresh login means the newly approved token was no good either, so
+  // one automatic re-pair is all this ever attempts, whether the rejection lands at startup or
+  // once the session is already live. A second one is treated as a hard failure instead of pairing
+  // forever.
+  #hasReauthenticated = false
+  #granted: Record<Permission, boolean> = { allowWrite: false, allowConfigEdit: false, allowInput: false, allowExec: false }
+
+  constructor(options: StudioOptions, configPath: string) {
+    this.#options = options
+    this.#configPath = configPath
+    this.#logLevel = logLevelMap[options.logLevel ?? 'info']
+    this.#isRich = isRichOutput()
+  }
+
   // One clack gutter block, or the same lines plainly.
-  const say = (lines: string | Array<string>) => (isRich ? prompts.log.message(lines) : console.log([lines].flat().join('\n')))
-  const reportDisconnected = () => {
-    if (options.logLevel === 'silent') {
+  #say(lines: string | Array<string>): void {
+    if (this.#isRich) {
+      prompts.log.message(lines)
+    } else {
+      console.log([lines].flat().join('\n'))
+    }
+  }
+
+  #reportDisconnected(): void {
+    if (this.#options.logLevel === 'silent') {
       return
     }
     // `outro` closes the block `intro` opened, so it is not a written line.
-    if (isRich) {
+    if (this.#isRich) {
       prompts.outro('Disconnected')
     } else {
       console.log('Disconnected')
     }
   }
 
-  try {
-    const envToken = process.env.KUBB_AGENT_TOKEN
-    const stored = envToken ? null : await readCredentials()
+  /**
+   * Connects and streams generation events until the process is stopped or Studio rejects the
+   * token.
+   *
+   * One `AbortController` covers the whole run: it cancels an in-flight pairing poll on Ctrl+C and
+   * lets a live token rejection race a shutdown signal, armed once and torn down in `finally` so a
+   * retried pairing never leaves behind a duplicate `SIGINT`/`SIGTERM` listener.
+   */
+  async run(): Promise<void> {
+    this.#processEvents.once('SIGINT', this.#requestShutdown)
+    this.#processEvents.once('SIGTERM', this.#requestShutdown)
 
-    const initialCredentials: Credentials = await (async () => {
-      // A credential is only reused for the Studio it was issued by, so switching `--url` re-pairs
-      // instead of sending one instance's token to another.
-      const resolved = envToken
-        ? { studioUrl: options.studioUrl, token: envToken, agentId: '', agentSlug: '' }
-        : stored?.studioUrl === options.studioUrl
-          ? stored
-          : null
+    try {
+      this.#credentials = await this.#resolveInitialCredentials()
 
-      if (resolved) {
-        return resolved
-      }
+      const { allowWrite, allowConfigEdit, allowInput, allowExec } = await resolvePermissions(
+        this.#options,
+        this.#credentials,
+        this.#configPath,
+        !this.#usingEnvToken,
+      )
+      this.#granted = { allowWrite, allowConfigEdit, allowInput, allowExec }
 
-      if (isCIEnvironment()) {
-        throw new Error(`Not paired with ${options.studioUrl}. Set KUBB_AGENT_TOKEN, or run \`kubb studio login\` on a machine with a browser.`)
-      }
+      this.#printBanner()
 
-      return login(options, { signal: shutdown.signal })
-    })()
-
-    // Everything the reconnect loop below mutates, on one object instead of separate `let`s: state.
-    const state = {
-      credentials: initialCredentials,
-      // `envToken` itself never changes, but once a browser login has replaced the credentials,
-      // later rejections are no longer about the environment variable and need the paired-again message.
-      usingEnvToken: !!envToken,
-      // Whether the "Press Ctrl+C" hint already printed, so a reconnect never repeats it.
-      hinted: false,
-      // A rejection right after a fresh login means the newly approved token was no good either, so
-      // one automatic re-pair is all this ever attempts, whether the rejection lands at startup or
-      // once the session is already live. A second one is treated as a hard failure instead of
-      // pairing forever.
-      hasReauthenticated: false,
-    }
-
-    const { allowWrite, allowConfigEdit, allowInput, allowExec } = await resolvePermissions(options, state.credentials, configPath, !state.usingEnvToken)
-    const granted = { allowWrite, allowConfigEdit, allowInput, allowExec }
-
-    const detail = (label: string, value: string) => `${styleText('dim', label.padEnd(7))}  ${value}`
-
-    if (options.logLevel !== 'silent') {
-      say([
-        detail('Studio', styleText('cyan', options.studioUrl)),
-        detail('Project', path.basename(process.cwd())),
-        detail('Config', path.relative(process.cwd(), configPath) || configPath),
-        '',
-        styleText('dim', 'Permissions'),
-        ...formatPermissionRows(granted),
-      ])
-    }
-
-    while (true) {
-      let notifyAuthRequired: (error: InvalidAgentTokenError) => void = () => {}
-      const authRequired = new Promise<InvalidAgentTokenError>((resolve) => {
-        notifyAuthRequired = resolve
-      })
-
-      const client = createClient({
-        token: state.credentials.token,
-        studioUrl: options.studioUrl,
-        configPath,
-        version: options.version,
-        // Reloaded on every generate, so an edit to kubb.config.ts is picked up without reconnecting.
-        loadConfig: async () => (await loadConfigs(options)).config,
-        client: { kind: 'cli' },
-        root: process.cwd(),
-        ...granted,
-        // Fires once the pool is already stopped, only for a token rejected during background
-        // reconnect. A startup rejection is handled below through `client.connect()` itself.
-        onAuthRequired: notifyAuthRequired,
-        // The loggers `kubb generate` installs, on both emitters, so one place renders the session
-        // events and the generations it drives.
-        installLogger: async (hooks) => {
-          await setupReporters(hooks, { logLevel, reporters: [cliReporter] })
-
-          // `client.connect()` resolves once the agent is registered, not once a session is open, so
-          // this is the only point that knows the connection is live. Registered after the loggers so
-          // it lands under their "Connected to ..." line, and once, since every reconnect fires again.
-          hooks.hook('studio:connected', () => {
-            if (state.hinted || options.logLevel === 'silent') {
-              return
-            }
-            state.hinted = true
-
-            say(styleText('dim', 'Press Ctrl+C to disconnect'))
-          })
-        },
-      })
-
-      try {
-        await client.connect()
-      } catch (error) {
-        if (!(error instanceof InvalidAgentTokenError)) {
-          throw error
-        }
-
-        client.disconnect()
-
-        // The token is dead: the agent was deleted in Studio, or the token was revoked. Keeping it
-        // only produces 401s on every run, so forget it and pair again.
-        if (state.usingEnvToken) {
-          throw explainRejectedToken(error, 'envToken')
-        }
-
-        await clearCredentials()
-
-        if (state.hasReauthenticated) {
-          throw explainRejectedToken(error, 'reauthExhausted')
-        }
-
-        if (isCIEnvironment() || !canUseTTY()) {
-          throw explainRejectedToken(error, 'nonInteractive')
-        }
-
-        console.log(styleText('yellow', `${error.message} Pairing again...`))
-
-        try {
-          state.credentials = await login(options, { signal: shutdown.signal, previousCredentials: state.credentials })
-        } catch (loginError) {
-          if (loginError instanceof PairingCanceledError) {
-            return
-          }
-          throw loginError
-        }
-
-        state.usingEnvToken = false
-        state.hasReauthenticated = true
-
-        continue
-      }
-
-      // Connected. Whichever comes first wins: a shutdown signal, or Studio rejecting the token
-      // while reconnecting in the background, well after this session was already live.
-      const shutdownWait = new Promise<{ kind: 'shutdown' }>((resolve) => {
-        if (shutdown.signal.aborted) {
-          resolve({ kind: 'shutdown' })
-          return
-        }
-        shutdown.signal.addEventListener('abort', () => resolve({ kind: 'shutdown' }), { once: true })
-      })
-      const authRequiredWait = authRequired.then((error) => ({ kind: 'authRequired' as const, error }))
-
-      const outcome = await Promise.race([shutdownWait, authRequiredWait])
-
-      client.disconnect()
-
-      if (outcome.kind === 'shutdown') {
-        reportDisconnected()
-
+      // Each iteration is one connection attempt. It returns once the run is over (a shutdown, or
+      // a canceled re-pair) or falls through to try again with whatever credentials are now current.
+      while (!(await this.#connectAndWait())) {}
+    } catch (error) {
+      // Canceling the very first pairing (before anything was ever connected) is Ctrl+C working as
+      // intended, not a failure to report.
+      if (error instanceof PairingCanceledError) {
         return
       }
 
-      const { error } = outcome
-
-      if (state.usingEnvToken) {
-        throw explainRejectedToken(error, 'envToken')
-      }
-
-      if (state.hasReauthenticated) {
-        throw explainRejectedToken(error, 'reauthExhausted')
-      }
-
-      if (isCIEnvironment() || !canUseTTY()) {
-        throw explainRejectedToken(error, 'nonInteractive')
-      }
-
-      console.log(styleText('yellow', `${error.message} Studio needs you to approve access again.`))
-
-      // Forget the dead token before pairing again, the same as a rejection at startup: `login`
-      // overwrites the file regardless, but a failed re-pair should not leave a rejected token
-      // behind for the next run to try again.
-      await clearCredentials()
-
-      try {
-        state.credentials = await login(options, { signal: shutdown.signal, previousCredentials: state.credentials })
-      } catch (loginError) {
-        if (loginError instanceof PairingCanceledError) {
-          reportDisconnected()
-
-          return
-        }
-        throw loginError
-      }
-
-      state.hasReauthenticated = true
+      throw error
+    } finally {
+      this.#processEvents.off('SIGINT', this.#requestShutdown)
+      this.#processEvents.off('SIGTERM', this.#requestShutdown)
     }
-  } catch (error) {
-    // Canceling the very first pairing (before anything was ever connected) is Ctrl+C working as
-    // intended, not a failure to report.
-    if (error instanceof PairingCanceledError) {
+  }
+
+  async #resolveInitialCredentials(): Promise<Credentials> {
+    const envToken = process.env.KUBB_AGENT_TOKEN
+    const stored = envToken ? null : await readCredentials()
+
+    // A credential is only reused for the Studio it was issued by, so switching `--url` re-pairs
+    // instead of sending one instance's token to another.
+    const resolved = envToken
+      ? { studioUrl: this.#options.studioUrl, token: envToken, agentId: '', agentSlug: '' }
+      : stored?.studioUrl === this.#options.studioUrl
+        ? stored
+        : null
+
+    if (resolved) {
+      return resolved
+    }
+
+    if (isCIEnvironment()) {
+      throw new Error(`Not paired with ${this.#options.studioUrl}. Set KUBB_AGENT_TOKEN, or run \`kubb studio login\` on a machine with a browser.`)
+    }
+
+    return login(this.#options, { signal: this.#shutdown.signal })
+  }
+
+  #printBanner(): void {
+    if (this.#options.logLevel === 'silent') {
       return
     }
 
-    throw error
-  } finally {
-    processEvents.off('SIGINT', requestShutdown)
-    processEvents.off('SIGTERM', requestShutdown)
+    const detail = (label: string, value: string) => `${styleText('dim', label.padEnd(7))}  ${value}`
+
+    this.#say([
+      detail('Studio', styleText('cyan', this.#options.studioUrl)),
+      detail('Project', path.basename(process.cwd())),
+      detail('Config', path.relative(process.cwd(), this.#configPath) || this.#configPath),
+      '',
+      styleText('dim', 'Permissions'),
+      ...formatPermissionRows(this.#granted),
+    ])
   }
+
+  /**
+   * Opens one client and waits for whichever comes first: a shutdown signal, or Studio rejecting
+   * the token, whether that rejection surfaces from `client.connect()` itself (a startup rejection)
+   * or later through `onAuthRequired` (a rejection during background reconnect). Returns whether
+   * the run is over.
+   */
+  async #connectAndWait(): Promise<boolean> {
+    let notifyAuthRequired: (error: InvalidAgentTokenError) => void = () => {}
+    const authRequired = new Promise<InvalidAgentTokenError>((resolve) => {
+      notifyAuthRequired = resolve
+    })
+
+    const client = createClient({
+      token: this.#credentials.token,
+      studioUrl: this.#options.studioUrl,
+      configPath: this.#configPath,
+      version: this.#options.version,
+      // Reloaded on every generate, so an edit to kubb.config.ts is picked up without reconnecting.
+      loadConfig: async () => (await loadConfigs(this.#options)).config,
+      client: { kind: 'cli' },
+      root: process.cwd(),
+      ...this.#granted,
+      // Fires once the pool is already stopped, only for a token rejected during background
+      // reconnect. A startup rejection is handled below through `client.connect()` itself.
+      onAuthRequired: notifyAuthRequired,
+      // The loggers `kubb generate` installs, on both emitters, so one place renders the session
+      // events and the generations it drives.
+      installLogger: async (hooks) => {
+        await setupReporters(hooks, { logLevel: this.#logLevel, reporters: [cliReporter] })
+
+        // `client.connect()` resolves once the agent is registered, not once a session is open, so
+        // this is the only point that knows the connection is live. Registered after the loggers so
+        // it lands under their "Connected to ..." line, and once, since every reconnect fires again.
+        hooks.hook('studio:connected', () => {
+          if (this.#hinted || this.#options.logLevel === 'silent') {
+            return
+          }
+          this.#hinted = true
+
+          this.#say(styleText('dim', 'Press Ctrl+C to disconnect'))
+        })
+      },
+    })
+
+    try {
+      await client.connect()
+    } catch (error) {
+      if (!(error instanceof InvalidAgentTokenError)) {
+        throw error
+      }
+
+      client.disconnect()
+
+      return this.#handleStartupRejection(error)
+    }
+
+    const shutdownWait = new Promise<{ kind: 'shutdown' }>((resolve) => {
+      if (this.#shutdown.signal.aborted) {
+        resolve({ kind: 'shutdown' })
+        return
+      }
+      this.#shutdown.signal.addEventListener('abort', () => resolve({ kind: 'shutdown' }), { once: true })
+    })
+    const authRequiredWait = authRequired.then((error) => ({ kind: 'authRequired' as const, error }))
+
+    const outcome = await Promise.race([shutdownWait, authRequiredWait])
+
+    client.disconnect()
+
+    if (outcome.kind === 'shutdown') {
+      this.#reportDisconnected()
+
+      return true
+    }
+
+    return this.#handleLiveRejection(outcome.error)
+  }
+
+  /**
+   * The token was dead before a session ever opened: the agent was deleted in Studio, or the token
+   * was revoked. Keeping it only produces 401s on every run, so it is forgotten and paired again.
+   * Returns whether the run is over.
+   */
+  async #handleStartupRejection(error: InvalidAgentTokenError): Promise<boolean> {
+    if (this.#usingEnvToken) {
+      throw explainRejectedToken(error, 'envToken')
+    }
+
+    await clearCredentials()
+
+    if (this.#hasReauthenticated) {
+      throw explainRejectedToken(error, 'reauthExhausted')
+    }
+
+    if (isCIEnvironment() || !canUseTTY()) {
+      throw explainRejectedToken(error, 'nonInteractive')
+    }
+
+    console.log(styleText('yellow', `${error.message} Pairing again...`))
+
+    if (!(await this.#reauthenticate())) {
+      return true
+    }
+
+    this.#usingEnvToken = false
+
+    return false
+  }
+
+  /**
+   * Studio rejected the token in the background, well after the session was already live. Returns
+   * whether the run is over.
+   */
+  async #handleLiveRejection(error: InvalidAgentTokenError): Promise<boolean> {
+    if (this.#usingEnvToken) {
+      throw explainRejectedToken(error, 'envToken')
+    }
+
+    if (this.#hasReauthenticated) {
+      throw explainRejectedToken(error, 'reauthExhausted')
+    }
+
+    if (isCIEnvironment() || !canUseTTY()) {
+      throw explainRejectedToken(error, 'nonInteractive')
+    }
+
+    console.log(styleText('yellow', `${error.message} Studio needs you to approve access again.`))
+
+    // Forget the dead token before pairing again, the same as a rejection at startup: `login`
+    // overwrites the file regardless, but a failed re-pair should not leave a rejected token
+    // behind for the next run to try again.
+    await clearCredentials()
+
+    if (!(await this.#reauthenticate())) {
+      this.#reportDisconnected()
+
+      return true
+    }
+
+    return false
+  }
+
+  /**
+   * Re-pairs and stores the resulting credentials. Returns false when the operator canceled it.
+   */
+  async #reauthenticate(): Promise<boolean> {
+    try {
+      this.#credentials = await login(this.#options, { signal: this.#shutdown.signal, previousCredentials: this.#credentials })
+    } catch (loginError) {
+      if (loginError instanceof PairingCanceledError) {
+        return false
+      }
+      throw loginError
+    }
+
+    this.#hasReauthenticated = true
+
+    return true
+  }
+}
+
+/**
+ * Connects this project to Studio and streams generation events until the process is stopped or
+ * Studio rejects the token.
+ */
+export async function connect(options: StudioOptions): Promise<void> {
+  // Resolved before any network call to Studio (pairing included), so a project with no config
+  // fails fast instead of starting a device-authorization flow it can never use.
+  const { configPath } = await loadConfigs(options)
+
+  await new StudioConnection(options, configPath).run()
 }
 
 /**

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -270,9 +270,6 @@ class StudioConnection {
 
   // Known once `run()` resolves the initial credentials, before anything else reads this field.
   #credentials!: Credentials
-  // An operator-supplied token is never replaced automatically, so every rejection of one is
-  // reported instead of paired again.
-  readonly #usingEnvToken = !!process.env.KUBB_AGENT_TOKEN
   // Whether the "Press Ctrl+C" hint already printed, so a reconnect never repeats it.
   #hinted = false
   // One automatic re-pair per run, whether the rejection lands at startup or once the session is
@@ -325,7 +322,7 @@ class StudioConnection {
     try {
       this.#credentials = await this.#resolveInitialCredentials()
 
-      this.#granted = await resolvePermissions(this.#options, this.#credentials, this.#configPath, !this.#usingEnvToken)
+      this.#granted = await resolvePermissions(this.#options, this.#credentials, this.#configPath, !process.env.KUBB_AGENT_TOKEN)
 
       this.#printBanner()
 
@@ -495,7 +492,8 @@ class StudioConnection {
    * Returns whether the run is over.
    */
   async #handleStartupRejection(error: InvalidAgentTokenError): Promise<boolean> {
-    if (this.#usingEnvToken) {
+    // An operator-supplied token is never replaced automatically.
+    if (process.env.KUBB_AGENT_TOKEN) {
       throw explainRejectedToken(error, 'envToken')
     }
 
@@ -517,7 +515,7 @@ class StudioConnection {
    * whether the run is over.
    */
   async #handleLiveRejection(error: InvalidAgentTokenError): Promise<boolean> {
-    if (this.#usingEnvToken) {
+    if (process.env.KUBB_AGENT_TOKEN) {
       throw explainRejectedToken(error, 'envToken')
     }
 
@@ -557,7 +555,7 @@ class StudioConnection {
     // The approved agent may be a different identity, whose saved permissions did not carry
     // forward. Resolving again asks for whatever this credential does not already hold, instead
     // of handing the new agent what the previous one was granted.
-    this.#granted = await resolvePermissions(this.#options, this.#credentials, this.#configPath, !this.#usingEnvToken)
+    this.#granted = await resolvePermissions(this.#options, this.#credentials, this.#configPath, !process.env.KUBB_AGENT_TOKEN)
 
     return true
   }

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -398,6 +398,15 @@ class StudioConnection {
    * the run is over.
    */
   async #connectAndWait(): Promise<boolean> {
+    // A shutdown can land outside the race below: while the permission prompts are open, or
+    // between a browser approval and this next attempt. Registering one more agent with Studio
+    // only to drop it again is not what the operator asked for.
+    if (this.#shutdown.signal.aborted) {
+      this.#reportDisconnected()
+
+      return true
+    }
+
     const { promise: authRequired, resolve: notifyAuthRequired } = Promise.withResolvers<InvalidAgentTokenError>()
 
     const client = createClient({
@@ -550,6 +559,11 @@ class StudioConnection {
     }
 
     this.#hasReauthenticated = true
+
+    // The approved agent may be a different identity, whose saved permissions did not carry
+    // forward. Resolving again asks for whatever this credential does not already hold, instead
+    // of handing the new agent what the previous one was granted.
+    this.#granted = await resolvePermissions(this.#options, this.#credentials, this.#configPath, !this.#usingEnvToken)
 
     return true
   }

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -260,8 +260,6 @@ function explainRejectedToken(error: InvalidAgentTokenError, reason: RejectedTok
 class StudioConnection {
   readonly #options: StudioOptions
   readonly #configPath: string
-  readonly #logLevel: number
-  readonly #isRich: boolean
   readonly #shutdown = new AbortController()
   readonly #requestShutdown = (): void => this.#shutdown.abort()
   // `bun-types` narrows `process.on`/`process.off` to its own event union, which omits Node's
@@ -282,13 +280,11 @@ class StudioConnection {
   constructor(options: StudioOptions, configPath: string) {
     this.#options = options
     this.#configPath = configPath
-    this.#logLevel = logLevelMap[options.logLevel ?? 'info']
-    this.#isRich = isRichOutput()
   }
 
   // One clack gutter block, or the same lines plainly.
   #say(lines: string | Array<string>): void {
-    if (this.#isRich) {
+    if (isRichOutput()) {
       prompts.log.message(lines)
     } else {
       console.log([lines].flat().join('\n'))
@@ -300,7 +296,7 @@ class StudioConnection {
       return
     }
     // `outro` closes the block `intro` opened, so it is not a written line.
-    if (this.#isRich) {
+    if (isRichOutput()) {
       prompts.outro('Disconnected')
     } else {
       console.log('Disconnected')
@@ -416,7 +412,7 @@ class StudioConnection {
       // The loggers `kubb generate` installs, on both emitters, so one place renders the session
       // events and the generations it drives.
       installLogger: async (hooks) => {
-        await setupReporters(hooks, { logLevel: this.#logLevel, reporters: [cliReporter] })
+        await setupReporters(hooks, { logLevel: logLevelMap[this.#options.logLevel ?? 'info'], reporters: [cliReporter] })
 
         // `client.connect()` resolves once the agent is registered, not once a session is open, so
         // this is the only point that knows the connection is live. Registered after the loggers so

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -238,8 +238,8 @@ async function loadConfigs(options: StudioOptions): Promise<{ configPath: string
 type RejectedTokenReason = 'envToken' | 'nonInteractive' | 'reauthExhausted'
 
 /**
- * Explains a rejected token to the operator. Never touches stored or environment credentials
- * itself, since a message-only path must not have side effects the caller did not ask for.
+ * Explains a rejected token to the operator. Builds the error and nothing else, so each caller
+ * decides what happens to the credentials.
  */
 function explainRejectedToken(error: InvalidAgentTokenError, reason: RejectedTokenReason): Error {
   if (reason === 'envToken') {
@@ -254,12 +254,8 @@ function explainRejectedToken(error: InvalidAgentTokenError, reason: RejectedTok
 }
 
 /**
- * One `kubb studio` connect run: pairing if needed, connecting, and reconnecting with a fresh
- * pairing whenever Studio rejects the token. `connect()` is the module's only entry point; this
- * class exists so the run's mutable state (credentials, whether the Ctrl+C hint already printed,
- * whether it already re-paired once) lives as fields instead of one closed-over `state` object
- * threaded through a `while (true)` loop, the same reasoning behind `@kubb/studio`'s
- * `StudioSession`.
+ * One `kubb studio` connect run: pairing if needed, connecting, and pairing again whenever Studio
+ * rejects the token. Reached through `connect()`, which is what the command runs.
  */
 class StudioConnection {
   readonly #options: StudioOptions
@@ -279,10 +275,9 @@ class StudioConnection {
   readonly #usingEnvToken = !!process.env.KUBB_AGENT_TOKEN
   // Whether the "Press Ctrl+C" hint already printed, so a reconnect never repeats it.
   #hinted = false
-  // A rejection right after a fresh login means the newly approved token was no good either, so
-  // one automatic re-pair is all this ever attempts, whether the rejection lands at startup or
-  // once the session is already live. A second one is treated as a hard failure instead of pairing
-  // forever.
+  // One automatic re-pair per run, whether the rejection lands at startup or once the session is
+  // live. A token rejected right after a fresh login is a hard failure, not a reason to keep
+  // pairing.
   #hasReauthenticated = false
   // Resolved by `run()` from the flags and the project's saved answers, before anything reads it.
   #granted!: Record<Permission, boolean>
@@ -320,8 +315,8 @@ class StudioConnection {
    * token.
    *
    * One `AbortController` covers the whole run: it cancels an in-flight pairing poll on Ctrl+C and
-   * lets a live token rejection race a shutdown signal, armed once and torn down in `finally` so a
-   * retried pairing never leaves behind a duplicate `SIGINT`/`SIGTERM` listener.
+   * ends the wait in `#connectAndWait`. Its signal listeners are armed once here, so a retried
+   * pairing cannot leave a duplicate behind.
    */
   async run(): Promise<void> {
     this.#processEvents.once('SIGINT', this.#requestShutdown)
@@ -392,10 +387,9 @@ class StudioConnection {
   }
 
   /**
-   * Opens one client and waits for whichever comes first: a shutdown signal, or Studio rejecting
-   * the token, whether that rejection surfaces from `client.connect()` itself (a startup rejection)
-   * or later through `onAuthRequired` (a rejection during background reconnect). Returns whether
-   * the run is over.
+   * Opens one client and waits for whichever comes first: a shutdown, or Studio rejecting the
+   * token. A rejection arrives either from `client.connect()` itself, at startup, or later through
+   * `onAuthRequired`, during a background reconnect. Returns whether the run is over.
    */
   async #connectAndWait(): Promise<boolean> {
     // A shutdown can land outside the race below: while the permission prompts are open, or
@@ -453,9 +447,9 @@ class StudioConnection {
       return this.#handleStartupRejection(error)
     }
 
-    // `{ once: true }` only removes the listener once the abort event fires, not once this race is
-    // settled by the other side, so `settled` drops it either way. Without that, a token rejection
-    // that gets reauthenticated leaves one behind on `#shutdown.signal` for every reconnect.
+    // `{ once: true }` drops the listener when the abort fires, not when the other side settles
+    // the race, so `settled` covers that half. Without it a reauthenticated rejection leaves one
+    // behind on `#shutdown.signal` for every reconnect.
     const settled = new AbortController()
     // Resolves with nothing, so the race reports a shutdown as the absence of a rejection.
     const shutdownWait = new Promise<undefined>((resolve) => {
@@ -483,7 +477,7 @@ class StudioConnection {
 
   /**
    * Throws when a rejected token cannot be replaced by pairing again: this run already paired once
-   * and was rejected anyway, or there is no browser to approve a new pairing with.
+   * and was rejected anyway, or there is no browser to approve a new pairing.
    */
   #assertCanReauthenticate(error: InvalidAgentTokenError): void {
     if (this.#hasReauthenticated) {

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -274,9 +274,9 @@ class StudioConnection {
 
   // Known once `run()` resolves the initial credentials, before anything else reads this field.
   #credentials!: Credentials
-  // `envToken` itself never changes, but once a browser login has replaced the credentials, later
-  // rejections are no longer about the environment variable and need the paired-again message.
-  #usingEnvToken = !!process.env.KUBB_AGENT_TOKEN
+  // An operator-supplied token is never replaced automatically, so every rejection of one is
+  // reported instead of paired again.
+  readonly #usingEnvToken = !!process.env.KUBB_AGENT_TOKEN
   // Whether the "Press Ctrl+C" hint already printed, so a reconnect never repeats it.
   #hinted = false
   // A rejection right after a fresh login means the newly approved token was no good either, so
@@ -448,28 +448,28 @@ class StudioConnection {
     // settled by the other side, so `settled` drops it either way. Without that, a token rejection
     // that gets reauthenticated leaves one behind on `#shutdown.signal` for every reconnect.
     const settled = new AbortController()
-    const shutdownWait = new Promise<{ kind: 'shutdown' }>((resolve) => {
+    // Resolves with nothing, so the race reports a shutdown as the absence of a rejection.
+    const shutdownWait = new Promise<undefined>((resolve) => {
       if (this.#shutdown.signal.aborted) {
-        resolve({ kind: 'shutdown' })
+        resolve(undefined)
         return
       }
-      this.#shutdown.signal.addEventListener('abort', () => resolve({ kind: 'shutdown' }), { once: true, signal: settled.signal })
+      this.#shutdown.signal.addEventListener('abort', () => resolve(undefined), { once: true, signal: settled.signal })
     })
-    const authRequiredWait = authRequired.then((error) => ({ kind: 'authRequired' as const, error }))
 
-    const outcome = await Promise.race([shutdownWait, authRequiredWait])
+    const rejection = await Promise.race([shutdownWait, authRequired])
 
     settled.abort()
 
     client.disconnect()
 
-    if (outcome.kind === 'shutdown') {
+    if (!rejection) {
       this.#reportDisconnected()
 
       return true
     }
 
-    return this.#handleLiveRejection(outcome.error)
+    return this.#handleLiveRejection(rejection)
   }
 
   /**
@@ -505,8 +505,6 @@ class StudioConnection {
     if (!(await this.#reauthenticate())) {
       return true
     }
-
-    this.#usingEnvToken = false
 
     return false
   }

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -231,29 +231,15 @@ async function loadConfigs(options: StudioOptions): Promise<{ configPath: string
 }
 
 /**
- * Why a rejected token could not be recovered automatically, so {@link explainRejectedToken} can
- * pick the one instruction that actually applies.
+ * Why a rejected token could not be recovered automatically: it came from `KUBB_AGENT_TOKEN`, no
+ * browser is available to re-pair with, or the token this run already re-paired for was rejected
+ * again.
  */
-type RejectedTokenReason =
-  /**
-   * The dead token came from `KUBB_AGENT_TOKEN`. Never overwritten or replaced automatically: an
-   * operator-managed credential stays the operator's to manage.
-   */
-  | 'envToken'
-  /**
-   * CI or no TTY: there is no browser to approve a pairing code in.
-   */
-  | 'nonInteractive'
-  /**
-   * A token this run already re-paired for was rejected again, so another automatic attempt would
-   * just repeat the same failure.
-   */
-  | 'exhausted'
+type RejectedTokenReason = 'envToken' | 'nonInteractive' | 'exhausted'
 
 /**
- * Explains a rejected token to the operator and says what to do about it. Never touches stored or
- * environment credentials itself, since a message-only path must not have side effects the caller
- * did not ask for.
+ * Explains a rejected token to the operator. Never touches stored or environment credentials
+ * itself, since a message-only path must not have side effects the caller did not ask for.
  */
 function explainRejectedToken(error: InvalidAgentTokenError, reason: RejectedTokenReason): Error {
   if (reason === 'envToken') {
@@ -271,10 +257,9 @@ function explainRejectedToken(error: InvalidAgentTokenError, reason: RejectedTok
  * Connects this project to Studio and streams generation events until the process is stopped or
  * Studio rejects the token.
  *
- * One `AbortController` covers the whole call: it cancels an in-flight pairing poll on Ctrl+C, and
- * lets a live token rejection win a race against shutdown instead of waiting for the next signal.
- * It is armed once and torn down in `finally`, so retrying pairing in the loop below never leaves
- * behind a duplicate `SIGINT`/`SIGTERM` listener.
+ * One `AbortController` covers the whole call: it cancels an in-flight pairing poll on Ctrl+C and
+ * lets a live token rejection race a shutdown signal, armed once and torn down in `finally` so a
+ * retried pairing never leaves behind a duplicate `SIGINT`/`SIGTERM` listener.
  */
 export async function connect(options: StudioOptions): Promise<void> {
   // Resolved before any network call to Studio (pairing included), so a project with no config

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -284,7 +284,8 @@ class StudioConnection {
   // once the session is already live. A second one is treated as a hard failure instead of pairing
   // forever.
   #hasReauthenticated = false
-  #granted: Record<Permission, boolean> = { allowWrite: false, allowConfigEdit: false, allowInput: false, allowExec: false }
+  // Resolved by `run()` from the flags and the project's saved answers, before anything reads it.
+  #granted!: Record<Permission, boolean>
 
   constructor(options: StudioOptions, configPath: string) {
     this.#options = options
@@ -329,13 +330,7 @@ class StudioConnection {
     try {
       this.#credentials = await this.#resolveInitialCredentials()
 
-      const { allowWrite, allowConfigEdit, allowInput, allowExec } = await resolvePermissions(
-        this.#options,
-        this.#credentials,
-        this.#configPath,
-        !this.#usingEnvToken,
-      )
-      this.#granted = { allowWrite, allowConfigEdit, allowInput, allowExec }
+      this.#granted = await resolvePermissions(this.#options, this.#credentials, this.#configPath, !this.#usingEnvToken)
 
       this.#printBanner()
 
@@ -403,10 +398,7 @@ class StudioConnection {
    * the run is over.
    */
   async #connectAndWait(): Promise<boolean> {
-    let notifyAuthRequired: (error: InvalidAgentTokenError) => void = () => {}
-    const authRequired = new Promise<InvalidAgentTokenError>((resolve) => {
-      notifyAuthRequired = resolve
-    })
+    const { promise: authRequired, resolve: notifyAuthRequired } = Promise.withResolvers<InvalidAgentTokenError>()
 
     const client = createClient({
       token: this.#credentials.token,
@@ -453,24 +445,21 @@ class StudioConnection {
     }
 
     // `{ once: true }` only removes the listener once the abort event fires, not once this race is
-    // settled by the other side, so a token rejection that gets reauthenticated would otherwise
-    // leave one behind on `#shutdown.signal` for every reconnect the run makes.
-    let onAbort: (() => void) | undefined
+    // settled by the other side, so `settled` drops it either way. Without that, a token rejection
+    // that gets reauthenticated leaves one behind on `#shutdown.signal` for every reconnect.
+    const settled = new AbortController()
     const shutdownWait = new Promise<{ kind: 'shutdown' }>((resolve) => {
       if (this.#shutdown.signal.aborted) {
         resolve({ kind: 'shutdown' })
         return
       }
-      onAbort = () => resolve({ kind: 'shutdown' })
-      this.#shutdown.signal.addEventListener('abort', onAbort, { once: true })
+      this.#shutdown.signal.addEventListener('abort', () => resolve({ kind: 'shutdown' }), { once: true, signal: settled.signal })
     })
     const authRequiredWait = authRequired.then((error) => ({ kind: 'authRequired' as const, error }))
 
     const outcome = await Promise.race([shutdownWait, authRequiredWait])
 
-    if (onAbort) {
-      this.#shutdown.signal.removeEventListener('abort', onAbort)
-    }
+    settled.abort()
 
     client.disconnect()
 
@@ -481,6 +470,20 @@ class StudioConnection {
     }
 
     return this.#handleLiveRejection(outcome.error)
+  }
+
+  /**
+   * Throws when a rejected token cannot be replaced by pairing again: this run already paired once
+   * and was rejected anyway, or there is no browser to approve a new pairing with.
+   */
+  #assertCanReauthenticate(error: InvalidAgentTokenError): void {
+    if (this.#hasReauthenticated) {
+      throw explainRejectedToken(error, 'reauthExhausted')
+    }
+
+    if (isCIEnvironment() || !canUseTTY()) {
+      throw explainRejectedToken(error, 'nonInteractive')
+    }
   }
 
   /**
@@ -495,13 +498,7 @@ class StudioConnection {
 
     await clearCredentials()
 
-    if (this.#hasReauthenticated) {
-      throw explainRejectedToken(error, 'reauthExhausted')
-    }
-
-    if (isCIEnvironment() || !canUseTTY()) {
-      throw explainRejectedToken(error, 'nonInteractive')
-    }
+    this.#assertCanReauthenticate(error)
 
     console.log(styleText('yellow', `${error.message} Pairing again...`))
 
@@ -523,13 +520,7 @@ class StudioConnection {
       throw explainRejectedToken(error, 'envToken')
     }
 
-    if (this.#hasReauthenticated) {
-      throw explainRejectedToken(error, 'reauthExhausted')
-    }
-
-    if (isCIEnvironment() || !canUseTTY()) {
-      throw explainRejectedToken(error, 'nonInteractive')
-    }
+    this.#assertCanReauthenticate(error)
 
     console.log(styleText('yellow', `${error.message} Studio needs you to approve access again.`))
 

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -283,7 +283,7 @@ class StudioConnection {
   }
 
   // One clack gutter block, or the same lines plainly.
-  #say(lines: string | Array<string>): void {
+  #log(lines: string | Array<string>): void {
     if (isRichOutput()) {
       prompts.log.message(lines)
     } else {
@@ -369,7 +369,7 @@ class StudioConnection {
 
     const detail = (label: string, value: string) => `${styleText('dim', label.padEnd(7))}  ${value}`
 
-    this.#say([
+    this.#log([
       detail('Studio', styleText('cyan', this.#options.studioUrl)),
       detail('Project', path.basename(process.cwd())),
       detail('Config', path.relative(process.cwd(), this.#configPath) || this.#configPath),
@@ -423,7 +423,7 @@ class StudioConnection {
           }
           this.#hinted = true
 
-          this.#say(styleText('dim', 'Press Ctrl+C to disconnect'))
+          this.#log(styleText('dim', 'Press Ctrl+C to disconnect'))
         })
       },
     })

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -107,11 +107,11 @@ async function login({ studioUrl, autoOpen }: StudioOptions, { signal, previousC
   }
 
   const spinner = createSpinner()
-  spinner?.start('Waiting for approval')
+  spinner.start('Waiting for approval')
 
   try {
     const { token, agent } = await pollForPairingToken({ studioUrl, session, signal })
-    spinner?.stop(`Paired as ${agent.name}`)
+    spinner.stop(`Paired as ${agent.name}`)
 
     const keepsIdentity = previousCredentials?.studioUrl === studioUrl && previousCredentials.agentId === agent.id
     const credentials: Credentials = {
@@ -127,7 +127,7 @@ async function login({ studioUrl, autoOpen }: StudioOptions, { signal, previousC
 
     return credentials
   } catch (error) {
-    spinner?.stop(error instanceof PairingCanceledError ? 'Pairing canceled' : 'Pairing failed')
+    spinner.stop(error instanceof PairingCanceledError ? 'Pairing canceled' : 'Pairing failed')
     throw error
   }
 }

--- a/packages/studio/src/client.test.ts
+++ b/packages/studio/src/client.test.ts
@@ -55,9 +55,9 @@ describe('createClient', () => {
     const error = new InvalidAgentTokenError('https://kubb.studio')
 
     // Two pool sessions reject the same dead token at once.
-    capturedOptions[0]?.onAuthRequired?.(error)
-    capturedOptions[1]?.onAuthRequired?.(error)
-    capturedOptions[2]?.onAuthRequired?.(error)
+    capturedOptions[0]?.onTokenRejected?.(error)
+    capturedOptions[1]?.onTokenRejected?.(error)
+    capturedOptions[2]?.onTokenRejected?.(error)
 
     expect(onAuthRequired).toHaveBeenCalledTimes(1)
     expect(onAuthRequired).toHaveBeenCalledWith(error)
@@ -78,7 +78,7 @@ describe('createClient', () => {
     const client = createClient({ ...options, poolSize: 1, onAuthRequired })
     await client.connect()
 
-    vi.mocked(connectToStudio).mock.calls[0]?.[0].onAuthRequired?.(new InvalidAgentTokenError('https://kubb.studio'))
+    vi.mocked(connectToStudio).mock.calls[0]?.[0].onTokenRejected?.(new InvalidAgentTokenError('https://kubb.studio'))
 
     expect(calls).toStrictEqual(['abort', 'onAuthRequired'])
     expect(capturedSignal?.aborted).toBe(true)

--- a/packages/studio/src/client.test.ts
+++ b/packages/studio/src/client.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { InvalidAgentTokenError } from './api.ts'
+import { createClient } from './client.ts'
+import type { ConnectToStudioOptions } from './connectStudio.ts'
+
+vi.mock('./api.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./api.ts')>()),
+  registerAgent: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock('./connectStudio.ts', () => ({
+  connectToStudio: vi.fn(),
+}))
+
+import { registerAgent } from './api.ts'
+import { connectToStudio } from './connectStudio.ts'
+
+const options = {
+  token: 'my-token',
+  studioUrl: 'https://kubb.studio',
+  configPath: 'kubb.config.ts',
+  loadConfig: vi.fn(),
+  version: '1.0.0',
+}
+
+afterEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('createClient', () => {
+  it('opens one connectToStudio session per pool slot, each with its own AbortSignal listener', async () => {
+    vi.mocked(connectToStudio).mockResolvedValue(undefined)
+
+    const client = createClient({ ...options, poolSize: 3 })
+    await client.connect()
+
+    expect(connectToStudio).toHaveBeenCalledTimes(3)
+    expect(registerAgent).toHaveBeenCalledWith({ token: 'my-token', studioUrl: 'https://kubb.studio', poolSize: 3 })
+  })
+
+  it('fires onAuthRequired once when several pool sessions reject the same token concurrently', async () => {
+    const onAuthRequired = vi.fn()
+    const capturedOptions: Array<ConnectToStudioOptions> = []
+
+    vi.mocked(connectToStudio).mockImplementation((opts) => {
+      capturedOptions.push(opts)
+      // Every pool slot resolves startup normally: the rejection happens later, during background
+      // reconnect, which is exactly what onAuthRequired covers.
+      return Promise.resolve()
+    })
+
+    const client = createClient({ ...options, poolSize: 3, onAuthRequired })
+    await client.connect()
+
+    const error = new InvalidAgentTokenError('https://kubb.studio')
+
+    // Two pool sessions reject the same dead token at once.
+    capturedOptions[0]?.onAuthRequired?.(error)
+    capturedOptions[1]?.onAuthRequired?.(error)
+    capturedOptions[2]?.onAuthRequired?.(error)
+
+    expect(onAuthRequired).toHaveBeenCalledTimes(1)
+    expect(onAuthRequired).toHaveBeenCalledWith(error)
+  })
+
+  it('aborts the pool signal before calling the caller onAuthRequired', async () => {
+    const calls: Array<string> = []
+    const onAuthRequired = vi.fn(() => calls.push('onAuthRequired'))
+    let capturedSignal: AbortSignal | undefined
+
+    vi.mocked(connectToStudio).mockImplementation((opts) => {
+      capturedSignal = opts.signal
+      capturedSignal?.addEventListener('abort', () => calls.push('abort'))
+
+      return Promise.resolve()
+    })
+
+    const client = createClient({ ...options, poolSize: 1, onAuthRequired })
+    await client.connect()
+
+    vi.mocked(connectToStudio).mock.calls[0]?.[0].onAuthRequired?.(new InvalidAgentTokenError('https://kubb.studio'))
+
+    expect(calls).toStrictEqual(['abort', 'onAuthRequired'])
+    expect(capturedSignal?.aborted).toBe(true)
+  })
+
+  it('rejects connect() with the startup error instead of calling onAuthRequired', async () => {
+    const onAuthRequired = vi.fn()
+    const error = new InvalidAgentTokenError('https://kubb.studio')
+    vi.mocked(connectToStudio).mockRejectedValue(error)
+
+    const client = createClient({ ...options, onAuthRequired })
+
+    await expect(client.connect()).rejects.toBe(error)
+    expect(onAuthRequired).not.toHaveBeenCalled()
+  })
+})

--- a/packages/studio/src/client.ts
+++ b/packages/studio/src/client.ts
@@ -12,14 +12,12 @@ export type ClientOptions = Omit<ConnectToStudioOptions, 'signal'> & {
    */
   storage?: Storage
   /**
-   * Called once a live pool rejects its token: Studio answered a background reconnect with 401,
-   * meaning the token was revoked or the agent was deleted. Every session in the pool is already
-   * stopped by the time this fires, so a host only needs to obtain a replacement token and start a
-   * new client with it.
+   * Called once when a live pool's token is rejected during background reconnect (401: revoked, or
+   * the agent was deleted). The whole pool is already stopped by the time this fires, so a host
+   * only needs to obtain a replacement token and start a new client.
    *
-   * Never fires for a token rejected at startup, which `connect()`'s own rejection already
-   * reports, nor for an ordinary session expiry or a revoked session, both of which reconnect on
-   * their own.
+   * Never fires for a startup rejection, which `connect()` reports by throwing, nor for an ordinary
+   * session expiry or revocation, both of which reconnect on their own.
    */
   onAuthRequired?: (error: InvalidAgentTokenError) => void
 }

--- a/packages/studio/src/client.ts
+++ b/packages/studio/src/client.ts
@@ -5,7 +5,7 @@ import { registerAgent } from './api.ts'
 import { type ConnectToStudioOptions, connectToStudio } from './connectStudio.ts'
 import { setStorage } from './machine.ts'
 
-export type ClientOptions = Omit<ConnectToStudioOptions, 'signal'> & {
+export type ClientOptions = Omit<ConnectToStudioOptions, 'signal' | 'onTokenRejected'> & {
   /**
    * Where the machine secret and the last Studio config are persisted. Defaults to in-memory,
    * which gives up a stable machine identity across restarts.

--- a/packages/studio/src/client.ts
+++ b/packages/studio/src/client.ts
@@ -1,5 +1,6 @@
 import type { Storage } from 'unstorage'
 import { agentDefaults } from './constants.ts'
+import type { InvalidAgentTokenError } from './api.ts'
 import { registerAgent } from './api.ts'
 import { type ConnectToStudioOptions, connectToStudio } from './connectStudio.ts'
 import { setStorage } from './machine.ts'
@@ -10,6 +11,17 @@ export type ClientOptions = Omit<ConnectToStudioOptions, 'signal'> & {
    * which gives up a stable machine identity across restarts.
    */
   storage?: Storage
+  /**
+   * Called once a live pool rejects its token: Studio answered a background reconnect with 401,
+   * meaning the token was revoked or the agent was deleted. Every session in the pool is already
+   * stopped by the time this fires, so a host only needs to obtain a replacement token and start a
+   * new client with it.
+   *
+   * Never fires for a token rejected at startup, which `connect()`'s own rejection already
+   * reports, nor for an ordinary session expiry or a revoked session, both of which reconnect on
+   * their own.
+   */
+  onAuthRequired?: (error: InvalidAgentTokenError) => void
 }
 
 export type Client = {
@@ -36,13 +48,29 @@ export type Client = {
  * await studio.connect()
  * ```
  */
-export function createClient({ storage, ...options }: ClientOptions): Client {
+export function createClient({ storage, onAuthRequired, ...options }: ClientOptions): Client {
   if (storage) {
     setStorage(storage)
   }
 
   const controller = new AbortController()
   const poolSize = options.poolSize ?? agentDefaults.poolSize
+  // Several pool sessions can reject the same token at once, so this instance fires the callback
+  // at most once instead of once per session.
+  let authRequiredFired = false
+
+  function notifyAuthRequired(error: InvalidAgentTokenError) {
+    if (authRequiredFired) {
+      return
+    }
+    authRequiredFired = true
+
+    // Stop the whole pool first: every session's socket closes and every pending retry timer is
+    // canceled through the `signal` each one already listens on, so the caller starts its next
+    // client from a clean slate.
+    controller.abort()
+    onAuthRequired?.(error)
+  }
 
   return {
     async connect() {
@@ -52,7 +80,7 @@ export function createClient({ storage, ...options }: ClientOptions): Client {
       // Awaited: `connectToStudio` only ever rejects with `InvalidAgentTokenError` (every other
       // failure is retried internally through its own reconnect loop and resolves normally), so
       // awaiting here surfaces a dead token to the caller without blocking on a down Studio.
-      await Promise.all(Array.from({ length: poolSize }, () => connectToStudio({ ...options, signal: controller.signal })))
+      await Promise.all(Array.from({ length: poolSize }, () => connectToStudio({ ...options, signal: controller.signal, onAuthRequired: notifyAuthRequired })))
     },
     disconnect() {
       controller.abort()

--- a/packages/studio/src/client.ts
+++ b/packages/studio/src/client.ts
@@ -78,7 +78,7 @@ export function createClient({ storage, onAuthRequired, ...options }: ClientOpti
       // Awaited: `connectToStudio` only ever rejects with `InvalidAgentTokenError` (every other
       // failure is retried internally through its own reconnect loop and resolves normally), so
       // awaiting here surfaces a dead token to the caller without blocking on a down Studio.
-      await Promise.all(Array.from({ length: poolSize }, () => connectToStudio({ ...options, signal: controller.signal, onAuthRequired: notifyAuthRequired })))
+      await Promise.all(Array.from({ length: poolSize }, () => connectToStudio({ ...options, signal: controller.signal, onTokenRejected: notifyAuthRequired })))
     },
     disconnect() {
       controller.abort()

--- a/packages/studio/src/client.ts
+++ b/packages/studio/src/client.ts
@@ -14,7 +14,7 @@ export type ClientOptions = Omit<ConnectToStudioOptions, 'signal' | 'onTokenReje
   /**
    * Called once when a live pool's token is rejected during background reconnect (401: revoked, or
    * the agent was deleted). The whole pool is already stopped by the time this fires, so a host
-   * only needs to obtain a replacement token and start a new client.
+   * only needs to get a replacement token and start a new client.
    *
    * Never fires for a startup rejection, which `connect()` reports by throwing, nor for an ordinary
    * session expiry or revocation, both of which reconnect on their own.
@@ -54,8 +54,8 @@ export function createClient({ storage, onAuthRequired, ...options }: ClientOpti
   const controller = new AbortController()
   const poolSize = options.poolSize ?? agentDefaults.poolSize
   function notifyAuthRequired(error: InvalidAgentTokenError) {
-    // Several pool sessions can reject the same token at once, and a host can have stopped the pool
-    // itself, so an already-aborted controller is what says the callback is spent.
+    // Several pool sessions can reject the same token at once, and a host can stop the pool
+    // itself, so an aborted controller is what says this callback is spent.
     if (controller.signal.aborted) {
       return
     }

--- a/packages/studio/src/client.ts
+++ b/packages/studio/src/client.ts
@@ -53,15 +53,12 @@ export function createClient({ storage, onAuthRequired, ...options }: ClientOpti
 
   const controller = new AbortController()
   const poolSize = options.poolSize ?? agentDefaults.poolSize
-  // Several pool sessions can reject the same token at once, so this instance fires the callback
-  // at most once instead of once per session.
-  let authRequiredFired = false
-
   function notifyAuthRequired(error: InvalidAgentTokenError) {
-    if (authRequiredFired) {
+    // Several pool sessions can reject the same token at once, and a host can have stopped the pool
+    // itself, so an already-aborted controller is what says the callback is spent.
+    if (controller.signal.aborted) {
       return
     }
-    authRequiredFired = true
 
     // Stop the whole pool first: every session's socket closes and every pending retry timer is
     // canceled through the `signal` each one already listens on, so the caller starts its next

--- a/packages/studio/src/connectStudio.test.ts
+++ b/packages/studio/src/connectStudio.test.ts
@@ -43,7 +43,7 @@ vi.mock('./ws.ts', () => ({
   setupEventsStream: vi.fn(),
 }))
 
-import { createAgentSession, disconnect } from './api.ts'
+import { createAgentSession, disconnect, InvalidAgentTokenError } from './api.ts'
 import { generate } from './generate.ts'
 
 import { createWebsocket, sendAgentMessage, setupEventsStream } from './ws.ts'
@@ -946,6 +946,44 @@ describe('connectToStudio', () => {
     expect(disconnect).not.toHaveBeenCalled()
     // Unlike a revoked session, an expired one triggers a reconnect.
     expect(consoleSpy.info).toHaveBeenCalledWith(expect.stringContaining('Retrying connection'))
+  })
+
+  it('calls onAuthRequired and stops retrying when a background reconnect is rejected with an invalid token', async () => {
+    vi.useFakeTimers()
+    const onAuthRequired = vi.fn()
+
+    await connectToStudio({ ...options, onAuthRequired })
+
+    await mockWs.trigger('close')
+
+    const error = new InvalidAgentTokenError('https://kubb.studio')
+    vi.mocked(createAgentSession).mockRejectedValueOnce(error)
+
+    await vi.advanceTimersByTimeAsync(options.retryInterval!)
+
+    expect(onAuthRequired).toHaveBeenCalledWith(error)
+
+    // A rejected token stays rejected, so no further reconnect attempt should follow.
+    await vi.advanceTimersByTimeAsync(options.retryInterval! * 3)
+    expect(createAgentSession).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps retrying an ordinary network failure without calling onAuthRequired', async () => {
+    vi.useFakeTimers()
+    const onAuthRequired = vi.fn()
+
+    await connectToStudio({ ...options, onAuthRequired })
+
+    await mockWs.trigger('close')
+
+    vi.mocked(createAgentSession).mockRejectedValueOnce(new Error('502 Bad Gateway'))
+    vi.mocked(createAgentSession).mockResolvedValueOnce(makeSession())
+
+    await vi.advanceTimersByTimeAsync(options.retryInterval!)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(onAuthRequired).not.toHaveBeenCalled()
+    expect(createAgentSession).toHaveBeenCalledTimes(2)
   })
 
   it('logs and retries instead of crashing when a reconnect attempt fails to reach Studio', async () => {

--- a/packages/studio/src/connectStudio.test.ts
+++ b/packages/studio/src/connectStudio.test.ts
@@ -930,6 +930,13 @@ describe('connectToStudio', () => {
     expect(disconnect).not.toHaveBeenCalled()
     // A revoked session does not trigger a reconnect.
     expect(consoleSpy.info).not.toHaveBeenCalledWith(expect.stringContaining('Retrying connection'))
+
+    // A real socket fires its own `close` event once `.close()` above settles. That must not run
+    // teardown a second time and reconnect a session Studio just revoked.
+    await mockWs.trigger('close')
+
+    expect(disconnect).not.toHaveBeenCalled()
+    expect(consoleSpy.info).not.toHaveBeenCalledWith(expect.stringContaining('Retrying connection'))
   })
 
   it('cleans up and reconnects when a disconnect message with reason "expired" is received', async () => {
@@ -946,6 +953,16 @@ describe('connectToStudio', () => {
     expect(disconnect).not.toHaveBeenCalled()
     // Unlike a revoked session, an expired one triggers a reconnect.
     expect(consoleSpy.info).toHaveBeenCalledWith(expect.stringContaining('Retrying connection'))
+
+    const reconnectCount = vi.mocked(consoleSpy.info).mock.calls.filter((call) => String(call[0]).includes('Retrying connection')).length
+
+    // A real socket fires its own `close` event once `.close()` above settles. That must not run
+    // teardown a second time and queue a duplicate reconnect on top of the one already scheduled
+    // above.
+    await mockWs.trigger('close')
+
+    expect(disconnect).not.toHaveBeenCalled()
+    expect(vi.mocked(consoleSpy.info).mock.calls.filter((call) => String(call[0]).includes('Retrying connection'))).toHaveLength(reconnectCount)
   })
 
   it('calls onTokenRejected and stops retrying when a background reconnect is rejected with an invalid token', async () => {

--- a/packages/studio/src/connectStudio.test.ts
+++ b/packages/studio/src/connectStudio.test.ts
@@ -948,11 +948,11 @@ describe('connectToStudio', () => {
     expect(consoleSpy.info).toHaveBeenCalledWith(expect.stringContaining('Retrying connection'))
   })
 
-  it('calls onAuthRequired and stops retrying when a background reconnect is rejected with an invalid token', async () => {
+  it('calls onTokenRejected and stops retrying when a background reconnect is rejected with an invalid token', async () => {
     vi.useFakeTimers()
-    const onAuthRequired = vi.fn()
+    const onTokenRejected = vi.fn()
 
-    await connectToStudio({ ...options, onAuthRequired })
+    await connectToStudio({ ...options, onTokenRejected })
 
     await mockWs.trigger('close')
 
@@ -961,18 +961,18 @@ describe('connectToStudio', () => {
 
     await vi.advanceTimersByTimeAsync(options.retryInterval!)
 
-    expect(onAuthRequired).toHaveBeenCalledWith(error)
+    expect(onTokenRejected).toHaveBeenCalledWith(error)
 
     // A rejected token stays rejected, so no further reconnect attempt should follow.
     await vi.advanceTimersByTimeAsync(options.retryInterval! * 3)
     expect(createAgentSession).toHaveBeenCalledTimes(2)
   })
 
-  it('keeps retrying an ordinary network failure without calling onAuthRequired', async () => {
+  it('keeps retrying an ordinary network failure without calling onTokenRejected', async () => {
     vi.useFakeTimers()
-    const onAuthRequired = vi.fn()
+    const onTokenRejected = vi.fn()
 
-    await connectToStudio({ ...options, onAuthRequired })
+    await connectToStudio({ ...options, onTokenRejected })
 
     await mockWs.trigger('close')
 
@@ -982,7 +982,7 @@ describe('connectToStudio', () => {
     await vi.advanceTimersByTimeAsync(options.retryInterval!)
     await vi.advanceTimersByTimeAsync(0)
 
-    expect(onAuthRequired).not.toHaveBeenCalled()
+    expect(onTokenRejected).not.toHaveBeenCalled()
     expect(createAgentSession).toHaveBeenCalledTimes(2)
   })
 

--- a/packages/studio/src/connectStudio.ts
+++ b/packages/studio/src/connectStudio.ts
@@ -1,7 +1,8 @@
+import { writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
 import { styleText } from 'node:util'
-import { getErrorMessage, read, toError, write } from '@internals/utils'
+import { getErrorMessage, read, toError } from '@internals/utils'
 import { type Config, fsStorage, Hookable, type KubbHooks, memoryStorage } from '@kubb/core'
 import { version as kubbVersion } from '../package.json'
 import { setupHookListener } from './hooks.ts'
@@ -665,7 +666,9 @@ class StudioSession {
       const { source: patched, outcomes, changed } = applyConfigEdits(current, edits)
 
       if (changed) {
-        await write(configFile, patched)
+        // `writeFile` rather than the `write` helper: that one trims and re-terminates what it
+        // writes, which is right for generated output and wrong for a file the user wrote by hand.
+        await writeFile(configFile, patched, 'utf-8')
       }
 
       sendAgentMessage(ws, {

--- a/packages/studio/src/connectStudio.ts
+++ b/packages/studio/src/connectStudio.ts
@@ -75,9 +75,9 @@ export type ConnectToStudioOptions = {
 /**
  * Schedules another connection attempt.
  *
- * Hoisted out of `connectToStudio` on purpose: a pending retry timer reaches its whole enclosing
- * scope, so keeping it inside would pin the closed socket, the hook emitter, and the session id
- * alive for the length of every retry interval.
+ * A free function rather than a method: a pending retry timer reaches whatever it closes over, so
+ * closing only over `options` (not a `StudioSession`) keeps a queued retry from pinning a closed
+ * socket, its hook emitter, or its session id alive for the length of the retry interval.
  */
 function reconnect(options: ConnectToStudioOptions): void {
   const { signal, retryInterval = agentDefaults.retryIntervalMs, onTokenRejected } = options
@@ -119,423 +119,504 @@ function reconnect(options: ConnectToStudioOptions): void {
   signal?.addEventListener('abort', cancel, { once: true })
 }
 
-export async function connectToStudio(options: ConnectToStudioOptions): Promise<void> {
-  const {
-    token,
-    studioUrl = agentDefaults.studioUrl,
-    configPath,
-    loadConfig,
-    version,
-    client,
+/**
+ * One WebSocket session with Studio: opening it, keeping it alive, and running whatever Studio
+ * sends over it. `connectToStudio` is the module's only public entry point; this class exists so
+ * that session's several pieces of mutable state (the socket, the heartbeat timer, whether a
+ * generation is running) live as fields instead of a pile of closed-over `let`s, matching how
+ * `KubbDriver` holds a single build's state in `@kubb/core`.
+ */
+class StudioSession {
+  readonly #options: ConnectToStudioOptions
+  readonly #token: string
+  readonly #studioUrl: string
+  readonly #configPath: string
+  readonly #loadConfig: () => Promise<Config>
+  readonly #version: string
+  readonly #client: ClientInfo | undefined
+  readonly #allowWrite: boolean
+  readonly #allowInput: boolean
+  readonly #allowExec: boolean
+  readonly #root: string
+  readonly #heartbeatInterval: number
+  readonly #signal: AbortSignal | undefined
+  readonly #installLogger: ((hooks: Hookable<KubbHooks>) => void | Promise<void>) | undefined
+  // Each session gets its own isolated event emitter so generation events from one session do not
+  // bleed into another session's WebSocket stream.
+  readonly #hooks = new Hookable<KubbHooks>()
+
+  // Known once `createAgentSession` resolves.
+  #sessionId = ''
+  #slug: string | null | undefined
+  #ws: WebSocket | undefined
+  // Known before the agent announces itself, and refreshed by a later `studio:connect`, so both
+  // sides can be named from the first connect on.
+  #studioVersion: string | undefined
+  // Effective permissions: always disabled in sandbox mode.
+  #canWrite = false
+  // A sandbox has no user project to edit, so a config edit is never granted there.
+  #canEditConfig = false
+  #configFilePath = ''
+  // A sandbox agent always generates from the spec Studio supplies; a local agent only when opted in.
+  #canUseInput = false
+  #isSandbox = false
+
+  // Tracks whether the studio server explicitly disconnected us (no reconnect needed).
+  #serverDisconnected = false
+  // Guards against a second `generate` command starting while one is already running. Without
+  // this, two concurrent `generate()` calls share this socket via `setupEventsStream`, and their
+  // events interleave with no way for Studio to tell the two runs apart.
+  #isGenerating = false
+  #heartbeatTimer: ReturnType<typeof setInterval> | undefined
+  // Tracks socket liveness: Studio replies to every ping with a pong. When pongs stop arriving the
+  // connection is half-open (e.g. dropped during a Studio deploy) and must be terminated so the
+  // reconnect loop can establish a fresh session.
+  #lastPongAt = Date.now()
+
+  constructor(options: ConnectToStudioOptions) {
+    this.#options = options
+    this.#token = options.token
+    this.#studioUrl = options.studioUrl ?? agentDefaults.studioUrl
+    this.#configPath = options.configPath
+    this.#loadConfig = options.loadConfig
+    this.#version = options.version
+    this.#client = options.client
     // Every permission is off unless the host grants it.
-    allowWrite = false,
-    allowConfigEdit = false,
-    allowInput = false,
-    allowExec = false,
-    root = process.cwd(),
-    heartbeatInterval: requestedHeartbeatInterval = agentDefaults.heartbeatIntervalMs,
-    signal,
-    installLogger,
-  } = options
+    this.#allowWrite = options.allowWrite ?? false
+    this.#allowInput = options.allowInput ?? false
+    this.#allowExec = options.allowExec ?? false
+    this.#root = options.root ?? process.cwd()
+    this.#signal = options.signal
+    this.#installLogger = options.installLogger
+    // Studio counts an agent offline once its last ping is older than its liveness window, so a
+    // slower cadence would make a healthy agent invisible. Clamped here rather than in a host's
+    // env parsing, so every host is held to the contract.
+    this.#heartbeatInterval = Math.min(options.heartbeatInterval ?? agentDefaults.heartbeatIntervalMs, agentDefaults.heartbeatIntervalMs)
+  }
 
-  // Studio counts an agent offline once its last ping is older than its liveness window, so a
-  // slower cadence would make a healthy agent invisible. Clamped here rather than in a host's env
-  // parsing, so every host is held to the contract.
-  const heartbeatInterval = Math.min(requestedHeartbeatInterval, agentDefaults.heartbeatIntervalMs)
+  async connect(): Promise<void> {
+    await this.#installLogger?.(this.#hooks)
 
-  // Each connection gets its own isolated event emitter so generation events
-  // from one session do not bleed into another session's WebSocket stream.
-  const hooks = new Hookable<KubbHooks>()
-  await installLogger?.(hooks)
+    try {
+      // Before the session exists, so a host can cover the wait: `createAgentSession` is a round
+      // trip and the socket after it opens without being awaited.
+      await this.#hooks.callHook('studio:connecting', { url: this.#studioUrl })
 
-  try {
-    // Before the session exists, so a host can cover the wait: `createAgentSession` is a round
-    // trip and the socket after it opens without being awaited.
-    await hooks.callHook('studio:connecting', { url: studioUrl })
+      const { sessionId, slug, wsUrl, isSandbox, version: sessionStudioVersion } = await createAgentSession({ token: this.#token, studioUrl: this.#studioUrl })
 
-    const { sessionId, slug, wsUrl, isSandbox, version: sessionStudioVersion } = await createAgentSession({ token, studioUrl })
+      this.#sessionId = sessionId
+      this.#slug = slug
+      this.#studioVersion = sessionStudioVersion
+      this.#isSandbox = isSandbox
+      this.#canWrite = isSandbox ? false : this.#allowWrite
+      this.#canEditConfig = isSandbox ? false : (this.#options.allowConfigEdit ?? false)
+      // `configPath` is relative to the agent's root unless it is already absolute, which is what
+      // `resolve` does on its own.
+      this.#configFilePath = path.resolve(this.#root, this.#configPath)
+      this.#canUseInput = isSandbox || this.#allowInput
 
-    // Known before the agent announces itself, and refreshed by a later `studio:connect`, so both
-    // sides can be named from the first connect on.
-    let studioVersion = sessionStudioVersion
-    const ws = createWebsocket(wsUrl, {
-      headers: { Authorization: `Bearer ${token}` },
+      const ws = createWebsocket(wsUrl, { headers: { Authorization: `Bearer ${this.#token}` } })
+      this.#ws = ws
+
+      ws.addEventListener('open', this.#onOpen)
+      ws.addEventListener('close', this.#onClose)
+      ws.addEventListener('error', this.#onError)
+      ws.addEventListener('message', this.#onMessage)
+      // The socket's own close event fires after this, and `#teardown` is idempotent, so the
+      // shutdown path cannot be turned into a reconnect by the close that follows it.
+      this.#signal?.addEventListener('abort', this.#onAbort, { once: true })
+
+      this.#heartbeatTimer = setInterval(() => this.#sendHeartbeat(), this.#heartbeatInterval)
+
+      // Only `kubb:error` is ever fired on the connection emitter. Every generation event goes
+      // through its own emitter below, so it gets that one listener rather than the full stream.
+      this.#hooks.hook('kubb:error', ({ error }) => sendErrorMessage(ws, error))
+    } catch (error) {
+      // Reaching here means the session was never created (Studio down, a 502 mid-deploy), so no
+      // socket exists and none of the socket-driven reconnect paths can fire. Retry from here or
+      // the slot is dropped for the lifetime of the process.
+      await this.#hooks.callHook('studio:error', { error: toError(error) })
+
+      if (error instanceof InvalidAgentTokenError) {
+        throw error
+      }
+
+      reconnect(this.#options)
+    }
+  }
+
+  #sendHeartbeat(): void {
+    // Two consecutive missed pongs mean the socket is dead even though no close event arrived.
+    // Terminate (not close) so a half-open TCP connection can't linger. The resulting close event
+    // triggers cleanup and the reconnect loop.
+    if (Date.now() - this.#lastPongAt > this.#heartbeatInterval * 2) {
+      void this.#hooks.callHook('studio:warn', { message: 'No reply from Kubb Studio, terminating the stale connection' })
+      // Stop the timer here rather than waiting for `#cleanup`, since the close event can lag, and
+      // until it runs this interval would re-terminate and re-log every tick.
+      clearInterval(this.#heartbeatTimer)
+      this.#heartbeatTimer = undefined
+      this.#ws?.terminate()
+
+      return
+    }
+
+    if (this.#ws) {
+      sendAgentMessage(this.#ws, { type: 'agent:ping' })
+    }
+  }
+
+  /**
+   * Reads `kubb.config.ts` and reports which plugin options Studio may edit.
+   *
+   * Skipped when the host did not grant `allowConfigEdit`. The patcher pulls in `magicast`
+   * (~25ms, ~55MB RSS), so read-only agents never import it.
+   *
+   * Not cached: the user can edit the file between two Studio actions.
+   */
+  async #readConfigFileView(source?: string): Promise<ConfigFileView | undefined> {
+    if (!this.#canEditConfig) {
+      return undefined
+    }
+
+    try {
+      const { readConfig } = await import('./configFile.ts')
+
+      return readConfig(source ?? (await readFile(this.#configFilePath, 'utf-8')))
+    } catch (error) {
+      await this.#hooks.callHook('studio:warn', { message: `Could not read ${this.#configFilePath}: ${getErrorMessage(error)}` })
+
+      return undefined
+    }
+  }
+
+  async #sendConnectedPayload(): Promise<void> {
+    if (!this.#ws) {
+      return
+    }
+
+    const config = await this.#loadConfig()
+
+    sendAgentMessage(this.#ws, {
+      type: 'agent:connect',
+      payload: {
+        versions: { kubb: kubbVersion, agent: this.#version },
+        root: this.#root,
+        config: {
+          path: this.#configPath,
+          file: await this.#readConfigFileView(),
+          plugins: config.plugins.map((plugin) => ({
+            name: `@kubb/${plugin.name}`,
+            // Functions and symbols in plugin options are dropped by `JSON.stringify` on the way out.
+            options: plugin.options ?? {},
+          })),
+        },
+        permissions: {
+          allowWrite: this.#canWrite,
+          allowInput: this.#canUseInput,
+          allowExec: this.#allowExec,
+          allowConfigEdit: this.#canEditConfig,
+        },
+      },
+    })
+  }
+
+  async #handleOpen(): Promise<void> {
+    this.#lastPongAt = Date.now()
+    await this.#hooks.callHook('studio:connected', {
+      url: this.#studioUrl,
+      versions: { studio: this.#studioVersion, kubb: kubbVersion, agent: this.#version },
     })
 
-    // Effective permissions: always disabled in sandbox mode
-    const canWrite = isSandbox ? false : allowWrite
-    // A sandbox has no user project to edit, so a config edit is never granted there.
-    const canEditConfig = isSandbox ? false : allowConfigEdit
-    // `configPath` is relative to the agent's root unless it is already absolute, which is what
-    // `resolve` does on its own.
-    const configFilePath = path.resolve(root, configPath)
-    // A sandbox agent always generates from the spec Studio supplies; a local agent only when opted in.
-    const canUseInput = isSandbox || allowInput
-    // Tracks whether the studio server explicitly disconnected us (no reconnect needed)
-    let serverDisconnected = false
-    // Guards against a second `generate` command starting while one is already running.
-    // Without this, two concurrent `generate()` calls share this socket via `setupEventsStream`,
-    // and their events interleave with no way for Studio to tell the two runs apart.
-    let isGenerating = false
-    let heartbeatTimer: ReturnType<typeof setInterval> | undefined
-    // Tracks socket liveness: Studio replies to every ping with a pong. When pongs stop
-    // arriving the connection is half-open (e.g. dropped during a Studio deploy) and must
-    // be terminated so the reconnect loop can establish a fresh session.
-    let lastPongAt = Date.now()
+    // Announce readiness without waiting for a `studio:connect` command. The command from the
+    // Studio UI is lost when it is sent while the agent is not attached to the session (e.g.
+    // reconnecting after a deploy), so the agent introduces itself on every open.
+    try {
+      await this.#sendConnectedPayload()
+    } catch (error) {
+      await this.#hooks.callHook('studio:warn', { message: `Failed to send the connect payload: ${getErrorMessage(error)}` })
+    }
+  }
 
-    const onAbort = () => void teardown({ reason: 'shutdown', retry: false })
+  // `addEventListener` drops the returned promise, so a host whose logger throws would take the
+  // process down with an unhandled rejection instead of just losing a line of output. Nothing is
+  // left to report it with at that point, which is why this swallows.
+  #onOpen = (): void => void this.#handleOpen().catch(() => {})
 
-    function cleanup(reason = 'cleanup') {
-      clearInterval(heartbeatTimer)
-      heartbeatTimer = undefined
+  #onAbort = (): void => void this.#teardown({ reason: 'shutdown', retry: false })
 
-      // This connection is over, so its shutdown listener must go with it. Otherwise every
-      // reconnect leaves one behind on a signal that only fires at process exit.
-      signal?.removeEventListener('abort', onAbort)
+  #cleanup(reason = 'cleanup'): void {
+    clearInterval(this.#heartbeatTimer)
+    this.#heartbeatTimer = undefined
 
-      hooks.removeAllHooks()
+    // This connection is over, so its shutdown listener must go with it. Otherwise every
+    // reconnect leaves one behind on a signal that only fires at process exit.
+    this.#signal?.removeEventListener('abort', this.#onAbort)
 
-      try {
-        ws.close(1000, reason)
-      } catch {}
+    this.#hooks.removeAllHooks()
 
-      ws.removeEventListener('open', onOpen)
-      ws.removeEventListener('close', onClose)
-      ws.removeEventListener('error', onError)
-      ws.removeEventListener('message', onMessage)
+    const ws = this.#ws
+    if (!ws) {
+      return
     }
 
-    /**
-     * Reads `kubb.config.ts` and reports which plugin options Studio may edit.
-     *
-     * Skipped when the host did not grant `allowConfigEdit`. The patcher pulls in `magicast`
-     * (~25ms, ~55MB RSS), so read-only agents never import it.
-     *
-     * Not cached: the user can edit the file between two Studio actions.
-     */
-    async function readConfigFileView(source?: string): Promise<ConfigFileView | undefined> {
-      if (!canEditConfig) {
-        return undefined
-      }
+    try {
+      ws.close(1000, reason)
+    } catch {}
 
-      try {
-        const { readConfig } = await import('./configFile.ts')
+    ws.removeEventListener('open', this.#onOpen)
+    ws.removeEventListener('close', this.#onClose)
+    ws.removeEventListener('error', this.#onError)
+    ws.removeEventListener('message', this.#onMessage)
+  }
 
-        return readConfig(source ?? (await readFile(configFilePath, 'utf-8')))
-      } catch (error) {
-        await hooks.callHook('studio:warn', { message: `Could not read ${configFilePath}: ${getErrorMessage(error)}` })
+  /**
+   * Drops the socket and tells Studio the session is over. `#serverDisconnected` guards against
+   * the close event running this a second time, and against a shutdown reconnecting.
+   */
+  async #teardown({ reason, retry }: { reason?: string; retry: boolean }): Promise<void> {
+    if (this.#serverDisconnected) {
+      return
+    }
+    this.#serverDisconnected = true
 
-        return undefined
-      }
+    // Announce the shutdown while the socket is still open, so Studio marks the session offline
+    // now instead of waiting out the heartbeat window. `sendAgentMessage` is a no-op on a socket
+    // that has already closed, which is every other way we get here.
+    if (reason === 'shutdown' && this.#ws) {
+      sendAgentMessage(this.#ws, { type: 'agent:disconnect', reason: 'shutdown' })
     }
 
-    async function sendConnectedPayload() {
-      const config = await loadConfig()
+    this.#cleanup(reason)
+    // Already tearing down, so a failed disconnect changes nothing.
+    await disconnect({ sessionId: this.#sessionId, studioUrl: this.#studioUrl, token: this.#token, slug: this.#slug }).catch(() => {})
+
+    if (retry) {
+      reconnect(this.#options)
+    }
+  }
+
+  #onClose = (): void => void this.#teardown({ retry: true })
+
+  #onError = (): void => {
+    void this.#hooks.callHook('studio:error', { error: new Error('Failed to connect to Kubb Studio') })
+
+    this.#onClose()
+  }
+
+  #onMessage = async (message: WebSocket.MessageEvent): Promise<void> => {
+    try {
+      const data = JSON.parse(message.data as string) as AgentMessage
+
+      if (isStudioPingMessage(data)) {
+        this.#lastPongAt = Date.now()
+
+        return
+      }
+
+      if (isDisconnectMessage(data)) {
+        await this.#hooks.callHook('studio:disconnected', { reason: data.reason })
+
+        if (data.reason === 'revoked') {
+          this.#cleanup(`session_${data.reason}`)
+          return
+        }
+
+        if (data.reason === 'expired') {
+          this.#cleanup()
+          reconnect(this.#options)
+
+          return
+        }
+
+        return
+      }
+
+      if (isCommandMessage(data)) {
+        await this.#handleCommand(data)
+
+        return
+      }
+
+      await this.#hooks.callHook('studio:warn', { message: `Ignored an unknown message from Kubb Studio: ${data.type}` })
+    } catch (error) {
+      await this.#hooks.callHook('studio:error', { error: toError(error) })
+
+      // Errors thrown before `generate()` runs (e.g. config loading, plugin resolution) never
+      // reach `generate()`'s own `kubb:error` emission, so without this the Studio UI shows
+      // nothing while the agent silently fails. Forward them on the connection-level `#hooks`
+      // emitter, already wired to this socket via `setupEventsStream`.
+      await Promise.resolve(this.#hooks.callHook('kubb:error', { error: toError(error) })).catch(() => {})
+    }
+  }
+
+  async #handleCommand(data: AgentMessage & { type: `studio:${string}` }): Promise<void> {
+    const ws = this.#ws
+    if (!ws) {
+      return
+    }
+
+    // Every command type is `studio:<verb>`, so the verb alone is what a host wants to show.
+    const command = data.type.slice('studio:'.length)
+
+    await this.#hooks.callHook('studio:command:start', { command })
+
+    if (data.type === 'studio:generate') {
+      await this.#handleGenerate(data, command)
+
+      return
+    }
+
+    if (data.type === 'studio:connect') {
+      this.#studioVersion = data.version ?? this.#studioVersion
+      await this.#sendConnectedPayload()
+
+      await this.#hooks.callHook('studio:command:end', { command })
+
+      return
+    }
+
+    if (data.type === 'studio:save') {
+      await this.#handleSave(data, command)
+    }
+  }
+
+  async #handleGenerate(data: Extract<AgentMessage, { type: 'studio:generate' }>, command: string): Promise<void> {
+    if (this.#isGenerating) {
+      await this.#hooks.callHook('studio:warn', { message: 'Ignored generate: a generation is already in progress' })
+
+      await Promise.resolve(
+        this.#hooks.callHook('kubb:error', { error: new Error('A generation is already in progress, please wait for it to finish') }),
+      ).catch(() => {})
+
+      return
+    }
+
+    const ws = this.#ws
+    if (!ws) {
+      return
+    }
+
+    this.#isGenerating = true
+
+    try {
+      const config = await this.#loadConfig()
+      const patch = data.payload
+      const plugins = await mergePlugins(config.plugins, patch?.plugins)
+      const adapter = await mergeAdapter(config.adapter, patch?.adapter)
+
+      // A sandbox agent always uses the inline spec (empty string included, since it has no disk
+      // file); a local agent only when opted in, and an empty or absent spec falls back to disk.
+      const inputOverride = this.#isSandbox ? (patch?.input ?? '') : (this.#allowInput && patch?.input) || undefined
+
+      if (this.#allowWrite && this.#isSandbox) {
+        await this.#hooks.callHook('studio:warn', { message: 'Running in a sandbox, so writing files is disabled' })
+      }
+
+      if (patch?.input && !this.#canUseInput) {
+        // The Docker agent reads `allowInput` from `KUBB_AGENT_ALLOW_INPUT`. The CLI grants it
+        // through `--allowInput` or the per-project prompt instead, so each host gets its own remedy.
+        const remedy = this.#client?.kind === 'cli' ? '--allowInput, or answer yes when kubb studio asks,' : 'KUBB_AGENT_ALLOW_INPUT=true'
+        await this.#hooks.callHook('studio:warn', { message: `Ignored the spec from Studio; set ${remedy} to generate from it` })
+      }
+
+      const generationHooks = new Hookable<KubbHooks>()
+      await this.#installLogger?.(generationHooks)
+      setupHookListener(generationHooks, this.#root)
+      setupEventsStream(ws, generationHooks)
+
+      const resolvedPlugins = plugins ?? config.plugins
+
+      await generate({
+        config: {
+          ...config,
+          root: this.#root,
+          input: inputOverride ?? config.input,
+          storage: this.#canWrite ? fsStorage() : memoryStorage(),
+          output: this.#allowExec ? { ...config.output } : { ...config.output, format: false, lint: false, postGenerate: [] },
+          plugins: resolvedPlugins,
+          adapter,
+        },
+        hooks: generationHooks,
+      })
+
+      await this.#hooks.callHook('studio:command:end', {
+        command,
+        info: `${resolvedPlugins.length} plugin${resolvedPlugins.length === 1 ? '' : 's'}, ${this.#canWrite ? 'written to disk' : 'in memory'}${inputOverride !== undefined ? ', from a Studio spec' : ''}`,
+      })
+    } finally {
+      this.#isGenerating = false
+    }
+  }
+
+  async #handleSave(data: Extract<AgentMessage, { type: 'studio:save' }>, command: string): Promise<void> {
+    const ws = this.#ws
+    if (!ws) {
+      return
+    }
+
+    // Studio waits on an `agent:save` for every `studio:save`, so every path out of this function
+    // sends one. `edits` is checked before it is walked: the message crosses the same trust
+    // boundary as the values inside it.
+    if (!Array.isArray(data.edits)) {
+      await this.#hooks.callHook('studio:warn', { message: 'Ignored save: the message carried no edits' })
+
+      sendAgentMessage(ws, { type: 'agent:save', payload: { outcomes: [], changed: false } })
+
+      return
+    }
+
+    const edits = data.edits
+    const refuse = (reason: string) =>
+      sendAgentMessage(ws, {
+        type: 'agent:save',
+        payload: { outcomes: edits.map((edit) => ({ edit, applied: false, reason })), changed: false },
+      })
+
+    if (!this.#canEditConfig) {
+      await this.#hooks.callHook('studio:warn', { message: 'Ignored save: editing kubb.config.ts was not granted' })
+
+      refuse('the agent was not granted permission to edit kubb.config.ts')
+
+      return
+    }
+
+    // A generation reloads the config while it runs, so rewriting the file underneath it would
+    // leave that run working from half the change.
+    if (this.#isGenerating) {
+      refuse('a generation is in progress')
+
+      return
+    }
+
+    try {
+      // Read straight before the patch rather than reusing what went out on connect. The user may
+      // have edited the file since, and since every untouched node keeps its own text, patching
+      // what is on disk right now preserves that edit.
+      const { applyConfigEdits } = await import('./configFile.ts')
+      const current = await readFile(this.#configFilePath, 'utf-8')
+      const { source: patched, outcomes, changed } = applyConfigEdits(current, edits)
+
+      if (changed) {
+        await writeFile(this.#configFilePath, patched, 'utf-8')
+      }
 
       sendAgentMessage(ws, {
-        type: 'agent:connect',
-        payload: {
-          versions: { kubb: kubbVersion, agent: version },
-          root,
-          config: {
-            path: configPath,
-            file: await readConfigFileView(),
-            plugins: config.plugins.map((plugin) => ({
-              name: `@kubb/${plugin.name}`,
-              // Functions and symbols in plugin options are dropped by `JSON.stringify` on the way out.
-              options: plugin.options ?? {},
-            })),
-          },
-          permissions: {
-            allowWrite: canWrite,
-            allowInput: canUseInput,
-            allowExec,
-            allowConfigEdit: canEditConfig,
-          },
-        },
+        type: 'agent:save',
+        payload: { outcomes, changed, file: changed ? await this.#readConfigFileView(patched) : undefined },
       })
+
+      const applied = outcomes.filter((outcome) => outcome.applied).length
+      await this.#hooks.callHook('studio:command:end', { command, info: `applied ${applied}/${outcomes.length} edits to ${this.#configPath}` })
+    } catch (error) {
+      // An unreadable config, a read-only filesystem. Reported as a refusal of every edit so
+      // Studio hears back rather than waiting on a reply that never comes.
+      await this.#hooks.callHook('studio:error', { error: toError(error) })
+
+      refuse(getErrorMessage(error))
     }
-
-    async function handleOpen() {
-      lastPongAt = Date.now()
-      await hooks.callHook('studio:connected', { url: studioUrl, versions: { studio: studioVersion, kubb: kubbVersion, agent: version } })
-
-      // Announce readiness without waiting for a `studio:connect` command. The command from the
-      // Studio UI is lost when it is sent while the agent is not attached to the session
-      // (e.g. reconnecting after a deploy), so the agent introduces itself on every open.
-      try {
-        await sendConnectedPayload()
-      } catch (error) {
-        await hooks.callHook('studio:warn', { message: `Failed to send the connect payload: ${getErrorMessage(error)}` })
-      }
-    }
-
-    // `addEventListener` drops the returned promise, so a host whose logger throws would take the
-    // process down with an unhandled rejection instead of just losing a line of output. Nothing is
-    // left to report it with at that point, which is why this swallows.
-    const onOpen = () => void handleOpen().catch(() => {})
-
-    /**
-     * Drops the socket and tells Studio the session is over. `serverDisconnected` guards against
-     * the close event running this a second time, and against a shutdown reconnecting.
-     */
-    async function teardown({ reason, retry }: { reason?: string; retry: boolean }) {
-      if (serverDisconnected) {
-        return
-      }
-      serverDisconnected = true
-
-      // Announce the shutdown while the socket is still open, so Studio marks the session offline
-      // now instead of waiting out the heartbeat window. `sendAgentMessage` is a no-op on a socket
-      // that has already closed, which is every other way we get here.
-      if (reason === 'shutdown') {
-        sendAgentMessage(ws, { type: 'agent:disconnect', reason: 'shutdown' })
-      }
-
-      cleanup(reason)
-      // Already tearing down, so a failed disconnect changes nothing.
-      await disconnect({ sessionId, studioUrl, token, slug }).catch(() => {})
-
-      if (retry) {
-        reconnect(options)
-      }
-    }
-
-    const onClose = () => teardown({ retry: true })
-
-    const onError = () => {
-      void hooks.callHook('studio:error', { error: new Error('Failed to connect to Kubb Studio') })
-
-      return onClose()
-    }
-
-    ws.addEventListener('open', onOpen)
-    ws.addEventListener('close', onClose)
-    ws.addEventListener('error', onError)
-    // The socket's own close event fires after this, and `teardown` is idempotent, so the shutdown
-    // path cannot be turned into a reconnect by the close that follows it.
-    signal?.addEventListener('abort', onAbort, { once: true })
-
-    heartbeatTimer = setInterval(() => {
-      // Two consecutive missed pongs mean the socket is dead even though no close event
-      // arrived. Terminate (not close) so a half-open TCP connection can't linger. The
-      // resulting close event triggers cleanup and the reconnect loop.
-      if (Date.now() - lastPongAt > heartbeatInterval * 2) {
-        void hooks.callHook('studio:warn', { message: 'No reply from Kubb Studio, terminating the stale connection' })
-        // Stop the timer here rather than waiting for cleanup(), since the close event can lag,
-        // and until it runs this interval would re-terminate and re-log every tick.
-        clearInterval(heartbeatTimer)
-        heartbeatTimer = undefined
-        ws.terminate()
-
-        return
-      }
-
-      sendAgentMessage(ws, { type: 'agent:ping' })
-    }, heartbeatInterval)
-
-    // Only `kubb:error` is ever fired on the connection emitter. Every generation event goes
-    // through its own emitter below, so it gets that one listener rather than the full stream.
-    hooks.hook('kubb:error', ({ error }) => sendErrorMessage(ws, error))
-
-    const onMessage = async (message: WebSocket.MessageEvent) => {
-      try {
-        const data = JSON.parse(message.data as string) as AgentMessage
-
-        if (isStudioPingMessage(data)) {
-          lastPongAt = Date.now()
-
-          return
-        }
-
-        if (isDisconnectMessage(data)) {
-          await hooks.callHook('studio:disconnected', { reason: data.reason })
-
-          if (data.reason === 'revoked') {
-            cleanup(`session_${data.reason}`)
-            return
-          }
-
-          if (data.reason === 'expired') {
-            cleanup()
-            reconnect(options)
-
-            return
-          }
-
-          return
-        }
-
-        if (isCommandMessage(data)) {
-          // Every command type is `studio:<verb>`, so the verb alone is what a host wants to show.
-          const command = data.type.slice('studio:'.length)
-
-          await hooks.callHook('studio:command:start', { command })
-
-          if (data.type === 'studio:generate') {
-            if (isGenerating) {
-              await hooks.callHook('studio:warn', { message: 'Ignored generate: a generation is already in progress' })
-
-              await Promise.resolve(
-                hooks.callHook('kubb:error', { error: new Error('A generation is already in progress, please wait for it to finish') }),
-              ).catch(() => {})
-
-              return
-            }
-
-            isGenerating = true
-
-            try {
-              const config = await loadConfig()
-              const patch = data.payload
-              const plugins = await mergePlugins(config.plugins, patch?.plugins)
-              const adapter = await mergeAdapter(config.adapter, patch?.adapter)
-
-              // A sandbox agent always uses the inline spec (empty string included, since it has no disk
-              // file); a local agent only when opted in, and an empty or absent spec falls back to disk.
-              const inputOverride = isSandbox ? (patch?.input ?? '') : (allowInput && patch?.input) || undefined
-
-              if (allowWrite && isSandbox) {
-                await hooks.callHook('studio:warn', { message: 'Running in a sandbox, so writing files is disabled' })
-              }
-
-              if (patch?.input && !canUseInput) {
-                // The Docker agent reads `allowInput` from `KUBB_AGENT_ALLOW_INPUT`. The CLI grants it
-                // through `--allowInput` or the per-project prompt instead, so each host gets its own remedy.
-                const remedy = client?.kind === 'cli' ? '--allowInput, or answer yes when kubb studio asks,' : 'KUBB_AGENT_ALLOW_INPUT=true'
-                await hooks.callHook('studio:warn', { message: `Ignored the spec from Studio; set ${remedy} to generate from it` })
-              }
-
-              const generationHooks = new Hookable<KubbHooks>()
-              await installLogger?.(generationHooks)
-              setupHookListener(generationHooks, root)
-              setupEventsStream(ws, generationHooks)
-
-              const resolvedPlugins = plugins ?? config.plugins
-
-              await generate({
-                config: {
-                  ...config,
-                  root,
-                  input: inputOverride ?? config.input,
-                  storage: canWrite ? fsStorage() : memoryStorage(),
-                  output: allowExec ? { ...config.output } : { ...config.output, format: false, lint: false, postGenerate: [] },
-                  plugins: resolvedPlugins,
-                  adapter,
-                },
-                hooks: generationHooks,
-              })
-
-              await hooks.callHook('studio:command:end', {
-                command,
-                info: `${resolvedPlugins.length} plugin${resolvedPlugins.length === 1 ? '' : 's'}, ${canWrite ? 'written to disk' : 'in memory'}${inputOverride !== undefined ? ', from a Studio spec' : ''}`,
-              })
-            } finally {
-              isGenerating = false
-            }
-
-            return
-          }
-
-          if (data.type === 'studio:connect') {
-            studioVersion = data.version ?? studioVersion
-            await sendConnectedPayload()
-
-            await hooks.callHook('studio:command:end', { command })
-
-            return
-          }
-
-          if (data.type === 'studio:save') {
-            // Studio waits on an `agent:save` for every `studio:save`, so every path out of this
-            // branch sends one. `edits` is checked before it is walked: the message crosses the same
-            // trust boundary as the values inside it.
-            if (!Array.isArray(data.edits)) {
-              await hooks.callHook('studio:warn', { message: 'Ignored save: the message carried no edits' })
-
-              sendAgentMessage(ws, { type: 'agent:save', payload: { outcomes: [], changed: false } })
-
-              return
-            }
-
-            const edits = data.edits
-            const refuse = (reason: string) =>
-              sendAgentMessage(ws, {
-                type: 'agent:save',
-                payload: { outcomes: edits.map((edit) => ({ edit, applied: false, reason })), changed: false },
-              })
-
-            if (!canEditConfig) {
-              await hooks.callHook('studio:warn', { message: 'Ignored save: editing kubb.config.ts was not granted' })
-
-              refuse('the agent was not granted permission to edit kubb.config.ts')
-
-              return
-            }
-
-            // A generation reloads the config while it runs, so rewriting the file underneath it
-            // would leave that run working from half the change.
-            if (isGenerating) {
-              refuse('a generation is in progress')
-
-              return
-            }
-
-            try {
-              // Read straight before the patch rather than reusing what went out on connect. The user
-              // may have edited the file since, and since every untouched node keeps its own text,
-              // patching what is on disk right now preserves that edit.
-              const { applyConfigEdits } = await import('./configFile.ts')
-              const current = await readFile(configFilePath, 'utf-8')
-              const { source: patched, outcomes, changed } = applyConfigEdits(current, edits)
-
-              if (changed) {
-                await writeFile(configFilePath, patched, 'utf-8')
-              }
-
-              sendAgentMessage(ws, {
-                type: 'agent:save',
-                payload: { outcomes, changed, file: changed ? await readConfigFileView(patched) : undefined },
-              })
-
-              const applied = outcomes.filter((outcome) => outcome.applied).length
-              await hooks.callHook('studio:command:end', { command, info: `applied ${applied}/${outcomes.length} edits to ${configPath}` })
-            } catch (error) {
-              // An unreadable config, a read-only filesystem. Reported as a refusal of every edit so
-              // Studio hears back rather than waiting on a reply that never comes.
-              await hooks.callHook('studio:error', { error: toError(error) })
-
-              refuse(getErrorMessage(error))
-            }
-
-            return
-          }
-
-          return
-        }
-
-        await hooks.callHook('studio:warn', { message: `Ignored an unknown message from Kubb Studio: ${data.type}` })
-      } catch (error) {
-        await hooks.callHook('studio:error', { error: toError(error) })
-
-        // Errors thrown before `generate()` runs (e.g. config loading, plugin resolution)
-        // never reach `generate()`'s own `kubb:error` emission, so without this the Studio
-        // UI shows nothing while the agent silently fails. Forward them on the connection-level
-        // `hooks` emitter, already wired to this socket via `setupEventsStream`.
-        await Promise.resolve(hooks.callHook('kubb:error', { error: toError(error) })).catch(() => {})
-      }
-    }
-    ws.addEventListener('message', onMessage)
-  } catch (error) {
-    // Reaching here means the session was never created (Studio down, a 502 mid-deploy), so no
-    // socket exists and none of the socket-driven reconnect paths can fire. Retry from here or the
-    // slot is dropped for the lifetime of the process.
-    await hooks.callHook('studio:error', { error: toError(error) })
-
-    if (error instanceof InvalidAgentTokenError) {
-      throw error
-    }
-
-    reconnect(options)
   }
+}
+
+export async function connectToStudio(options: ConnectToStudioOptions): Promise<void> {
+  await new StudioSession(options).connect()
 }

--- a/packages/studio/src/connectStudio.ts
+++ b/packages/studio/src/connectStudio.ts
@@ -135,6 +135,7 @@ class StudioSession {
   readonly #version: string
   readonly #client: ClientInfo | undefined
   readonly #allowWrite: boolean
+  readonly #allowConfigEdit: boolean
   readonly #allowInput: boolean
   readonly #allowExec: boolean
   readonly #root: string
@@ -183,6 +184,7 @@ class StudioSession {
     this.#client = options.client
     // Every permission is off unless the host grants it.
     this.#allowWrite = options.allowWrite ?? false
+    this.#allowConfigEdit = options.allowConfigEdit ?? false
     this.#allowInput = options.allowInput ?? false
     this.#allowExec = options.allowExec ?? false
     this.#root = options.root ?? process.cwd()
@@ -209,7 +211,7 @@ class StudioSession {
       this.#studioVersion = sessionStudioVersion
       this.#isSandbox = isSandbox
       this.#canWrite = isSandbox ? false : this.#allowWrite
-      this.#canEditConfig = isSandbox ? false : (this.#options.allowConfigEdit ?? false)
+      this.#canEditConfig = isSandbox ? false : this.#allowConfigEdit
       // `configPath` is relative to the agent's root unless it is already absolute, which is what
       // `resolve` does on its own.
       this.#configFilePath = path.resolve(this.#root, this.#configPath)
@@ -417,11 +419,16 @@ class StudioSession {
         await this.#hooks.callHook('studio:disconnected', { reason: data.reason })
 
         if (data.reason === 'revoked') {
+          // `#cleanup` already unhooks the socket's own `close` listener before returning, which is
+          // what actually keeps a real `close` event from re-entering `#teardown`. Set regardless,
+          // so this path stays safe against `#teardown` being reached some other way later.
+          this.#serverDisconnected = true
           this.#cleanup(`session_${data.reason}`)
           return
         }
 
         if (data.reason === 'expired') {
+          this.#serverDisconnected = true
           this.#cleanup()
           reconnect(this.#options)
 
@@ -461,7 +468,7 @@ class StudioSession {
     await this.#hooks.callHook('studio:command:start', { command })
 
     if (data.type === 'studio:generate') {
-      await this.#handleGenerate(data, command)
+      await this.#handleGenerate(ws, data, command)
 
       return
     }
@@ -476,11 +483,11 @@ class StudioSession {
     }
 
     if (data.type === 'studio:save') {
-      await this.#handleSave(data, command)
+      await this.#handleSave(ws, data, command)
     }
   }
 
-  async #handleGenerate(data: Extract<AgentMessage, { type: 'studio:generate' }>, command: string): Promise<void> {
+  async #handleGenerate(ws: WebSocket, data: Extract<AgentMessage, { type: 'studio:generate' }>, command: string): Promise<void> {
     if (this.#isGenerating) {
       await this.#hooks.callHook('studio:warn', { message: 'Ignored generate: a generation is already in progress' })
 
@@ -488,11 +495,6 @@ class StudioSession {
         this.#hooks.callHook('kubb:error', { error: new Error('A generation is already in progress, please wait for it to finish') }),
       ).catch(() => {})
 
-      return
-    }
-
-    const ws = this.#ws
-    if (!ws) {
       return
     }
 
@@ -548,12 +550,7 @@ class StudioSession {
     }
   }
 
-  async #handleSave(data: Extract<AgentMessage, { type: 'studio:save' }>, command: string): Promise<void> {
-    const ws = this.#ws
-    if (!ws) {
-      return
-    }
-
+  async #handleSave(ws: WebSocket, data: Extract<AgentMessage, { type: 'studio:save' }>, command: string): Promise<void> {
     // Studio waits on an `agent:save` for every `studio:save`, so every path out of this function
     // sends one. `edits` is checked before it is walked: the message crosses the same trust
     // boundary as the values inside it.

--- a/packages/studio/src/connectStudio.ts
+++ b/packages/studio/src/connectStudio.ts
@@ -93,17 +93,16 @@ type ResolvedOptions = ConnectToStudioOptions & {
   retryInterval: number
   heartbeatInterval: number
   /**
-   * Absolute path to the config file, for reading and patching it. `configPath` stays as the host
-   * gave it, since that is the project-relative form Studio shows.
+   * Absolute path to the config file, for reading and patching it. `configPath` keeps the form the
+   * host gave, which is what Studio shows.
    */
   configFile: string
 }
 
 /**
- * Fills in the defaults a session needs from a host's options: the hosted Studio URL, the current
- * working directory, and every permission off unless granted.
- *
- * Idempotent, so a reconnect can hand an already-resolved bag straight back in.
+ * Fills in a host's options: the hosted Studio URL, the current working directory, and every
+ * permission off unless granted. Idempotent, so a reconnect can pass an already-resolved bag
+ * back in.
  */
 function applyStudioDefaults(options: ConnectToStudioOptions): ResolvedOptions {
   const root = options.root ?? process.cwd()
@@ -175,11 +174,8 @@ function reconnect(options: ResolvedOptions): void {
 }
 
 /**
- * One WebSocket session with Studio: opening it, keeping it alive, and running whatever Studio
- * sends over it. `connectToStudio` is the module's only public entry point; this class exists so
- * that session's several pieces of mutable state (the socket, the heartbeat timer, whether a
- * generation is running) live as fields instead of a pile of closed-over `let`s, matching how
- * `KubbDriver` holds a single build's state in `@kubb/core`.
+ * One WebSocket session with Studio: opening it, keeping it alive, and running the commands it
+ * sends. Reached through `connectToStudio`, the module's only export.
  */
 class StudioSession {
   readonly #options: ResolvedOptions
@@ -193,8 +189,8 @@ class StudioSession {
   readonly #unhooks: Array<() => void> = []
 
   /**
-   * What Studio handed back. Set once `createAgentSession` resolves, and the marker for whether a
-   * session exists at all: until then there is nothing to disconnect and no sandbox flag to read.
+   * What `createAgentSession` handed back, and the marker for whether a session exists at all.
+   * Before it resolves there is nothing to disconnect and no sandbox flag to read.
    */
   #session: AgentConnectResponse | undefined
   #ws: WebSocket | undefined
@@ -220,8 +216,7 @@ class StudioSession {
   }
 
   /**
-   * A sandbox agent runs on Studio's own infrastructure, so it has no user project: it never
-   * writes to disk and never edits a config file that is not there.
+   * A sandbox agent runs on Studio's own infrastructure, so it has no user project to touch.
    */
   get #isSandbox(): boolean {
     return this.#session?.isSandbox === true
@@ -236,7 +231,8 @@ class StudioSession {
   }
 
   /**
-   * A sandbox agent always generates from the spec Studio supplies; a local agent only when opted in.
+   * A sandbox agent always generates from the spec Studio supplies. A local agent only when the
+   * host opted in.
    */
   get #canUseInput(): boolean {
     return this.#isSandbox || this.#options.allowInput
@@ -265,10 +261,9 @@ class StudioSession {
       this.#listen(ws, 'error', this.#onError)
       this.#listen(ws, 'message', this.#onMessage)
 
-      // The socket's own close event fires after this, and `#end` is idempotent, so the shutdown
-      // path cannot be turned into a reconnect by the close that follows it. Tracked like every
-      // other listener: the signal itself only fires at process exit, so a reconnect that left one
-      // behind would pile them up for the life of the process.
+      // `#end` is idempotent, so the close event that follows a shutdown cannot turn it into a
+      // reconnect. Tracked like the socket's own listeners: the signal fires once at process exit,
+      // so one left behind per reconnect would pile up.
       signal?.addEventListener('abort', this.#onAbort, { once: true })
       this.#unhooks.push(() => signal?.removeEventListener('abort', this.#onAbort))
 
@@ -308,8 +303,8 @@ class StudioSession {
   }
 
   /**
-   * Forwards a failure to Studio over the connection emitter, which `setupEventsStream` has
-   * already wired to this socket. Swallows a listener's own failure: this is already the error path.
+   * Forwards a failure to Studio over the connection emitter, which `connect` wired to this
+   * socket. Swallows a listener's own failure, since this is already the error path.
    */
   #emitError(error: Error): Promise<void> {
     return Promise.resolve(this.#hooks.callHook('kubb:error', { error })).catch(() => {})
@@ -426,7 +421,7 @@ class StudioSession {
 
   /**
    * Drops the socket and detaches every listener and timer this session added. Idempotent, and
-   * safe to call before `connect` ever opened anything.
+   * safe before `connect` opened anything.
    *
    * @internal
    */
@@ -445,9 +440,8 @@ class StudioSession {
   }
 
   /**
-   * Ends the session: tells Studio it is over, disposes of the socket, and optionally schedules a
-   * reconnect. `#disposed` guards against the close event running this a second time, and against
-   * a shutdown reconnecting.
+   * Ends the session: tells Studio it is over, drops the socket, and optionally reconnects.
+   * `#disposed` keeps the close event from running this twice, and a shutdown from reconnecting.
    */
   async #end({ reason, retry }: { reason?: string; retry: boolean }): Promise<void> {
     const { studioUrl, token } = this.#options

--- a/packages/studio/src/connectStudio.ts
+++ b/packages/studio/src/connectStudio.ts
@@ -63,6 +63,12 @@ export type ConnectToStudioOptions = {
    * the runtime prints nothing, which is what a library should default to.
    */
   installLogger?: (hooks: Hookable<KubbHooks>) => void | Promise<void>
+  /**
+   * Called when a background reconnect is rejected with an invalid token. Wired in by
+   * `createClient`, which wraps it to fire once per pool and stop every session; not meant to be
+   * set directly by a host.
+   */
+  onAuthRequired?: (error: InvalidAgentTokenError) => void
 }
 
 /**
@@ -73,7 +79,7 @@ export type ConnectToStudioOptions = {
  * alive for the length of every retry interval.
  */
 function reconnect(options: ConnectToStudioOptions): void {
-  const { signal, retryInterval = agentDefaults.retryIntervalMs } = options
+  const { signal, retryInterval = agentDefaults.retryIntervalMs, onAuthRequired } = options
 
   if (signal?.aborted) {
     return
@@ -97,7 +103,11 @@ function reconnect(options: ConnectToStudioOptions): void {
       console.error(styleText('red', `Reconnect attempt to Kubb Studio failed: ${getErrorMessage(error)}`))
 
       // A rejected token stays rejected, so retrying only spams 401s until the process is killed.
+      // The host learns about it here instead: the startup path already reports its own rejection
+      // by throwing, so only the background path needs the callback.
       if (error instanceof InvalidAgentTokenError) {
+        onAuthRequired?.(error)
+
         return
       }
 

--- a/packages/studio/src/connectStudio.ts
+++ b/packages/studio/src/connectStudio.ts
@@ -16,6 +16,7 @@ import {
   isStudioPingMessage,
 } from './protocol/index.ts'
 import { createAgentSession, disconnect, InvalidAgentTokenError } from './api.ts'
+import { applyConfigEdits, readConfig } from './configFile.ts'
 import { generate } from './generate.ts'
 import { agentDefaults } from './constants.ts'
 import { mergeAdapter, mergePlugins } from './resolveConfig.ts'
@@ -333,10 +334,8 @@ class StudioSession {
   /**
    * Reads `kubb.config.ts` and reports which plugin options Studio may edit.
    *
-   * Skipped when the host did not grant `allowConfigEdit`. The patcher pulls in `magicast`
-   * (~25ms, ~55MB RSS), so read-only agents never import it.
-   *
-   * Not cached: the user can edit the file between two Studio actions.
+   * Skipped when the host did not grant `allowConfigEdit`. Not cached: the user can edit the file
+   * between two Studio actions.
    */
   async #readConfigFileView(source?: string): Promise<ConfigFileView | undefined> {
     if (!this.#canEditConfig) {
@@ -344,8 +343,6 @@ class StudioSession {
     }
 
     try {
-      const { readConfig } = await import('./configFile.ts')
-
       return readConfig(source ?? (await read(this.#options.configFile)))
     } catch (error) {
       await this.#warn(`Could not read ${this.#options.configFile}: ${getErrorMessage(error)}`)
@@ -655,7 +652,6 @@ class StudioSession {
       // Read straight before the patch rather than reusing what went out on connect. The user may
       // have edited the file since, and since every untouched node keeps its own text, patching
       // what is on disk right now preserves that edit.
-      const { applyConfigEdits } = await import('./configFile.ts')
       const current = await read(configFile)
       const { source: patched, outcomes, changed } = applyConfigEdits(current, edits)
 

--- a/packages/studio/src/connectStudio.ts
+++ b/packages/studio/src/connectStudio.ts
@@ -1,12 +1,19 @@
-import { readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
 import { styleText } from 'node:util'
-import { getErrorMessage, toError } from '@internals/utils'
+import { getErrorMessage, read, toError, write } from '@internals/utils'
 import { type Config, fsStorage, Hookable, type KubbHooks, memoryStorage } from '@kubb/core'
 import { version as kubbVersion } from '../package.json'
 import { setupHookListener } from './hooks.ts'
-import { type AgentMessage, type ClientInfo, type ConfigFileView, isCommandMessage, isDisconnectMessage, isStudioPingMessage } from './protocol/index.ts'
+import {
+  type AgentConnectResponse,
+  type AgentMessage,
+  type ClientInfo,
+  type ConfigFileView,
+  isCommandMessage,
+  isDisconnectMessage,
+  isStudioPingMessage,
+} from './protocol/index.ts'
 import { createAgentSession, disconnect, InvalidAgentTokenError } from './api.ts'
 import { generate } from './generate.ts'
 import { agentDefaults } from './constants.ts'
@@ -73,14 +80,61 @@ export type ConnectToStudioOptions = {
 }
 
 /**
+ * A session's options with every default filled in, so nothing downstream repeats a fallback.
+ */
+type ResolvedOptions = ConnectToStudioOptions & {
+  studioUrl: string
+  root: string
+  allowWrite: boolean
+  allowConfigEdit: boolean
+  allowInput: boolean
+  allowExec: boolean
+  retryInterval: number
+  heartbeatInterval: number
+  /**
+   * Absolute path to the config file, for reading and patching it. `configPath` stays as the host
+   * gave it, since that is the project-relative form Studio shows.
+   */
+  configFile: string
+}
+
+/**
+ * Fills in the defaults a session needs from a host's options: the hosted Studio URL, the current
+ * working directory, and every permission off unless granted.
+ *
+ * Idempotent, so a reconnect can hand an already-resolved bag straight back in.
+ */
+function applyStudioDefaults(options: ConnectToStudioOptions): ResolvedOptions {
+  const root = options.root ?? process.cwd()
+
+  return {
+    ...options,
+    studioUrl: options.studioUrl ?? agentDefaults.studioUrl,
+    root,
+    // `configPath` is relative to the agent's root unless it is already absolute, which is what
+    // `resolve` does on its own.
+    configFile: path.resolve(root, options.configPath),
+    allowWrite: options.allowWrite ?? false,
+    allowConfigEdit: options.allowConfigEdit ?? false,
+    allowInput: options.allowInput ?? false,
+    allowExec: options.allowExec ?? false,
+    retryInterval: options.retryInterval ?? agentDefaults.retryIntervalMs,
+    // Studio counts an agent offline once its last ping is older than its liveness window, so a
+    // slower cadence would make a healthy agent invisible. Clamped here rather than in a host's
+    // env parsing, so every host is held to the contract.
+    heartbeatInterval: Math.min(options.heartbeatInterval ?? agentDefaults.heartbeatIntervalMs, agentDefaults.heartbeatIntervalMs),
+  }
+}
+
+/**
  * Schedules another connection attempt.
  *
  * A free function rather than a method: a pending retry timer reaches whatever it closes over, so
  * closing only over `options` (not a `StudioSession`) keeps a queued retry from pinning a closed
  * socket, its hook emitter, or its session id alive for the length of the retry interval.
  */
-function reconnect(options: ConnectToStudioOptions): void {
-  const { signal, retryInterval = agentDefaults.retryIntervalMs, onTokenRejected } = options
+function reconnect(options: ResolvedOptions): void {
+  const { signal, retryInterval, onTokenRejected } = options
 
   if (signal?.aborted) {
     return
@@ -127,43 +181,29 @@ function reconnect(options: ConnectToStudioOptions): void {
  * `KubbDriver` holds a single build's state in `@kubb/core`.
  */
 class StudioSession {
-  readonly #options: ConnectToStudioOptions
-  readonly #token: string
-  readonly #studioUrl: string
-  readonly #configPath: string
-  readonly #loadConfig: () => Promise<Config>
-  readonly #version: string
-  readonly #client: ClientInfo | undefined
-  readonly #allowWrite: boolean
-  readonly #allowConfigEdit: boolean
-  readonly #allowInput: boolean
-  readonly #allowExec: boolean
-  readonly #root: string
-  readonly #heartbeatInterval: number
-  readonly #signal: AbortSignal | undefined
-  readonly #installLogger: ((hooks: Hookable<KubbHooks>) => void | Promise<void>) | undefined
+  readonly #options: ResolvedOptions
   // Each session gets its own isolated event emitter so generation events from one session do not
   // bleed into another session's WebSocket stream.
   readonly #hooks = new Hookable<KubbHooks>()
+  /**
+   * Removers for every listener this session added (socket, shutdown signal, hooks) so `dispose`
+   * detaches them in one pass. Listeners a host attached itself through `installLogger` survive.
+   */
+  readonly #unhooks: Array<() => void> = []
 
-  // Known once `createAgentSession` resolves.
-  #sessionId = ''
-  #slug: string | null | undefined
+  /**
+   * What Studio handed back. Set once `createAgentSession` resolves, and the marker for whether a
+   * session exists at all: until then there is nothing to disconnect and no sandbox flag to read.
+   */
+  #session: AgentConnectResponse | undefined
   #ws: WebSocket | undefined
   // Known before the agent announces itself, and refreshed by a later `studio:connect`, so both
   // sides can be named from the first connect on.
   #studioVersion: string | undefined
-  // Effective permissions: always disabled in sandbox mode.
-  #canWrite = false
-  // A sandbox has no user project to edit, so a config edit is never granted there.
-  #canEditConfig = false
-  #configFilePath = ''
-  // A sandbox agent always generates from the spec Studio supplies; a local agent only when opted in.
-  #canUseInput = false
-  #isSandbox = false
 
-  // Tracks whether the studio server explicitly disconnected us (no reconnect needed).
-  #serverDisconnected = false
+  // Whether the session is over: guards the close event from tearing down twice, and a shutdown
+  // from being turned into a reconnect.
+  #disposed = false
   // Guards against a second `generate` command starting while one is already running. Without
   // this, two concurrent `generate()` calls share this socket via `setupEventsStream`, and their
   // events interleave with no way for Studio to tell the two runs apart.
@@ -175,64 +215,67 @@ class StudioSession {
   #lastPongAt = Date.now()
 
   constructor(options: ConnectToStudioOptions) {
-    this.#options = options
-    this.#token = options.token
-    this.#studioUrl = options.studioUrl ?? agentDefaults.studioUrl
-    this.#configPath = options.configPath
-    this.#loadConfig = options.loadConfig
-    this.#version = options.version
-    this.#client = options.client
-    // Every permission is off unless the host grants it.
-    this.#allowWrite = options.allowWrite ?? false
-    this.#allowConfigEdit = options.allowConfigEdit ?? false
-    this.#allowInput = options.allowInput ?? false
-    this.#allowExec = options.allowExec ?? false
-    this.#root = options.root ?? process.cwd()
-    this.#signal = options.signal
-    this.#installLogger = options.installLogger
-    // Studio counts an agent offline once its last ping is older than its liveness window, so a
-    // slower cadence would make a healthy agent invisible. Clamped here rather than in a host's
-    // env parsing, so every host is held to the contract.
-    this.#heartbeatInterval = Math.min(options.heartbeatInterval ?? agentDefaults.heartbeatIntervalMs, agentDefaults.heartbeatIntervalMs)
+    this.#options = applyStudioDefaults(options)
+  }
+
+  /**
+   * A sandbox agent runs on Studio's own infrastructure, so it has no user project: it never
+   * writes to disk and never edits a config file that is not there.
+   */
+  get #isSandbox(): boolean {
+    return this.#session?.isSandbox === true
+  }
+
+  get #canWrite(): boolean {
+    return !this.#isSandbox && this.#options.allowWrite
+  }
+
+  get #canEditConfig(): boolean {
+    return !this.#isSandbox && this.#options.allowConfigEdit
+  }
+
+  /**
+   * A sandbox agent always generates from the spec Studio supplies; a local agent only when opted in.
+   */
+  get #canUseInput(): boolean {
+    return this.#isSandbox || this.#options.allowInput
   }
 
   async connect(): Promise<void> {
-    await this.#installLogger?.(this.#hooks)
+    const { token, studioUrl, signal, heartbeatInterval, installLogger } = this.#options
+
+    await installLogger?.(this.#hooks)
 
     try {
       // Before the session exists, so a host can cover the wait: `createAgentSession` is a round
       // trip and the socket after it opens without being awaited.
-      await this.#hooks.callHook('studio:connecting', { url: this.#studioUrl })
+      await this.#hooks.callHook('studio:connecting', { url: studioUrl })
 
-      const { sessionId, slug, wsUrl, isSandbox, version: sessionStudioVersion } = await createAgentSession({ token: this.#token, studioUrl: this.#studioUrl })
+      const session = await createAgentSession({ token, studioUrl })
 
-      this.#sessionId = sessionId
-      this.#slug = slug
-      this.#studioVersion = sessionStudioVersion
-      this.#isSandbox = isSandbox
-      this.#canWrite = isSandbox ? false : this.#allowWrite
-      this.#canEditConfig = isSandbox ? false : this.#allowConfigEdit
-      // `configPath` is relative to the agent's root unless it is already absolute, which is what
-      // `resolve` does on its own.
-      this.#configFilePath = path.resolve(this.#root, this.#configPath)
-      this.#canUseInput = isSandbox || this.#allowInput
+      this.#session = session
+      this.#studioVersion = session.version
 
-      const ws = createWebsocket(wsUrl, { headers: { Authorization: `Bearer ${this.#token}` } })
+      const ws = createWebsocket(session.wsUrl, { headers: { Authorization: `Bearer ${token}` } })
       this.#ws = ws
 
-      ws.addEventListener('open', this.#onOpen)
-      ws.addEventListener('close', this.#onClose)
-      ws.addEventListener('error', this.#onError)
-      ws.addEventListener('message', this.#onMessage)
-      // The socket's own close event fires after this, and `#teardown` is idempotent, so the
-      // shutdown path cannot be turned into a reconnect by the close that follows it.
-      this.#signal?.addEventListener('abort', this.#onAbort, { once: true })
+      this.#listen(ws, 'open', this.#onOpen)
+      this.#listen(ws, 'close', this.#onClose)
+      this.#listen(ws, 'error', this.#onError)
+      this.#listen(ws, 'message', this.#onMessage)
 
-      this.#heartbeatTimer = setInterval(() => this.#sendHeartbeat(), this.#heartbeatInterval)
+      // The socket's own close event fires after this, and `#end` is idempotent, so the shutdown
+      // path cannot be turned into a reconnect by the close that follows it. Tracked like every
+      // other listener: the signal itself only fires at process exit, so a reconnect that left one
+      // behind would pile them up for the life of the process.
+      signal?.addEventListener('abort', this.#onAbort, { once: true })
+      this.#unhooks.push(() => signal?.removeEventListener('abort', this.#onAbort))
+
+      this.#heartbeatTimer = setInterval(() => this.#sendHeartbeat(), heartbeatInterval)
 
       // Only `kubb:error` is ever fired on the connection emitter. Every generation event goes
       // through its own emitter below, so it gets that one listener rather than the full stream.
-      this.#hooks.hook('kubb:error', ({ error }) => sendErrorMessage(ws, error))
+      this.#unhooks.push(this.#hooks.hook('kubb:error', ({ error }) => sendErrorMessage(ws, error)))
     } catch (error) {
       // Reaching here means the session was never created (Studio down, a 502 mid-deploy), so no
       // socket exists and none of the socket-driven reconnect paths can fire. Retry from here or
@@ -247,13 +290,37 @@ class StudioSession {
     }
   }
 
+  /**
+   * Adds a socket listener and tracks its remover, so `dispose` detaches every listener at once.
+   */
+  #listen<TEvent extends keyof WebSocket.WebSocketEventMap>(
+    ws: WebSocket,
+    event: TEvent,
+    listener: (event: WebSocket.WebSocketEventMap[TEvent]) => void,
+  ): void {
+    ws.addEventListener(event, listener)
+    this.#unhooks.push(() => ws.removeEventListener(event, listener))
+  }
+
+  #warn(message: string): Promise<void> | void {
+    return this.#hooks.callHook('studio:warn', { message })
+  }
+
+  /**
+   * Forwards a failure to Studio over the connection emitter, which `setupEventsStream` has
+   * already wired to this socket. Swallows a listener's own failure: this is already the error path.
+   */
+  #emitError(error: Error): Promise<void> {
+    return Promise.resolve(this.#hooks.callHook('kubb:error', { error })).catch(() => {})
+  }
+
   #sendHeartbeat(): void {
     // Two consecutive missed pongs mean the socket is dead even though no close event arrived.
     // Terminate (not close) so a half-open TCP connection can't linger. The resulting close event
     // triggers cleanup and the reconnect loop.
-    if (Date.now() - this.#lastPongAt > this.#heartbeatInterval * 2) {
-      void this.#hooks.callHook('studio:warn', { message: 'No reply from Kubb Studio, terminating the stale connection' })
-      // Stop the timer here rather than waiting for `#cleanup`, since the close event can lag, and
+    if (Date.now() - this.#lastPongAt > this.#options.heartbeatInterval * 2) {
+      void this.#warn('No reply from Kubb Studio, terminating the stale connection')
+      // Stop the timer here rather than waiting for `dispose`, since the close event can lag, and
       // until it runs this interval would re-terminate and re-log every tick.
       clearInterval(this.#heartbeatTimer)
       this.#heartbeatTimer = undefined
@@ -283,28 +350,30 @@ class StudioSession {
     try {
       const { readConfig } = await import('./configFile.ts')
 
-      return readConfig(source ?? (await readFile(this.#configFilePath, 'utf-8')))
+      return readConfig(source ?? (await read(this.#options.configFile)))
     } catch (error) {
-      await this.#hooks.callHook('studio:warn', { message: `Could not read ${this.#configFilePath}: ${getErrorMessage(error)}` })
+      await this.#warn(`Could not read ${this.#options.configFile}: ${getErrorMessage(error)}`)
 
       return undefined
     }
   }
 
   async #sendConnectedPayload(): Promise<void> {
+    const { configPath, root, version, loadConfig, allowExec } = this.#options
+
     if (!this.#ws) {
       return
     }
 
-    const config = await this.#loadConfig()
+    const config = await loadConfig()
 
     sendAgentMessage(this.#ws, {
       type: 'agent:connect',
       payload: {
-        versions: { kubb: kubbVersion, agent: this.#version },
-        root: this.#root,
+        versions: { kubb: kubbVersion, agent: version },
+        root,
         config: {
-          path: this.#configPath,
+          path: configPath,
           file: await this.#readConfigFileView(),
           plugins: config.plugins.map((plugin) => ({
             name: `@kubb/${plugin.name}`,
@@ -315,7 +384,7 @@ class StudioSession {
         permissions: {
           allowWrite: this.#canWrite,
           allowInput: this.#canUseInput,
-          allowExec: this.#allowExec,
+          allowExec,
           allowConfigEdit: this.#canEditConfig,
         },
       },
@@ -325,8 +394,8 @@ class StudioSession {
   async #handleOpen(): Promise<void> {
     this.#lastPongAt = Date.now()
     await this.#hooks.callHook('studio:connected', {
-      url: this.#studioUrl,
-      versions: { studio: this.#studioVersion, kubb: kubbVersion, agent: this.#version },
+      url: this.#options.studioUrl,
+      versions: { studio: this.#studioVersion, kubb: kubbVersion, agent: this.#options.version },
     })
 
     // Announce readiness without waiting for a `studio:connect` command. The command from the
@@ -335,7 +404,7 @@ class StudioSession {
     try {
       await this.#sendConnectedPayload()
     } catch (error) {
-      await this.#hooks.callHook('studio:warn', { message: `Failed to send the connect payload: ${getErrorMessage(error)}` })
+      await this.#warn(`Failed to send the connect payload: ${getErrorMessage(error)}`)
     }
   }
 
@@ -344,42 +413,48 @@ class StudioSession {
   // left to report it with at that point, which is why this swallows.
   #onOpen = (): void => void this.#handleOpen().catch(() => {})
 
-  #onAbort = (): void => void this.#teardown({ reason: 'shutdown', retry: false })
+  #onAbort = (): void => void this.#end({ reason: 'shutdown', retry: false })
 
-  #cleanup(reason = 'cleanup'): void {
-    clearInterval(this.#heartbeatTimer)
-    this.#heartbeatTimer = undefined
+  #onClose = (): void => void this.#end({ retry: true })
 
-    // This connection is over, so its shutdown listener must go with it. Otherwise every
-    // reconnect leaves one behind on a signal that only fires at process exit.
-    this.#signal?.removeEventListener('abort', this.#onAbort)
+  #onError = (): void => {
+    void this.#hooks.callHook('studio:error', { error: new Error('Failed to connect to Kubb Studio') })
 
-    this.#hooks.removeAllHooks()
-
-    const ws = this.#ws
-    if (!ws) {
-      return
-    }
-
-    try {
-      ws.close(1000, reason)
-    } catch {}
-
-    ws.removeEventListener('open', this.#onOpen)
-    ws.removeEventListener('close', this.#onClose)
-    ws.removeEventListener('error', this.#onError)
-    ws.removeEventListener('message', this.#onMessage)
+    this.#onClose()
   }
 
   /**
-   * Drops the socket and tells Studio the session is over. `#serverDisconnected` guards against
-   * the close event running this a second time, and against a shutdown reconnecting.
+   * Drops the socket and detaches every listener and timer this session added. Idempotent, and
+   * safe to call before `connect` ever opened anything.
+   *
+   * @internal
    */
-  async #teardown({ reason, retry }: { reason?: string; retry: boolean }): Promise<void> {
-    if (this.#serverDisconnected) {
+  dispose(reason = 'cleanup'): void {
+    clearInterval(this.#heartbeatTimer)
+    this.#heartbeatTimer = undefined
+
+    try {
+      // Closed before the listeners go, so the close event this triggers arrives after they are
+      // already detached and cannot re-enter `#end`.
+      this.#ws?.close(1000, reason)
+    } catch {}
+
+    for (const unhook of this.#unhooks) unhook()
+    this.#unhooks.length = 0
+  }
+
+  /**
+   * Ends the session: tells Studio it is over, disposes of the socket, and optionally schedules a
+   * reconnect. `#disposed` guards against the close event running this a second time, and against
+   * a shutdown reconnecting.
+   */
+  async #end({ reason, retry }: { reason?: string; retry: boolean }): Promise<void> {
+    const { studioUrl, token } = this.#options
+
+    if (this.#disposed) {
       return
     }
-    this.#serverDisconnected = true
+    this.#disposed = true
 
     // Announce the shutdown while the socket is still open, so Studio marks the session offline
     // now instead of waiting out the heartbeat window. `sendAgentMessage` is a no-op on a socket
@@ -388,21 +463,17 @@ class StudioSession {
       sendAgentMessage(this.#ws, { type: 'agent:disconnect', reason: 'shutdown' })
     }
 
-    this.#cleanup(reason)
-    // Already tearing down, so a failed disconnect changes nothing.
-    await disconnect({ sessionId: this.#sessionId, studioUrl: this.#studioUrl, token: this.#token, slug: this.#slug }).catch(() => {})
+    this.dispose(reason)
+
+    // Nothing to tell Studio about when the session never opened.
+    if (this.#session) {
+      // Already tearing down, so a failed disconnect changes nothing.
+      await disconnect({ sessionId: this.#session.sessionId, studioUrl, token, slug: this.#session.slug }).catch(() => {})
+    }
 
     if (retry) {
       reconnect(this.#options)
     }
-  }
-
-  #onClose = (): void => void this.#teardown({ retry: true })
-
-  #onError = (): void => {
-    void this.#hooks.callHook('studio:error', { error: new Error('Failed to connect to Kubb Studio') })
-
-    this.#onClose()
   }
 
   #onMessage = async (message: WebSocket.MessageEvent): Promise<void> => {
@@ -416,24 +487,7 @@ class StudioSession {
       }
 
       if (isDisconnectMessage(data)) {
-        await this.#hooks.callHook('studio:disconnected', { reason: data.reason })
-
-        if (data.reason === 'revoked') {
-          // `#cleanup` already unhooks the socket's own `close` listener before returning, which is
-          // what actually keeps a real `close` event from re-entering `#teardown`. Set regardless,
-          // so this path stays safe against `#teardown` being reached some other way later.
-          this.#serverDisconnected = true
-          this.#cleanup(`session_${data.reason}`)
-          return
-        }
-
-        if (data.reason === 'expired') {
-          this.#serverDisconnected = true
-          this.#cleanup()
-          reconnect(this.#options)
-
-          return
-        }
+        await this.#handleDisconnect(data.reason)
 
         return
       }
@@ -444,15 +498,36 @@ class StudioSession {
         return
       }
 
-      await this.#hooks.callHook('studio:warn', { message: `Ignored an unknown message from Kubb Studio: ${data.type}` })
+      await this.#warn(`Ignored an unknown message from Kubb Studio: ${data.type}`)
     } catch (error) {
       await this.#hooks.callHook('studio:error', { error: toError(error) })
 
       // Errors thrown before `generate()` runs (e.g. config loading, plugin resolution) never
       // reach `generate()`'s own `kubb:error` emission, so without this the Studio UI shows
-      // nothing while the agent silently fails. Forward them on the connection-level `#hooks`
-      // emitter, already wired to this socket via `setupEventsStream`.
-      await Promise.resolve(this.#hooks.callHook('kubb:error', { error: toError(error) })).catch(() => {})
+      // nothing while the agent silently fails.
+      await this.#emitError(toError(error))
+    }
+  }
+
+  /**
+   * Studio ended the session itself. A revoked one stays ended, an expired one gets a fresh
+   * session, and anything else is left to the socket's own close event.
+   */
+  async #handleDisconnect(reason: string): Promise<void> {
+    await this.#hooks.callHook('studio:disconnected', { reason })
+
+    if (reason !== 'revoked' && reason !== 'expired') {
+      return
+    }
+
+    // `dispose` unhooks the socket's own `close` listener before returning, which is what actually
+    // keeps a real `close` event from re-entering `#end`. `#disposed` is set regardless, so this
+    // path stays safe against `#end` being reached some other way later.
+    this.#disposed = true
+    this.dispose(`session_${reason}`)
+
+    if (reason === 'expired') {
+      reconnect(this.#options)
     }
   }
 
@@ -467,33 +542,27 @@ class StudioSession {
 
     await this.#hooks.callHook('studio:command:start', { command })
 
-    if (data.type === 'studio:generate') {
-      await this.#handleGenerate(ws, data, command)
-
-      return
-    }
-
-    if (data.type === 'studio:connect') {
-      this.#studioVersion = data.version ?? this.#studioVersion
-      await this.#sendConnectedPayload()
-
-      await this.#hooks.callHook('studio:command:end', { command })
-
-      return
-    }
-
-    if (data.type === 'studio:save') {
-      await this.#handleSave(ws, data, command)
+    switch (data.type) {
+      case 'studio:generate':
+        await this.#handleGenerate(ws, data, command)
+        return
+      case 'studio:connect':
+        this.#studioVersion = data.version ?? this.#studioVersion
+        await this.#sendConnectedPayload()
+        await this.#hooks.callHook('studio:command:end', { command })
+        return
+      case 'studio:save':
+        await this.#handleSave(ws, data, command)
+        return
     }
   }
 
   async #handleGenerate(ws: WebSocket, data: Extract<AgentMessage, { type: 'studio:generate' }>, command: string): Promise<void> {
-    if (this.#isGenerating) {
-      await this.#hooks.callHook('studio:warn', { message: 'Ignored generate: a generation is already in progress' })
+    const { root, loadConfig, allowInput, allowWrite, allowExec, client, installLogger } = this.#options
 
-      await Promise.resolve(
-        this.#hooks.callHook('kubb:error', { error: new Error('A generation is already in progress, please wait for it to finish') }),
-      ).catch(() => {})
+    if (this.#isGenerating) {
+      await this.#warn('Ignored generate: a generation is already in progress')
+      await this.#emitError(new Error('A generation is already in progress, please wait for it to finish'))
 
       return
     }
@@ -501,29 +570,29 @@ class StudioSession {
     this.#isGenerating = true
 
     try {
-      const config = await this.#loadConfig()
+      const config = await loadConfig()
       const patch = data.payload
       const plugins = await mergePlugins(config.plugins, patch?.plugins)
       const adapter = await mergeAdapter(config.adapter, patch?.adapter)
 
       // A sandbox agent always uses the inline spec (empty string included, since it has no disk
       // file); a local agent only when opted in, and an empty or absent spec falls back to disk.
-      const inputOverride = this.#isSandbox ? (patch?.input ?? '') : (this.#allowInput && patch?.input) || undefined
+      const inputOverride = this.#isSandbox ? (patch?.input ?? '') : (allowInput && patch?.input) || undefined
 
-      if (this.#allowWrite && this.#isSandbox) {
-        await this.#hooks.callHook('studio:warn', { message: 'Running in a sandbox, so writing files is disabled' })
+      if (allowWrite && this.#isSandbox) {
+        await this.#warn('Running in a sandbox, so writing files is disabled')
       }
 
       if (patch?.input && !this.#canUseInput) {
         // The Docker agent reads `allowInput` from `KUBB_AGENT_ALLOW_INPUT`. The CLI grants it
         // through `--allowInput` or the per-project prompt instead, so each host gets its own remedy.
-        const remedy = this.#client?.kind === 'cli' ? '--allowInput, or answer yes when kubb studio asks,' : 'KUBB_AGENT_ALLOW_INPUT=true'
-        await this.#hooks.callHook('studio:warn', { message: `Ignored the spec from Studio; set ${remedy} to generate from it` })
+        const remedy = client?.kind === 'cli' ? '--allowInput, or answer yes when kubb studio asks,' : 'KUBB_AGENT_ALLOW_INPUT=true'
+        await this.#warn(`Ignored the spec from Studio; set ${remedy} to generate from it`)
       }
 
       const generationHooks = new Hookable<KubbHooks>()
-      await this.#installLogger?.(generationHooks)
-      setupHookListener(generationHooks, this.#root)
+      await installLogger?.(generationHooks)
+      setupHookListener(generationHooks, root)
       setupEventsStream(ws, generationHooks)
 
       const resolvedPlugins = plugins ?? config.plugins
@@ -531,10 +600,10 @@ class StudioSession {
       await generate({
         config: {
           ...config,
-          root: this.#root,
+          root,
           input: inputOverride ?? config.input,
           storage: this.#canWrite ? fsStorage() : memoryStorage(),
-          output: this.#allowExec ? { ...config.output } : { ...config.output, format: false, lint: false, postGenerate: [] },
+          output: allowExec ? { ...config.output } : { ...config.output, format: false, lint: false, postGenerate: [] },
           plugins: resolvedPlugins,
           adapter,
         },
@@ -551,11 +620,13 @@ class StudioSession {
   }
 
   async #handleSave(ws: WebSocket, data: Extract<AgentMessage, { type: 'studio:save' }>, command: string): Promise<void> {
+    const { configPath, configFile } = this.#options
+
     // Studio waits on an `agent:save` for every `studio:save`, so every path out of this function
     // sends one. `edits` is checked before it is walked: the message crosses the same trust
     // boundary as the values inside it.
     if (!Array.isArray(data.edits)) {
-      await this.#hooks.callHook('studio:warn', { message: 'Ignored save: the message carried no edits' })
+      await this.#warn('Ignored save: the message carried no edits')
 
       sendAgentMessage(ws, { type: 'agent:save', payload: { outcomes: [], changed: false } })
 
@@ -570,7 +641,7 @@ class StudioSession {
       })
 
     if (!this.#canEditConfig) {
-      await this.#hooks.callHook('studio:warn', { message: 'Ignored save: editing kubb.config.ts was not granted' })
+      await this.#warn('Ignored save: editing kubb.config.ts was not granted')
 
       refuse('the agent was not granted permission to edit kubb.config.ts')
 
@@ -590,11 +661,11 @@ class StudioSession {
       // have edited the file since, and since every untouched node keeps its own text, patching
       // what is on disk right now preserves that edit.
       const { applyConfigEdits } = await import('./configFile.ts')
-      const current = await readFile(this.#configFilePath, 'utf-8')
+      const current = await read(configFile)
       const { source: patched, outcomes, changed } = applyConfigEdits(current, edits)
 
       if (changed) {
-        await writeFile(this.#configFilePath, patched, 'utf-8')
+        await write(configFile, patched)
       }
 
       sendAgentMessage(ws, {
@@ -603,7 +674,7 @@ class StudioSession {
       })
 
       const applied = outcomes.filter((outcome) => outcome.applied).length
-      await this.#hooks.callHook('studio:command:end', { command, info: `applied ${applied}/${outcomes.length} edits to ${this.#configPath}` })
+      await this.#hooks.callHook('studio:command:end', { command, info: `applied ${applied}/${outcomes.length} edits to ${configPath}` })
     } catch (error) {
       // An unreadable config, a read-only filesystem. Reported as a refusal of every edit so
       // Studio hears back rather than waiting on a reply that never comes.

--- a/packages/studio/src/connectStudio.ts
+++ b/packages/studio/src/connectStudio.ts
@@ -64,11 +64,12 @@ export type ConnectToStudioOptions = {
    */
   installLogger?: (hooks: Hookable<KubbHooks>) => void | Promise<void>
   /**
-   * Called when a background reconnect is rejected with an invalid token. Wired in by
-   * `createClient`, which wraps it to fire once per pool and stop every session; not meant to be
-   * set directly by a host.
+   * Called when this session's background reconnect is rejected with an invalid token. Unlike
+   * `ClientOptions.onAuthRequired`, this fires once per session rather than once per pool:
+   * `createClient` wraps it into that deduped, pool-stopping callback. Not meant to be set
+   * directly by a host.
    */
-  onAuthRequired?: (error: InvalidAgentTokenError) => void
+  onTokenRejected?: (error: InvalidAgentTokenError) => void
 }
 
 /**
@@ -79,7 +80,7 @@ export type ConnectToStudioOptions = {
  * alive for the length of every retry interval.
  */
 function reconnect(options: ConnectToStudioOptions): void {
-  const { signal, retryInterval = agentDefaults.retryIntervalMs, onAuthRequired } = options
+  const { signal, retryInterval = agentDefaults.retryIntervalMs, onTokenRejected } = options
 
   if (signal?.aborted) {
     return
@@ -106,7 +107,7 @@ function reconnect(options: ConnectToStudioOptions): void {
       // The host learns about it here instead: the startup path already reports its own rejection
       // by throwing, so only the background path needs the callback.
       if (error instanceof InvalidAgentTokenError) {
-        onAuthRequired?.(error)
+        onTokenRejected?.(error)
 
         return
       }

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -11,4 +11,4 @@ export type {
 export { InvalidAgentTokenError } from './api.ts'
 export { defaultStudioUrl } from './constants.ts'
 export { createFileStorage, setStorage } from './machine.ts'
-export { pollForPairingToken, startPairing } from './pair.ts'
+export { PairingCanceledError, pollForPairingToken, startPairing } from './pair.ts'

--- a/packages/studio/src/pair.test.ts
+++ b/packages/studio/src/pair.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setTimeout as delay } from 'node:timers/promises'
-import { pollForPairingToken, type PairingSession } from './pair.ts'
+import { PairingCanceledError, pollForPairingToken, startPairing, type PairingSession } from './pair.ts'
 
 vi.mock('node:timers/promises', () => ({
   setTimeout: vi.fn(async () => {}),
@@ -89,7 +89,7 @@ describe('pollForPairingToken', () => {
     await vi.runAllTimersAsync()
     await promise
 
-    expect(delayMock).toHaveBeenCalledWith(5_000)
+    expect(delayMock).toHaveBeenCalledWith(5_000, undefined, { signal: undefined })
   })
 
   it('falls back to a 600s expiry instead of expiring before the first poll when Studio omits it', async () => {
@@ -112,5 +112,62 @@ describe('pollForPairingToken', () => {
 
     await expect(promise).resolves.toEqual(result)
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('socket hang up'))
+  })
+
+  it('rejects with PairingCanceledError when the signal aborts during the wait between polls', async () => {
+    const controller = new AbortController()
+    delayMock.mockImplementationOnce(() => {
+      controller.abort()
+      return Promise.reject(new Error('The operation was aborted'))
+    })
+
+    const promise = pollForPairingToken({ studioUrl: 'http://studio', session, signal: controller.signal })
+    promise.catch(() => {})
+    await vi.runAllTimersAsync()
+
+    await expect(promise).rejects.toBeInstanceOf(PairingCanceledError)
+  })
+
+  it('rejects with PairingCanceledError when the signal is already aborted before polling starts', async () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    const promise = pollForPairingToken({ studioUrl: 'http://studio', session, signal: controller.signal })
+
+    await expect(promise).rejects.toBeInstanceOf(PairingCanceledError)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects with PairingCanceledError when the signal aborts mid-request', async () => {
+    const controller = new AbortController()
+    fetchMock.mockImplementationOnce(() => {
+      controller.abort()
+      return Promise.reject(new Error('The operation was aborted'))
+    })
+
+    const promise = pollForPairingToken({ studioUrl: 'http://studio', session, signal: controller.signal })
+    promise.catch(() => {})
+    await vi.runAllTimersAsync()
+
+    await expect(promise).rejects.toBeInstanceOf(PairingCanceledError)
+  })
+})
+
+describe('startPairing', () => {
+  it('requests a pairing session from Studio', async () => {
+    const session = { device_code: 'device', user_code: 'ABCD-EFGH', verification_uri: 'https://kubb.studio/pair' }
+    fetchMock.mockResolvedValueOnce(createMockResponse(session))
+
+    await expect(startPairing({ studioUrl: 'http://studio', name: 'my-project', hostname: 'my-host' })).resolves.toMatchObject(session)
+  })
+
+  it('rejects with PairingCanceledError when the signal is already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    fetchMock.mockRejectedValueOnce(new DOMException('The operation was aborted', 'AbortError'))
+
+    await expect(startPairing({ studioUrl: 'http://studio', name: 'my-project', hostname: 'my-host', signal: controller.signal })).rejects.toBeInstanceOf(
+      PairingCanceledError,
+    )
   })
 })

--- a/packages/studio/src/pair.ts
+++ b/packages/studio/src/pair.ts
@@ -168,10 +168,6 @@ export async function pollForPairingToken({ studioUrl = agentDefaults.studioUrl,
       throw new PairingCanceledError()
     }
 
-    if (signal?.aborted) {
-      throw new PairingCanceledError()
-    }
-
     let response: PollResponse | undefined
     try {
       response = await ofetch<PollResponse | undefined>(`${studioUrl}/api/agent/token`, {

--- a/packages/studio/src/pair.ts
+++ b/packages/studio/src/pair.ts
@@ -45,6 +45,18 @@ export type PairingResult = {
  */
 const CLIENT_ID = 'kubb-cli'
 
+/**
+ * Thrown when a caller aborts `startPairing` or `pollForPairingToken` through their `signal`, such
+ * as a `kubb studio` shutdown mid-pairing. Distinct from a denial or an expired code, so a host can
+ * exit quietly instead of reporting a pairing failure.
+ */
+export class PairingCanceledError extends Error {
+  constructor() {
+    super('Pairing was canceled')
+    this.name = 'PairingCanceledError'
+  }
+}
+
 type StartPairingOptions = {
   studioUrl?: string
   /**
@@ -62,6 +74,10 @@ type StartPairingOptions = {
    * and ignores it for the CLI.
    */
   agentKind?: 'user' | 'sandbox'
+  /**
+   * Aborting this cancels the request in flight and rejects with {@link PairingCanceledError}.
+   */
+  signal?: AbortSignal
 }
 
 /**
@@ -75,22 +91,37 @@ export async function startPairing({
   hostname,
   clientId = CLIENT_ID,
   agentKind,
+  signal,
 }: StartPairingOptions): Promise<PairingSession> {
-  return ofetch<PairingSession>(`${studioUrl}/api/auth/device/code`, {
-    method: 'POST',
-    body: {
-      client_id: clientId,
-      name,
-      hostname,
-      machine_token: await getMachineToken(),
-      agent_kind: agentKind,
-    },
-  })
+  try {
+    return await ofetch<PairingSession>(`${studioUrl}/api/auth/device/code`, {
+      method: 'POST',
+      body: {
+        client_id: clientId,
+        name,
+        hostname,
+        machine_token: await getMachineToken(),
+        agent_kind: agentKind,
+      },
+      signal,
+    })
+  } catch (error) {
+    if (signal?.aborted) {
+      throw new PairingCanceledError()
+    }
+
+    throw error
+  }
 }
 
 type PollOptions = {
   studioUrl?: string
   session: PairingSession
+  /**
+   * Aborting this stops polling and rejects with {@link PairingCanceledError}, whether the abort
+   * lands between polls or during the wait for the next one.
+   */
+  signal?: AbortSignal
 }
 
 type PollError = 'authorization_pending' | 'slow_down' | 'expired_token' | 'access_denied' | 'invalid_grant'
@@ -119,7 +150,7 @@ function isPairingResult(response: PollResponse | undefined): response is Pairin
  *
  * @throws when the code expires, the user denies it, or Studio returns an unexpected error.
  */
-export async function pollForPairingToken({ studioUrl = agentDefaults.studioUrl, session }: PollOptions): Promise<PairingResult> {
+export async function pollForPairingToken({ studioUrl = agentDefaults.studioUrl, session, signal }: PollOptions): Promise<PairingResult> {
   // Both fields cross the network, so neither is trusted as-is: a missing or zero `interval` would
   // spin the poll loop, and a missing or zero `expires_in` would expire the code before the first
   // poll. `> 0` is also false for `NaN` and for a missing field, so it doubles as the type guard.
@@ -127,7 +158,19 @@ export async function pollForPairingToken({ studioUrl = agentDefaults.studioUrl,
   let intervalMs = (session.interval > 0 ? session.interval : 5) * 1000
 
   while (Date.now() < deadline) {
-    await delay(intervalMs)
+    if (signal?.aborted) {
+      throw new PairingCanceledError()
+    }
+
+    try {
+      await delay(intervalMs, undefined, { signal })
+    } catch {
+      throw new PairingCanceledError()
+    }
+
+    if (signal?.aborted) {
+      throw new PairingCanceledError()
+    }
 
     let response: PollResponse | undefined
     try {
@@ -137,8 +180,13 @@ export async function pollForPairingToken({ studioUrl = agentDefaults.studioUrl,
         // A denial, an expiry, and "not yet" all come back as 4xx with a body the caller needs to
         // read, so let every response through and switch on `error` instead of catching.
         ignoreResponseError: true,
+        signal,
       })
     } catch (error) {
+      if (signal?.aborted) {
+        throw new PairingCanceledError()
+      }
+
       // Studio can go briefly unreachable (a deploy, a dropped connection) during the minutes the
       // user has to approve in the browser. One failed poll should not end a pairing whose code is
       // still valid, so warn and try again on the next tick, the way `registerAgent` retries.


### PR DESCRIPTION
## 🎯 Changes

Implements the client and CLI half of periodic reauthentication (kubb-labs/kubb#3981). The server half, which enforces token expiry, is tracked separately in kubb-labs/platform#426.

`@kubb/studio`:
- `createClient` gains an optional `onAuthRequired` callback, called once a live pool's token is rejected during background reconnect, after the whole pool is already stopped. It fires exactly once per client even when several pool sessions reject the same token at once. It never fires for a token rejected at startup (`connect()` still throws for that, unchanged) or for an ordinary session expiry or revocation.
- `startPairing` and `pollForPairingToken` take an optional `signal`, so a host can cancel an in-flight pairing or poll. Aborting rejects with the new `PairingCanceledError`, exported from the package.

`@kubb/cli` (`kubb studio`):
- Reacts to `onAuthRequired`: explains what happened, reopens the browser approval flow, and reconnects with the new token. Saved project permissions carry forward only when the reauthenticated agent has the same identity and Studio URL.
- An operator-supplied `KUBB_AGENT_TOKEN` is never replaced automatically; the CLI tells the operator to update it.
- CI or a run without a TTY exits nonzero with instructions to run `kubb studio login`, without touching stored or environment credentials.
- A newly approved token rejected again immediately is treated as a hard failure instead of pairing forever (one automatic reauth per run, across both the startup and live-rejection paths).
- `connect()` now owns a single `AbortController` for its whole run, armed once and torn down in `finally`, so Ctrl+C cancels an in-flight pairing or poll and a reauth never leaves behind a duplicate `SIGINT`/`SIGTERM` listener.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EDaxW9rK7cneiFvbvMSfaB

---
_Generated by [Claude Code](https://claude.ai/code/session_01EDaxW9rK7cneiFvbvMSfaB)_