### PR TITLE
feat(studio): move the connect and re-pair loop out of the CLI

### DIFF
--- a/.changeset/brave-moons-invent.md
+++ b/.changeset/brave-moons-invent.md
@@ -1,0 +1,12 @@
+---
+'@kubb/studio': minor
+'@kubb/cli': patch
+---
+
+New `runConnection` keeps a host connected to Studio across token changes: it opens a client,
+waits until the run ends or Studio rejects the token, and reconnects with whatever credential the
+host hands back from `onTokenRejected`. Where credentials live, whether a rejected token may be
+replaced, and how any of it is reported stay with the host.
+
+`kubb studio` runs on it now instead of keeping its own copy of that loop. Its behavior is
+unchanged.

--- a/packages/cli/src/runners/studio/run.test.ts
+++ b/packages/cli/src/runners/studio/run.test.ts
@@ -272,14 +272,4 @@ describe('connect', () => {
     // One pairing only: the second rejection is a hard failure.
     expect(startPairing).toHaveBeenCalledTimes(1)
   })
-
-  it('surfaces a failure the studio runtime could not handle, without pairing again', async () => {
-    vi.mocked(readCredentials).mockResolvedValue(credentials)
-    // Anything that is not a rejected token reaches the CLI as-is: sessions retry those themselves.
-    vi.mocked(runConnection).mockRejectedValue(new Error('ECONNREFUSED'))
-
-    await expect(connect(options)).rejects.toThrow('ECONNREFUSED')
-    expect(startPairing).not.toHaveBeenCalled()
-    expect(clearCredentials).not.toHaveBeenCalled()
-  })
 })

--- a/packages/cli/src/runners/studio/run.test.ts
+++ b/packages/cli/src/runners/studio/run.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import * as prompts from '@clack/prompts'
-import { InvalidAgentTokenError, PairingCanceledError } from '@kubb/studio'
+import { InvalidAgentTokenError, PairingCanceledError, type ConnectionOptions } from '@kubb/studio'
 import type { Credentials } from './credentials.ts'
 import { connect, formatPermissionRows, resolvePermissions, type StudioOptions } from './run.ts'
 
@@ -30,7 +30,7 @@ vi.mock('../generate/utils.ts', () => ({
 }))
 vi.mock('@kubb/studio', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@kubb/studio')>()),
-  createClient: vi.fn(),
+  runConnection: vi.fn(),
   startPairing: vi.fn(),
   pollForPairingToken: vi.fn(),
   setStorage: vi.fn(),
@@ -39,7 +39,7 @@ vi.mock('@kubb/studio', async (importOriginal) => ({
 
 const confirm = vi.mocked(prompts.confirm)
 const { readCredentials, writeCredentials, clearCredentials } = await import('./credentials.ts')
-const { createClient, startPairing, pollForPairingToken } = await import('@kubb/studio')
+const { runConnection, startPairing, pollForPairingToken } = await import('@kubb/studio')
 const { isCIEnvironment, canUseTTY } = await import('../../utils/env.ts')
 
 const options: StudioOptions = {
@@ -57,7 +57,7 @@ beforeEach(() => {
   vi.mocked(writeCredentials).mockClear()
   vi.mocked(readCredentials).mockReset().mockResolvedValue(null)
   vi.mocked(clearCredentials).mockReset().mockResolvedValue(undefined)
-  vi.mocked(createClient).mockReset()
+  vi.mocked(runConnection).mockReset()
   vi.mocked(startPairing).mockReset()
   vi.mocked(pollForPairingToken).mockReset()
   vi.mocked(isCIEnvironment).mockReset().mockReturnValue(false)
@@ -68,28 +68,6 @@ beforeEach(() => {
 afterEach(() => {
   vi.restoreAllMocks()
 })
-
-/**
- * A `createClient` stand-in whose `connect()` and `disconnect()` behavior each test controls, and
- * that records the options every call was created with so a test can trigger `onAuthRequired` the
- * way a live background rejection would.
- */
-function mockClient(connectImpl: () => Promise<void>) {
-  const disconnect = vi.fn()
-  let onAuthRequired: ((error: InvalidAgentTokenError) => void) | undefined
-
-  vi.mocked(createClient).mockImplementationOnce((clientOptions) => {
-    onAuthRequired = clientOptions.onAuthRequired
-    return { connect: connectImpl, disconnect }
-  })
-
-  return {
-    disconnect,
-    triggerAuthRequired(error: InvalidAgentTokenError) {
-      onAuthRequired?.(error)
-    },
-  }
-}
 
 /**
  * Mocks a browser pairing the user approves. `agentId` is what decides whether the reauthenticated
@@ -187,51 +165,73 @@ describe('formatPermissionRows', () => {
 })
 
 describe('connect', () => {
+  const rejection = (live: boolean) => ({ error: new InvalidAgentTokenError(options.studioUrl), live })
+
+  /**
+   * A `runConnection` stand-in. It hands the CLI's own options back to the test and fires
+   * `onTokenRejected` for each queued rejection, which is what the studio runtime does when Studio
+   * turns a token down. Returns what the run would: `stopped` once the CLI declines to pair again.
+   */
+  function mockConnection(...rejections: Array<{ error: InvalidAgentTokenError; live: boolean }>) {
+    const captured: { options?: ConnectionOptions<{ token: string }>; outcome?: string } = {}
+
+    vi.mocked(runConnection).mockImplementation(async (connectionOptions) => {
+      captured.options = connectionOptions
+      let { credentials } = connectionOptions
+
+      for (const { error, live } of rejections) {
+        const next = await connectionOptions.onTokenRejected({ error, live, credentials })
+
+        if (!next) {
+          captured.outcome = 'stopped'
+          return 'stopped'
+        }
+
+        credentials = next
+      }
+
+      captured.outcome = 'shutdown'
+      return 'shutdown'
+    })
+
+    return captured
+  }
+
   it('tells the operator to update KUBB_AGENT_TOKEN when a live rejection hits an env-sourced token, without touching stored credentials', async () => {
     process.env.KUBB_AGENT_TOKEN = 'env-token'
-    const client = mockClient(() => Promise.resolve())
+    mockConnection(rejection(true))
 
-    const promise = connect(options)
-    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(1))
-    client.triggerAuthRequired(new InvalidAgentTokenError(options.studioUrl))
-
-    await expect(promise).rejects.toThrow(/update KUBB_AGENT_TOKEN/)
+    await expect(connect(options)).rejects.toThrow(/update KUBB_AGENT_TOKEN/)
     expect(clearCredentials).not.toHaveBeenCalled()
     expect(writeCredentials).not.toHaveBeenCalled()
-    expect(client.disconnect).toHaveBeenCalled()
   })
 
   it('tells the operator to run kubb studio login when a live rejection hits a CI run, without touching stored credentials', async () => {
     vi.mocked(readCredentials).mockResolvedValue(credentials)
     vi.mocked(isCIEnvironment).mockReturnValue(true)
-    const client = mockClient(() => Promise.resolve())
+    mockConnection(rejection(true))
 
-    const promise = connect(options)
-    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(1))
-    client.triggerAuthRequired(new InvalidAgentTokenError(options.studioUrl))
-
-    await expect(promise).rejects.toThrow(/kubb studio login/)
+    await expect(connect(options)).rejects.toThrow(/kubb studio login/)
     expect(clearCredentials).not.toHaveBeenCalled()
     expect(writeCredentials).not.toHaveBeenCalled()
+  })
+
+  it('forgets a token rejected before a session ever opened, even on a run that cannot pair again', async () => {
+    vi.mocked(readCredentials).mockResolvedValue(credentials)
+    vi.mocked(isCIEnvironment).mockReturnValue(true)
+    mockConnection(rejection(false))
+
+    await expect(connect(options)).rejects.toThrow(/kubb studio login/)
+    expect(clearCredentials).toHaveBeenCalled()
   })
 
   it('reauthenticates interactively on a live rejection and carries saved permissions forward for the same agent identity', async () => {
     vi.mocked(readCredentials).mockResolvedValue({ ...credentials, projects: { [process.cwd()]: { allowWrite: true } } })
     // The same agentId as the stored credential, so the reauth keeps the identity.
     mockPairing()
+    mockConnection(rejection(true))
 
-    const first = mockClient(() => Promise.resolve())
-    mockClient(() => Promise.resolve())
-
-    const promise = connect(options)
-    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(1))
-    first.triggerAuthRequired(new InvalidAgentTokenError(options.studioUrl))
-
-    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(2))
-    // Second client is live: end the run the same way Ctrl+C would.
-    process.emit('SIGINT' as never)
-
-    await promise
+    await connect(options)
 
     expect(writeCredentials).toHaveBeenCalledWith(expect.objectContaining({ token: 'new-token', projects: { [process.cwd()]: { allowWrite: true } } }))
   })
@@ -239,18 +239,9 @@ describe('connect', () => {
   it('does not carry saved permissions forward when the reauthenticated agent identity differs', async () => {
     vi.mocked(readCredentials).mockResolvedValue({ ...credentials, projects: { [process.cwd()]: { allowWrite: true } } })
     mockPairing('a-different-agent')
+    const connection = mockConnection(rejection(true))
 
-    const first = mockClient(() => Promise.resolve())
-    mockClient(() => Promise.resolve())
-
-    const promise = connect(options)
-    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(1))
-    first.triggerAuthRequired(new InvalidAgentTokenError(options.studioUrl))
-
-    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(2))
-    process.emit('SIGINT' as never)
-
-    await promise
+    await connect(options)
 
     const written = vi
       .mocked(writeCredentials)
@@ -259,58 +250,33 @@ describe('connect', () => {
     expect(written?.projects).toBeUndefined()
 
     // The permissions were granted to the previous agent, so the new one is asked again rather
-    // than inheriting them.
-    expect(vi.mocked(createClient).mock.calls[0]?.[0]).toMatchObject({ permissions: { allowWrite: true } })
-    expect(vi.mocked(createClient).mock.calls[1]?.[0]).toMatchObject({ permissions: { allowWrite: false } })
+    // than inheriting them. The next attempt reads them through `clientOptions`.
+    expect(connection.options?.clientOptions(credentials)).toMatchObject({ permissions: { allowWrite: false } })
   })
 
   it('exits cleanly instead of throwing when the user cancels pairing during a live reauth', async () => {
     vi.mocked(readCredentials).mockResolvedValue(credentials)
-    vi.mocked(startPairing).mockImplementation(
-      ({ signal }) =>
-        new Promise((_resolve, reject) => {
-          signal?.addEventListener('abort', () => reject(new PairingCanceledError()))
-        }),
-    )
+    vi.mocked(startPairing).mockRejectedValue(new PairingCanceledError())
+    const connection = mockConnection(rejection(true))
 
-    const client = mockClient(() => Promise.resolve())
-
-    const promise = connect(options)
-    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(1))
-    client.triggerAuthRequired(new InvalidAgentTokenError(options.studioUrl))
-
-    await vi.waitFor(() => expect(startPairing).toHaveBeenCalledTimes(1))
-    process.emit('SIGINT' as never)
-
-    await expect(promise).resolves.toBeUndefined()
-    // Only one client was ever created: cancellation during the reauth stops before a new one connects.
-    expect(createClient).toHaveBeenCalledTimes(1)
+    await expect(connect(options)).resolves.toBeUndefined()
+    expect(connection.outcome).toBe('stopped')
   })
 
   it('stops after one automatic reauth instead of pairing forever when the newly approved token is rejected again', async () => {
     vi.mocked(readCredentials).mockResolvedValue(credentials)
     mockPairing()
+    mockConnection(rejection(true), rejection(true))
 
-    const first = mockClient(() => Promise.resolve())
-    const second = mockClient(() => Promise.resolve())
-
-    const promise = connect(options)
-    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(1))
-    first.triggerAuthRequired(new InvalidAgentTokenError(options.studioUrl))
-
-    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(2))
-    // The freshly approved token is rejected again immediately.
-    second.triggerAuthRequired(new InvalidAgentTokenError(options.studioUrl))
-
-    await expect(promise).rejects.toThrow(/rejected the newly approved token/)
-    // No third client: one automatic reauth is all this ever attempts.
-    expect(createClient).toHaveBeenCalledTimes(2)
+    await expect(connect(options)).rejects.toThrow(/rejected the newly approved token/)
+    // One pairing only: the second rejection is a hard failure.
+    expect(startPairing).toHaveBeenCalledTimes(1)
   })
 
-  it('keeps retrying an ordinary network failure without reauthenticating, since only an InvalidAgentTokenError triggers pairing', async () => {
+  it('surfaces a failure the studio runtime could not handle, without pairing again', async () => {
     vi.mocked(readCredentials).mockResolvedValue(credentials)
-    // A plain connection failure at startup is not InvalidAgentTokenError, so it should surface as-is.
-    mockClient(() => Promise.reject(new Error('ECONNREFUSED')))
+    // Anything that is not a rejected token reaches the CLI as-is: sessions retry those themselves.
+    vi.mocked(runConnection).mockRejectedValue(new Error('ECONNREFUSED'))
 
     await expect(connect(options)).rejects.toThrow('ECONNREFUSED')
     expect(startPairing).not.toHaveBeenCalled()

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -9,11 +9,12 @@ import type { CLIOptions, Config } from '@kubb/core'
 import { cliReporter, logLevel as logLevelMap } from '@kubb/core'
 import {
   createFileStorage,
-  createClient,
+  type ClientOptions,
   defaultStudioUrl,
-  InvalidAgentTokenError,
+  type InvalidAgentTokenError,
   PairingCanceledError,
   pollForPairingToken,
+  runConnection,
   setStorage,
   startPairing,
 } from '@kubb/studio'
@@ -310,9 +311,16 @@ class StudioConnection {
 
       this.#printBanner()
 
-      // Each iteration is one connection attempt. It returns once the run is over (a shutdown, or
-      // a canceled re-pair) or falls through to try again with whatever credentials are now current.
-      while (!(await this.#connectAndWait())) {}
+      const outcome = await runConnection({
+        credentials: this.#credentials,
+        signal: this.#shutdown.signal,
+        clientOptions: () => this.#clientOptions(),
+        onTokenRejected: ({ error, live }) => this.#handleRejection(error, live),
+      })
+
+      if (outcome === 'shutdown') {
+        this.#reportDisconnected()
+      }
     } catch (error) {
       // Canceling the very first pairing (before anything was ever connected) is Ctrl+C working as
       // intended, not a failure to report.
@@ -368,24 +376,11 @@ class StudioConnection {
   }
 
   /**
-   * Opens one client and waits for whichever comes first: a shutdown, or Studio rejecting the
-   * token. A rejection arrives either from `client.connect()` itself, at startup, or later through
-   * `onAuthRequired`, during a background reconnect. Returns whether the run is over.
+   * What every connection attempt opens with. Rebuilt per attempt, so a re-pair that changed the
+   * granted permissions takes effect on the next one.
    */
-  async #connectAndWait(): Promise<boolean> {
-    // A shutdown can land outside the race below: while the permission prompts are open, or
-    // between a browser approval and this next attempt. Registering one more agent with Studio
-    // only to drop it again is not what the operator asked for.
-    if (this.#shutdown.signal.aborted) {
-      this.#reportDisconnected()
-
-      return true
-    }
-
-    const { promise: authRequired, resolve: notifyAuthRequired } = Promise.withResolvers<InvalidAgentTokenError>()
-
-    const client = createClient({
-      token: this.#credentials.token,
+  #clientOptions(): Omit<ClientOptions, 'token' | 'onAuthRequired'> {
+    return {
       studioUrl: this.#options.studioUrl,
       configPath: this.#configPath,
       version: this.#options.version,
@@ -394,11 +389,8 @@ class StudioConnection {
       client: { kind: 'cli' },
       root: process.cwd(),
       permissions: this.#granted,
-      // Fires once the pool is already stopped, only for a token rejected during background
-      // reconnect. A startup rejection is handled below through `client.connect()` itself.
-      onAuthRequired: notifyAuthRequired,
-      // The loggers `kubb generate` installs, on both emitters, so one place renders the session
-      // events and the generations it drives.
+      // The loggers `kubb generate` installs, so one place renders the session events and the
+      // generations it drives.
       installLogger: async (hooks) => {
         await setupReporters(hooks, { logLevel: logLevelMap[this.#options.logLevel ?? 'info'], reporters: [cliReporter] })
 
@@ -414,46 +406,7 @@ class StudioConnection {
           logBlock(styleText('dim', 'Press Ctrl+C to disconnect'))
         })
       },
-    })
-
-    try {
-      await client.connect()
-    } catch (error) {
-      if (!(error instanceof InvalidAgentTokenError)) {
-        throw error
-      }
-
-      client.disconnect()
-
-      return this.#handleStartupRejection(error)
     }
-
-    // `{ once: true }` drops the listener when the abort fires, not when the other side settles
-    // the race, so `settled` covers that half. Without it a reauthenticated rejection leaves one
-    // behind on `#shutdown.signal` for every reconnect.
-    const settled = new AbortController()
-    // Resolves with nothing, so the race reports a shutdown as the absence of a rejection.
-    const shutdownWait = new Promise<undefined>((resolve) => {
-      if (this.#shutdown.signal.aborted) {
-        resolve(undefined)
-        return
-      }
-      this.#shutdown.signal.addEventListener('abort', () => resolve(undefined), { once: true, signal: settled.signal })
-    })
-
-    const rejection = await Promise.race([shutdownWait, authRequired])
-
-    settled.abort()
-
-    client.disconnect()
-
-    if (!rejection) {
-      this.#reportDisconnected()
-
-      return true
-    }
-
-    return this.#handleLiveRejection(rejection)
   }
 
   /**
@@ -471,65 +424,53 @@ class StudioConnection {
   }
 
   /**
-   * The token was dead before a session ever opened: the agent was deleted in Studio, or the token
-   * was revoked. Keeping it only produces 401s on every run, so it is forgotten and paired again.
-   * Returns whether the run is over.
+   * Studio rejected the token, either before a session ever opened or once one was already live.
+   * Keeping a rejected token only produces 401s on every run, so it is forgotten and paired again.
+   * Returns the credential to reconnect with, or null when the run is over.
    */
-  async #handleStartupRejection(error: InvalidAgentTokenError): Promise<boolean> {
+  async #handleRejection(error: InvalidAgentTokenError, live: boolean): Promise<Credentials | null> {
     // An operator-supplied token is never replaced automatically.
     if (process.env.KUBB_AGENT_TOKEN) {
       throw explainRejectedToken(error, 'envToken')
     }
 
-    await clearCredentials()
-
-    this.#assertCanReauthenticate(error)
-
-    console.log(styleText('yellow', `${error.message} Pairing again...`))
-
-    if (!(await this.#reauthenticate())) {
-      return true
-    }
-
-    return false
-  }
-
-  /**
-   * Studio rejected the token in the background, well after the session was already live. Returns
-   * whether the run is over.
-   */
-  async #handleLiveRejection(error: InvalidAgentTokenError): Promise<boolean> {
-    if (process.env.KUBB_AGENT_TOKEN) {
-      throw explainRejectedToken(error, 'envToken')
+    // A token dead at startup is forgotten either way. A live one is only forgotten once this run
+    // knows it can pair again, so a CI run keeps the credential it could not replace.
+    if (!live) {
+      await clearCredentials()
     }
 
     this.#assertCanReauthenticate(error)
 
-    console.log(styleText('yellow', `${error.message} Studio needs you to approve access again.`))
+    console.log(styleText('yellow', live ? `${error.message} Studio needs you to approve access again.` : `${error.message} Pairing again...`))
 
-    // Forget the dead token before pairing again, the same as a rejection at startup: `login`
-    // overwrites the file regardless, but a failed re-pair should not leave a rejected token
-    // behind for the next run to try again.
-    await clearCredentials()
-
-    if (!(await this.#reauthenticate())) {
-      this.#reportDisconnected()
-
-      return true
+    if (live) {
+      await clearCredentials()
     }
 
-    return false
+    const credentials = await this.#reauthenticate()
+
+    if (!credentials) {
+      // Nothing was ever connected at startup, so there is no session to report the end of.
+      if (live) {
+        this.#reportDisconnected()
+      }
+
+      return null
+    }
+
+    return credentials
   }
 
   /**
-   * Re-pairs and stores the resulting credentials. Returns false when the operator canceled it.
+   * Re-pairs and stores the resulting credentials. Returns null when the operator canceled it.
    */
-  async #reauthenticate(): Promise<boolean> {
+  async #reauthenticate(): Promise<Credentials | null> {
     try {
       this.#credentials = await login(this.#options, { signal: this.#shutdown.signal, previousCredentials: this.#credentials })
     } catch (loginError) {
       if (loginError instanceof PairingCanceledError) {
-        return false
+        return null
       }
       throw loginError
     }
@@ -541,7 +482,7 @@ class StudioConnection {
     // of handing the new agent what the previous one was granted.
     this.#granted = await resolvePermissions(this.#options, this.#credentials, this.#configPath, !process.env.KUBB_AGENT_TOKEN)
 
-    return true
+    return this.#credentials
   }
 }
 

--- a/packages/cli/src/runners/studio/run.ts
+++ b/packages/cli/src/runners/studio/run.ts
@@ -450,13 +450,9 @@ class StudioConnection {
 
     const credentials = await this.#reauthenticate()
 
-    if (!credentials) {
-      // Nothing was ever connected at startup, so there is no session to report the end of.
-      if (live) {
-        this.#reportDisconnected()
-      }
-
-      return null
+    // Nothing was ever connected at startup, so there is no session to report the end of.
+    if (!credentials && live) {
+      this.#reportDisconnected()
     }
 
     return credentials

--- a/packages/studio/src/index.ts
+++ b/packages/studio/src/index.ts
@@ -11,4 +11,5 @@ export type {
 export { InvalidAgentTokenError } from './api.ts'
 export { defaultStudioUrl } from './constants.ts'
 export { createFileStorage, setStorage } from './machine.ts'
+export { runConnection, type ConnectionOptions, type ConnectionOutcome, type TokenRejection } from './runConnection.ts'
 export { PairingCanceledError, pollForPairingToken, startPairing } from './pair.ts'

--- a/packages/studio/src/runConnection.test.ts
+++ b/packages/studio/src/runConnection.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest'
 import { InvalidAgentTokenError } from './api.ts'
 import { runConnection } from './runConnection.ts'
 
@@ -8,23 +8,35 @@ import { createClient } from './client.ts'
 
 const clientOptions = () => ({ studioUrl: 'https://kubb.studio', configPath: 'kubb.config.ts', version: '1.0.0', loadConfig: vi.fn() })
 
+type FakeClient = {
+  connect: Mock<() => Promise<void>>
+  disconnect: Mock<() => void>
+  /**
+   * What the pool would call for a token rejected during background reconnect, once it has stopped.
+   */
+  onAuthRequired?: (error: InvalidAgentTokenError) => void
+  token?: string
+}
+
 /**
  * Queues one client per attempt. `connect` decides how that attempt ends, and every client records
  * whether it was disconnected, which is what the run promises before it moves on.
  */
-function queueClients(...connects: Array<() => Promise<void>>) {
-  const clients = connects.map((connect) => ({ connect: vi.fn(connect), disconnect: vi.fn() }))
+function queueClients(...connects: Array<() => Promise<void>>): Array<FakeClient> {
+  const clients: Array<FakeClient> = connects.map((connect) => ({ connect: vi.fn(connect), disconnect: vi.fn() }))
   let attempt = 0
 
   vi.mocked(createClient).mockImplementation((options) => {
     const client = clients[attempt++]
     if (!client) throw new Error('createClient was called more times than the test queued')
-    // The pool fires this for a token rejected during background reconnect, once it has stopped.
-    Object.assign(client, { onAuthRequired: options.onAuthRequired, token: options.token })
+
+    client.onAuthRequired = options.onAuthRequired
+    client.token = options.token
+
     return client
   })
 
-  return clients as Array<(typeof clients)[number] & { onAuthRequired?: (error: InvalidAgentTokenError) => void; token?: string }>
+  return clients
 }
 
 const rejected = () => Promise.reject(new InvalidAgentTokenError('https://kubb.studio'))

--- a/packages/studio/src/runConnection.test.ts
+++ b/packages/studio/src/runConnection.test.ts
@@ -116,10 +116,12 @@ describe('runConnection', () => {
 
   it('rethrows anything that is not a rejected token, since sessions retry those themselves', async () => {
     const error = new Error('ECONNREFUSED')
-    queueClients(() => Promise.reject(error))
+    const clients = queueClients(() => Promise.reject(error))
     const onTokenRejected = vi.fn()
 
     await expect(runConnection({ credentials: { token: 'a' }, clientOptions, onTokenRejected })).rejects.toBe(error)
     expect(onTokenRejected).not.toHaveBeenCalled()
+    // The attempt still closes its client on the way out.
+    expect(clients[0]?.disconnect).toHaveBeenCalled()
   })
 })

--- a/packages/studio/src/runConnection.test.ts
+++ b/packages/studio/src/runConnection.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { InvalidAgentTokenError } from './api.ts'
+import { runConnection } from './runConnection.ts'
+
+vi.mock('./client.ts', () => ({ createClient: vi.fn() }))
+
+import { createClient } from './client.ts'
+
+const clientOptions = () => ({ studioUrl: 'https://kubb.studio', configPath: 'kubb.config.ts', version: '1.0.0', loadConfig: vi.fn() })
+
+/**
+ * Queues one client per attempt. `connect` decides how that attempt ends, and every client records
+ * whether it was disconnected, which is what the run promises before it moves on.
+ */
+function queueClients(...connects: Array<() => Promise<void>>) {
+  const clients = connects.map((connect) => ({ connect: vi.fn(connect), disconnect: vi.fn() }))
+  let attempt = 0
+
+  vi.mocked(createClient).mockImplementation((options) => {
+    const client = clients[attempt++]
+    if (!client) throw new Error('createClient was called more times than the test queued')
+    // The pool fires this for a token rejected during background reconnect, once it has stopped.
+    Object.assign(client, { onAuthRequired: options.onAuthRequired, token: options.token })
+    return client
+  })
+
+  return clients as Array<(typeof clients)[number] & { onAuthRequired?: (error: InvalidAgentTokenError) => void; token?: string }>
+}
+
+const rejected = () => Promise.reject(new InvalidAgentTokenError('https://kubb.studio'))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('runConnection', () => {
+  it('stops before opening a client when the run is already shutting down', async () => {
+    const clients = queueClients()
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(runConnection({ credentials: { token: 'a' }, clientOptions, onTokenRejected: vi.fn(), signal: controller.signal })).resolves.toBe('shutdown')
+    expect(clients).toHaveLength(0)
+    expect(createClient).not.toHaveBeenCalled()
+  })
+
+  it('ends the run when the signal aborts while the session is live', async () => {
+    const clients = queueClients(() => Promise.resolve())
+    const controller = new AbortController()
+
+    const outcome = runConnection({ credentials: { token: 'a' }, clientOptions, onTokenRejected: vi.fn(), signal: controller.signal })
+    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(1))
+    controller.abort()
+
+    await expect(outcome).resolves.toBe('shutdown')
+    expect(clients[0]?.disconnect).toHaveBeenCalled()
+  })
+
+  it('reports a token rejected before a session opened, then reconnects with the replacement', async () => {
+    const clients = queueClients(rejected, () => Promise.resolve())
+    const controller = new AbortController()
+    const onTokenRejected = vi.fn(async () => ({ token: 'b' }))
+
+    const outcome = runConnection({ credentials: { token: 'a' }, clientOptions, onTokenRejected, signal: controller.signal })
+    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(2))
+    controller.abort()
+
+    await expect(outcome).resolves.toBe('shutdown')
+    expect(onTokenRejected).toHaveBeenCalledWith({ error: expect.any(InvalidAgentTokenError), credentials: { token: 'a' }, live: false })
+    expect(clients[0]?.disconnect).toHaveBeenCalled()
+    expect(clients[1]?.token).toBe('b')
+  })
+
+  it('reports a token rejected during a live session as live', async () => {
+    const clients = queueClients(
+      () => Promise.resolve(),
+      () => Promise.resolve(),
+    )
+    const controller = new AbortController()
+    const onTokenRejected = vi.fn(async () => ({ token: 'b' }))
+
+    const outcome = runConnection({ credentials: { token: 'a' }, clientOptions, onTokenRejected, signal: controller.signal })
+    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(1))
+    clients[0]?.onAuthRequired?.(new InvalidAgentTokenError('https://kubb.studio'))
+
+    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(2))
+    controller.abort()
+
+    await expect(outcome).resolves.toBe('shutdown')
+    expect(onTokenRejected).toHaveBeenCalledWith({ error: expect.any(InvalidAgentTokenError), credentials: { token: 'a' }, live: true })
+  })
+
+  it('rebuilds the client options for every attempt', async () => {
+    queueClients(rejected, () => Promise.resolve())
+    const controller = new AbortController()
+    const options = vi.fn(clientOptions)
+
+    const outcome = runConnection({
+      credentials: { token: 'a' },
+      clientOptions: options,
+      onTokenRejected: async () => ({ token: 'b' }),
+      signal: controller.signal,
+    })
+    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(2))
+    controller.abort()
+
+    await outcome
+    expect(options.mock.calls).toEqual([[{ token: 'a' }], [{ token: 'b' }]])
+  })
+
+  it('ends the run when the host declines to replace the token', async () => {
+    queueClients(rejected)
+
+    await expect(runConnection({ credentials: { token: 'a' }, clientOptions, onTokenRejected: async () => null })).resolves.toBe('stopped')
+  })
+
+  it('rethrows anything that is not a rejected token, since sessions retry those themselves', async () => {
+    const error = new Error('ECONNREFUSED')
+    queueClients(() => Promise.reject(error))
+    const onTokenRejected = vi.fn()
+
+    await expect(runConnection({ credentials: { token: 'a' }, clientOptions, onTokenRejected })).rejects.toBe(error)
+    expect(onTokenRejected).not.toHaveBeenCalled()
+  })
+})

--- a/packages/studio/src/runConnection.test.ts
+++ b/packages/studio/src/runConnection.test.ts
@@ -72,8 +72,9 @@ describe('runConnection', () => {
     const clients = queueClients(rejected, () => Promise.resolve())
     const controller = new AbortController()
     const onTokenRejected = vi.fn(async () => ({ token: 'b' }))
+    const options = vi.fn(clientOptions)
 
-    const outcome = runConnection({ credentials: { token: 'a' }, clientOptions, onTokenRejected, signal: controller.signal })
+    const outcome = runConnection({ credentials: { token: 'a' }, clientOptions: options, onTokenRejected, signal: controller.signal })
     await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(2))
     controller.abort()
 
@@ -81,6 +82,8 @@ describe('runConnection', () => {
     expect(onTokenRejected).toHaveBeenCalledWith({ error: expect.any(InvalidAgentTokenError), credentials: { token: 'a' }, live: false })
     expect(clients[0]?.disconnect).toHaveBeenCalled()
     expect(clients[1]?.token).toBe('b')
+    // Options are rebuilt per attempt, so a host that re-derives them from the credential is heard.
+    expect(options.mock.calls).toEqual([[{ token: 'a' }], [{ token: 'b' }]])
   })
 
   it('reports a token rejected during a live session as live', async () => {
@@ -100,24 +103,6 @@ describe('runConnection', () => {
 
     await expect(outcome).resolves.toBe('shutdown')
     expect(onTokenRejected).toHaveBeenCalledWith({ error: expect.any(InvalidAgentTokenError), credentials: { token: 'a' }, live: true })
-  })
-
-  it('rebuilds the client options for every attempt', async () => {
-    queueClients(rejected, () => Promise.resolve())
-    const controller = new AbortController()
-    const options = vi.fn(clientOptions)
-
-    const outcome = runConnection({
-      credentials: { token: 'a' },
-      clientOptions: options,
-      onTokenRejected: async () => ({ token: 'b' }),
-      signal: controller.signal,
-    })
-    await vi.waitFor(() => expect(createClient).toHaveBeenCalledTimes(2))
-    controller.abort()
-
-    await outcome
-    expect(options.mock.calls).toEqual([[{ token: 'a' }], [{ token: 'b' }]])
   })
 
   it('ends the run when the host declines to replace the token', async () => {

--- a/packages/studio/src/runConnection.ts
+++ b/packages/studio/src/runConnection.ts
@@ -53,7 +53,7 @@ export type ConnectionOptions<TCredentials extends { token: string }> = {
  * background reconnect. Resolves with the rejection, or nothing when the run is being shut down.
  */
 function waitForRejection(authRequired: Promise<InvalidAgentTokenError>, signal?: AbortSignal): Promise<InvalidAgentTokenError | undefined> {
-  // Nothing to race without a signal: that host ends the run some other way.
+  // Nothing to race without a signal: a host without one ends the run some other way.
   if (!signal) {
     return authRequired
   }
@@ -98,8 +98,6 @@ export async function runConnection<TCredentials extends { token: string }>({
 }: ConnectionOptions<TCredentials>): Promise<ConnectionOutcome> {
   let current = credentials
 
-  // Each pass is one connection attempt: it ends the run, or produces the credential the next
-  // attempt opens with.
   while (true) {
     // A shutdown can land outside the race below, while a host is pairing or prompting. Registering
     // one more agent with Studio only to drop it again is not what the operator asked for.
@@ -131,7 +129,6 @@ export async function runConnection<TCredentials extends { token: string }>({
 
       rejection = { error, credentials: current, live: false }
     } finally {
-      // Every way out of this attempt closes its client, the rethrow included.
       client.disconnect()
     }
 

--- a/packages/studio/src/runConnection.ts
+++ b/packages/studio/src/runConnection.ts
@@ -53,14 +53,16 @@ export type ConnectionOptions<TCredentials extends { token: string }> = {
  * background reconnect. Resolves with the rejection, or nothing when the run is being shut down.
  */
 function waitForRejection(authRequired: Promise<InvalidAgentTokenError>, signal?: AbortSignal): Promise<InvalidAgentTokenError | undefined> {
+  // Nothing to race without a signal: that host ends the run some other way.
+  if (!signal) {
+    return authRequired
+  }
+
   // `{ once: true }` drops the listener when the abort fires, not when the other side settles the
   // race, so `settled` covers that half. Without it a reconnected run leaves one behind on the
   // host's signal for every attempt it makes.
   const settled = new AbortController()
   const shutdown = new Promise<undefined>((resolve) => {
-    if (!signal) {
-      return
-    }
     if (signal.aborted) {
       resolve(undefined)
       return
@@ -115,8 +117,6 @@ export async function runConnection<TCredentials extends { token: string }>({
 
       const error = await waitForRejection(authRequired, signal)
 
-      client.disconnect()
-
       if (!error) {
         return 'shutdown'
       }
@@ -129,9 +129,10 @@ export async function runConnection<TCredentials extends { token: string }>({
         throw error
       }
 
-      client.disconnect()
-
       rejection = { error, credentials: current, live: false }
+    } finally {
+      // Every way out of this attempt closes its client, the rethrow included.
+      client.disconnect()
     }
 
     const next = await onTokenRejected(rejection)

--- a/packages/studio/src/runConnection.ts
+++ b/packages/studio/src/runConnection.ts
@@ -1,0 +1,145 @@
+import { InvalidAgentTokenError } from './api.ts'
+import { type ClientOptions, createClient } from './client.ts'
+
+/**
+ * Why a connection ended: the host asked it to stop through its `signal`, or the host declined to
+ * replace a rejected token.
+ */
+export type ConnectionOutcome = 'shutdown' | 'stopped'
+
+/**
+ * A rejected token, and whether it was already serving a live session when Studio rejected it.
+ */
+export type TokenRejection<TCredentials> = {
+  error: InvalidAgentTokenError
+  /**
+   * The credential Studio rejected, so a host can carry parts of it into the replacement.
+   */
+  credentials: TCredentials
+  /**
+   * `false` when the token was dead before a session ever opened, which is what `connect()` itself
+   * reports. `true` when a live pool's background reconnect was rejected, well after the session
+   * was up. Hosts treat the two differently: only the first has nothing to tear down.
+   */
+  live: boolean
+}
+
+export type ConnectionOptions<TCredentials extends { token: string }> = {
+  /**
+   * The credential to open with. Only its token is read here, so a host keeps whatever else it
+   * stores alongside.
+   */
+  credentials: TCredentials
+  /**
+   * Builds the client options for one attempt. Called again for every reconnect, so a host whose
+   * options depend on which agent approved, such as the permissions it granted, re-derives them
+   * rather than reusing the ones the rejected token was opened with.
+   */
+  clientOptions: (credentials: TCredentials) => Omit<ClientOptions, 'token' | 'onAuthRequired'>
+  /**
+   * Called when Studio rejects the token. Return the credential to reconnect with, or `null` to
+   * end the run. Throwing fails it, which is what a host does when it cannot pair again.
+   */
+  onTokenRejected: (rejection: TokenRejection<TCredentials>) => Promise<TCredentials | null>
+  /**
+   * Aborting this disconnects and ends the run. Hosts wire it to their own shutdown: `SIGINT` in
+   * the CLI, Nitro's `close` hook in the Docker agent.
+   */
+  signal?: AbortSignal
+}
+
+/**
+ * Waits for whichever comes first: the shutdown signal, or Studio rejecting the token during a
+ * background reconnect. Resolves with the rejection, or nothing when the run is being shut down.
+ */
+function waitForRejection(authRequired: Promise<InvalidAgentTokenError>, signal?: AbortSignal): Promise<InvalidAgentTokenError | undefined> {
+  // `{ once: true }` drops the listener when the abort fires, not when the other side settles the
+  // race, so `settled` covers that half. Without it a reconnected run leaves one behind on the
+  // host's signal for every attempt it makes.
+  const settled = new AbortController()
+  const shutdown = new Promise<undefined>((resolve) => {
+    if (!signal) {
+      return
+    }
+    if (signal.aborted) {
+      resolve(undefined)
+      return
+    }
+    signal.addEventListener('abort', () => resolve(undefined), { once: true, signal: settled.signal })
+  })
+
+  return Promise.race([shutdown, authRequired]).finally(() => settled.abort())
+}
+
+/**
+ * Keeps a host connected to Studio across token changes: it opens a client, waits until the run
+ * ends or Studio rejects the token, and reconnects with whatever credential the host hands back.
+ *
+ * The host owns everything around that. Where credentials live, whether a rejected token may be
+ * replaced, and how any of it is reported are all decisions `onTokenRejected` makes.
+ *
+ * @example
+ * ```ts
+ * const outcome = await runConnection({
+ *   credentials,
+ *   clientOptions: () => ({ studioUrl, configPath, version, loadConfig }),
+ *   signal: shutdown.signal,
+ *   onTokenRejected: ({ error, live }) => pairAgain(error, live),
+ * })
+ * ```
+ */
+export async function runConnection<TCredentials extends { token: string }>({
+  credentials,
+  clientOptions,
+  onTokenRejected,
+  signal,
+}: ConnectionOptions<TCredentials>): Promise<ConnectionOutcome> {
+  let current = credentials
+
+  // Each pass is one connection attempt: it ends the run, or produces the credential the next
+  // attempt opens with.
+  while (true) {
+    // A shutdown can land outside the race below, while a host is pairing or prompting. Registering
+    // one more agent with Studio only to drop it again is not what the operator asked for.
+    if (signal?.aborted) {
+      return 'shutdown'
+    }
+
+    const { promise: authRequired, resolve: notifyAuthRequired } = Promise.withResolvers<InvalidAgentTokenError>()
+    const client = createClient({ ...clientOptions(current), token: current.token, onAuthRequired: notifyAuthRequired })
+
+    let rejection: TokenRejection<TCredentials> | undefined
+
+    try {
+      await client.connect()
+
+      const error = await waitForRejection(authRequired, signal)
+
+      client.disconnect()
+
+      if (!error) {
+        return 'shutdown'
+      }
+
+      rejection = { error, credentials: current, live: true }
+    } catch (error) {
+      // Every other failure is retried inside the session's own reconnect loop, so anything that
+      // surfaces here is a dead token or a host's own bug.
+      if (!(error instanceof InvalidAgentTokenError)) {
+        throw error
+      }
+
+      client.disconnect()
+
+      rejection = { error, credentials: current, live: false }
+    }
+
+    const next = await onTokenRejected(rejection)
+
+    if (!next) {
+      return 'stopped'
+    }
+
+    current = next
+  }
+}


### PR DESCRIPTION
Follows #3985.

`packages/cli/src/runners/studio/run.ts` carried a loop that has nothing to do with the CLI: open a client, wait until the run ends or Studio rejects the token, reconnect with a new one. The Docker agent in kubb-labs/platform hand-rolls the same loop, and the two had already drifted (the CLI re-pairs once, the agent retries pairing up to five times).

## What moved

New `runConnection` in `@kubb/studio`:

```ts
const outcome = await runConnection({
  credentials,
  clientOptions: (credentials) => ({ studioUrl, configPath, version, loadConfig, permissions }),
  signal: shutdown.signal,
  onTokenRejected: ({ error, live }) => pairAgain(error, live),
})
```

It owns the mechanics: the shutdown-versus-rejection race, telling a token rejected at startup apart from one rejected during a live session, disconnecting each attempt, and rethrowing anything that is not a rejected token (sessions retry those themselves). It returns `'shutdown'` or `'stopped'`, so a host knows whether the run ended by request or because it declined to pair again.

`clientOptions` is a function rather than a bag, because the options depend on which agent approved. The CLI re-asks for permissions when a re-pair lands on a different agent identity, and the next attempt has to open with those.

## What stayed in the CLI

Everything that is actually the CLI: where credentials live, `KUBB_AGENT_TOKEN`, the CI and TTY checks, the one-re-pair-per-run policy, the prompts, the banner, and the wording of every message. `#handleStartupRejection` and `#handleLiveRejection` collapsed into one `#handleRejection(error, live)`, since the loop now decides which is which.

`run.ts` is 145 lines lighter and no longer imports `createClient`.

## Tests

The loop's tests moved with it: seven new cases in `runConnection.test.ts` cover the race, both rejection kinds, the per-attempt options rebuild, declining to pair, and the rethrow. The CLI's `connect` tests now drive `onTokenRejected` directly, which is what they were always testing, and gained one for a startup rejection on a run that cannot pair again.

`pnpm lint`, `pnpm typecheck`, 188 tests in `@kubb/studio`, 99 in `@kubb/cli`.

## Follow-up

kubb-labs/platform#428 can drop its own `StudioConnection` and its `pairWithRetries` loop onto this once the catalog moves.
