### PR TITLE
utils(ast): add schema property resolution and enum literal extraction

### DIFF
--- a/.changeset/fuzzy-pets-resolve.md
+++ b/.changeset/fuzzy-pets-resolve.md
@@ -1,0 +1,7 @@
+---
+'@kubb/ast': minor
+---
+
+Add utilities for resolving object properties through references and intersections and for reading
+literal values from enum schemas. Plugin authors can use these utilities to handle discriminated
+unions without implementing their own schema traversal.

--- a/packages/ast/src/utils/index.ts
+++ b/packages/ast/src/utils/index.ts
@@ -1,3 +1,4 @@
 export { extractStringsFromNodes } from './extractStringsFromNodes.ts'
 export { resolveRefName } from './refs.ts'
 export { collectImportedRefNames, collectUsedSchemaNames, findCircularSchemas, findCircularSchemasFromGraph } from './schemaGraph.ts'
+export { getSchemaLiteralValues, resolveSchemaProperties } from './schemaProperties.ts'

--- a/packages/ast/src/utils/schemaProperties.test.ts
+++ b/packages/ast/src/utils/schemaProperties.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { createProperty } from '../nodes/property.ts'
+import { createSchema } from '../nodes/schema.ts'
+import { getSchemaLiteralValues, resolveSchemaProperties } from './schemaProperties.ts'
+
+describe('resolveSchemaProperties', () => {
+  it('finds properties through references and intersections', () => {
+    const property = createProperty({
+      name: 'type',
+      required: true,
+      schema: createSchema({ type: 'enum', enumValues: ['cat'] }),
+    })
+    const object = createSchema({ type: 'object', properties: [property] })
+    const ref = createSchema({ type: 'ref', name: 'Cat', schema: object })
+    const node = createSchema({ type: 'intersection', members: [ref, createSchema({ type: 'object', properties: [property] })] })
+
+    expect(resolveSchemaProperties({ node, propertyName: 'type' })).toStrictEqual([property, property])
+  })
+
+  it('does not find properties in union branches', () => {
+    const node = createSchema({
+      type: 'union',
+      members: [
+        createSchema({
+          type: 'object',
+          properties: [createProperty({ name: 'type', schema: createSchema({ type: 'enum', enumValues: ['cat'] }) })],
+        }),
+      ],
+    })
+
+    expect(resolveSchemaProperties({ node, propertyName: 'type' })).toStrictEqual([])
+  })
+
+  it('terminates for circular resolved references', () => {
+    const node = createSchema({ type: 'ref', name: 'Node' })
+    node.schema = node
+
+    expect(resolveSchemaProperties({ node, propertyName: 'type' })).toStrictEqual([])
+  })
+})
+
+describe('getSchemaLiteralValues', () => {
+  it('collects unique values from enums, references, and unions', () => {
+    const cat = createSchema({ type: 'enum', enumValues: ['cat'] })
+    const node = createSchema({
+      type: 'union',
+      members: [createSchema({ type: 'ref', name: 'Cat', schema: cat }), cat, createSchema({ type: 'enum', enumValues: ['dog', null] })],
+    })
+
+    expect(getSchemaLiteralValues(node)).toStrictEqual(['cat', 'dog', null])
+  })
+
+  it('prefers named enum values', () => {
+    const node = createSchema({
+      type: 'enum',
+      enumValues: ['ignored'],
+      namedEnumValues: [{ name: 'Cat', value: 'cat', primitive: 'string' }],
+    })
+
+    expect(getSchemaLiteralValues(node)).toStrictEqual(['cat'])
+  })
+})

--- a/packages/ast/src/utils/schemaProperties.ts
+++ b/packages/ast/src/utils/schemaProperties.ts
@@ -1,0 +1,98 @@
+import type { PropertyNode, SchemaNode } from '../nodes/index.ts'
+
+/**
+ * Finds every matching property exposed by an object, resolved reference, or intersection.
+ *
+ * References are followed through their parsed `schema`. Circular references terminate without
+ * revisiting a node. Unions are not traversed because a property on one branch does not describe
+ * every branch.
+ *
+ * @example Faker discriminator narrowing
+ * ```ts
+ * const values = resolveSchemaProperties({ node: member, propertyName: union.discriminatorPropertyName }).flatMap(({ schema }) =>
+ *   getSchemaLiteralValues(schema),
+ * )
+ * const typeName = `Extract<Pet, { type: ${values.map(JSON.stringify).join(' | ')} }>`
+ * ```
+ *
+ * @example Zod discriminated unions
+ * ```ts
+ * const canDiscriminate = union.members?.every(
+ *   (member) => resolveSchemaProperties({ node: member, propertyName: 'type' }).length > 0,
+ * )
+ * const expression = canDiscriminate ? `z.discriminatedUnion('type', members)` : `z.union(members)`
+ * ```
+ *
+ * @example TypeScript property lookup
+ * ```ts
+ * const properties = resolveSchemaProperties({ node: schema, propertyName: 'status' })
+ * const statusSchemas = properties.map((property) => print(property.schema))
+ * ```
+ */
+export function resolveSchemaProperties({ node, propertyName }: { node: SchemaNode; propertyName: string }): ReadonlyArray<PropertyNode> {
+  const properties: Array<PropertyNode> = []
+  const visited = new WeakSet<SchemaNode>()
+
+  function visit(current: SchemaNode | null | undefined): void {
+    if (!current || visited.has(current)) return
+    visited.add(current)
+
+    if (current.type === 'object') {
+      const property = current.properties.find((candidate) => candidate.name === propertyName)
+      if (property) properties.push(property)
+      return
+    }
+
+    if (current.type === 'ref') {
+      visit(current.schema)
+      return
+    }
+
+    if (current.type === 'intersection') {
+      for (const member of current.members ?? []) visit(member)
+    }
+  }
+
+  visit(node)
+  return properties
+}
+
+/**
+ * Reads the unique literal values represented by an enum, resolved reference, or union.
+ *
+ * Named enum values take precedence over simple enum values, matching how renderers consume
+ * `EnumSchemaNode`.
+ *
+ * @example
+ * ```ts
+ * const values = getSchemaLiteralValues(enumNode)
+ * // ['cat', 'dog']
+ * ```
+ */
+export function getSchemaLiteralValues(node: SchemaNode): ReadonlyArray<string | number | boolean | null> {
+  const values = new Set<string | number | boolean | null>()
+  const visited = new WeakSet<SchemaNode>()
+
+  function visit(current: SchemaNode | null | undefined): void {
+    if (!current || visited.has(current)) return
+    visited.add(current)
+
+    if (current.type === 'enum') {
+      const enumValues = current.namedEnumValues?.map(({ value }) => value) ?? current.enumValues ?? []
+      for (const value of enumValues) values.add(value)
+      return
+    }
+
+    if (current.type === 'ref') {
+      visit(current.schema)
+      return
+    }
+
+    if (current.type === 'union') {
+      for (const member of current.members ?? []) visit(member)
+    }
+  }
+
+  visit(node)
+  return [...values]
+}


### PR DESCRIPTION
### Motivation

- Provide utilities to resolve object properties through `ref` and `intersection` schemas and to read literal values from `enum` schemas so renderers and plugins can handle discriminated unions without rolling their own traversal.

### Description

- Add `resolveSchemaProperties` utility to traverse `ref` and `intersection` nodes, skip `union` branches, and avoid infinite loops by tracking visited nodes.
- Add `getSchemaLiteralValues` utility to collect unique literal values from `enum`, `ref`, and `union` nodes and prefer `namedEnumValues` when present.
- Export the new utilities from `packages/ast/src/utils/index.ts` and include unit tests in `packages/ast/src/utils/schemaProperties.test.ts` covering reference/intersection resolution, union skipping, circular refs, unique value collection, and name-preference for enums.
- Add a changeset entry `.changeset/fuzzy-pets-resolve.md` documenting the minor version bump for `@kubb/ast`.

### Testing

- Ran the new unit tests in `packages/ast/src/utils/schemaProperties.test.ts` with `vitest`, which exercise `resolveSchemaProperties` and `getSchemaLiteralValues`, and they passed.
- The tests cover property resolution through `ref` and `intersection`, not traversing `union` branches, terminating on circular `ref`, collecting unique enum values, and preferring named enum values, and all assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9deaa0d5648323a09bdb61406cabec)