### PR TITLE
feat(core): add HTML report data collector

### DIFF
--- a/packages/core/src/reporters/htmlReportCollector.test.ts
+++ b/packages/core/src/reporters/htmlReportCollector.test.ts
@@ -1,0 +1,310 @@
+import { ast, type InputNode } from '@kubb/ast'
+import { describe, expect, it } from 'vitest'
+import { type ProblemDiagnostic, Diagnostics } from '../Diagnostics.ts'
+import { memoryStorage } from '../storages/memoryStorage.ts'
+import type { Config, KubbHooks } from '../types.ts'
+import { Hookable } from '../Hookable.ts'
+import { createHtmlReportCollector } from './htmlReportCollector.ts'
+
+function config(): Config {
+  return {
+    name: 'petstore',
+    root: '/workspace',
+    input: './petstore.yaml',
+    output: { path: './gen' },
+    parsers: [],
+    reporters: [],
+    plugins: [],
+    storage: memoryStorage(),
+  } as unknown as Config
+}
+
+function inputNode(names: Array<string>): InputNode {
+  return ast.factory.createInput({
+    meta: { title: 'Petstore', circularNames: [], enumNames: [] },
+    schemas: names.map((name) => ast.factory.createSchema({ type: 'object', name, properties: [] })),
+    operations: [],
+  })
+}
+
+function plugin(name: string) {
+  return { name } as KubbHooks['kubb:plugin:start'][0]['plugin']
+}
+
+function generatorContext(pluginName: string, cfg = config()) {
+  return {
+    config: cfg,
+    plugin: plugin(pluginName),
+  } as unknown as KubbHooks['kubb:generate:schema'][1]
+}
+
+function file(path: string) {
+  return ast.factory.createFile({
+    path,
+    baseName: path.split('/').at(-1) as `${string}.${string}`,
+    sources: [ast.factory.createSource({ nodes: [ast.factory.createText(`export const ${path.replaceAll(/[^a-z0-9]/gi, '_')} = true`)] })],
+  })
+}
+
+describe('createHtmlReportCollector', () => {
+  it('keeps the canonical AST separate from the plugin view', async () => {
+    const hooks = new Hookable<KubbHooks>()
+    const canonical = inputNode(['A', 'B', 'C'])
+    const collector = createHtmlReportCollector({ hooks, getInputNode: () => canonical })
+    const cfg = config()
+
+    await hooks.callHook('kubb:build:start', {
+      config: cfg,
+      adapter: { name: 'oas' },
+      meta: canonical.meta,
+      files: [],
+      getPlugin: () => undefined,
+      upsertFile: () => [],
+    } as unknown as KubbHooks['kubb:build:start'][0])
+    await hooks.callHook('kubb:plugin:start', { plugin: plugin('plugin-a') })
+    await hooks.callHook('kubb:generate:schema', canonical.schemas[0]!, generatorContext('plugin-a', cfg))
+
+    const snapshot = collector.getSnapshot()
+
+    expect(snapshot.ast?.schemas.map((schema) => schema.name)).toStrictEqual(['A', 'B', 'C'])
+    expect(snapshot.pluginViews['plugin-a']?.schemas.map((schema) => schema.name)).toStrictEqual(['A'])
+    expect(snapshot.run?.schemaCount).toBe(3)
+    expect(snapshot.run?.plugins[0]).toMatchObject({ name: 'plugin-a', schemaCount: 1 })
+  })
+
+  it('does not mutate the canonical AST when a plugin receives a transformed node', async () => {
+    const hooks = new Hookable<KubbHooks>()
+    const canonical = inputNode(['Pet'])
+    const collector = createHtmlReportCollector({ hooks, getInputNode: () => canonical })
+    const cfg = config()
+
+    await hooks.callHook('kubb:build:start', {
+      config: cfg,
+      adapter: { name: 'oas' },
+      meta: canonical.meta,
+      files: [],
+      getPlugin: () => undefined,
+      upsertFile: () => [],
+    } as unknown as KubbHooks['kubb:build:start'][0])
+    await hooks.callHook('kubb:plugin:start', { plugin: plugin('plugin-a') })
+    await hooks.callHook('kubb:generate:schema', ast.factory.createSchema({ type: 'string', name: 'Pet' }), generatorContext('plugin-a', cfg))
+
+    const snapshot = collector.getSnapshot()
+
+    expect(snapshot.ast?.schemas[0]).toMatchObject({ name: 'Pet', type: 'object' })
+    expect(snapshot.pluginViews['plugin-a']?.schemas[0]).toMatchObject({ name: 'Pet', type: 'string' })
+  })
+
+  it('records plugin lifecycle and associates schema and operation events with the plugin that received them', async () => {
+    const hooks = new Hookable<KubbHooks>()
+    const canonical = ast.factory.createInput({
+      meta: { circularNames: [], enumNames: [] },
+      schemas: [ast.factory.createSchema({ type: 'object', name: 'Pet', properties: [] })],
+      operations: [ast.factory.createOperation({ operationId: 'getPet', method: 'GET', path: '/pets/{petId}' })],
+    })
+    const collector = createHtmlReportCollector({ hooks, getInputNode: () => canonical })
+    const cfg = config()
+
+    await hooks.callHook('kubb:build:start', {
+      config: cfg,
+      adapter: { name: 'oas' },
+      meta: canonical.meta,
+      files: [],
+      getPlugin: () => undefined,
+      upsertFile: () => [],
+    } as unknown as KubbHooks['kubb:build:start'][0])
+    await hooks.callHook('kubb:plugin:start', { plugin: plugin('plugin-a') })
+    await hooks.callHook('kubb:generate:schema', canonical.schemas[0]!, generatorContext('plugin-a', cfg))
+    await hooks.callHook('kubb:generate:operation', canonical.operations[0]!, generatorContext('plugin-a', cfg))
+    await hooks.callHook('kubb:plugin:end', {
+      plugin: plugin('plugin-a'),
+      duration: 12,
+      success: true,
+      config: cfg,
+      files: [],
+      upsertFile: () => [],
+    })
+
+    const snapshot = collector.getSnapshot()
+
+    expect(snapshot.run?.plugins).toStrictEqual([{ name: 'plugin-a', status: 'success', duration: 12, error: null, schemaCount: 1, operationCount: 1 }])
+    expect(snapshot.pluginViews['plugin-a']?.operations.map((operation) => operation.operationId)).toStrictEqual(['getPet'])
+  })
+
+  it('preserves multiple plugin executions in order without overwriting their views', async () => {
+    const hooks = new Hookable<KubbHooks>()
+    const canonical = inputNode(['Pet', 'Store'])
+    const collector = createHtmlReportCollector({ hooks, getInputNode: () => canonical })
+    const cfg = config()
+
+    await hooks.callHook('kubb:build:start', {
+      config: cfg,
+      adapter: { name: 'oas' },
+      meta: canonical.meta,
+      files: [],
+      getPlugin: () => undefined,
+      upsertFile: () => [],
+    } as unknown as KubbHooks['kubb:build:start'][0])
+    await hooks.callHook('kubb:plugin:start', { plugin: plugin('plugin-a') })
+    await hooks.callHook('kubb:generate:schema', canonical.schemas[0]!, generatorContext('plugin-a', cfg))
+    await hooks.callHook('kubb:plugin:end', { plugin: plugin('plugin-a'), duration: 8, success: true, config: cfg, files: [], upsertFile: () => [] })
+    await hooks.callHook('kubb:plugin:start', { plugin: plugin('plugin-b') })
+    await hooks.callHook('kubb:generate:schema', canonical.schemas[1]!, generatorContext('plugin-b', cfg))
+    await hooks.callHook('kubb:plugin:end', {
+      plugin: plugin('plugin-b'),
+      duration: 5,
+      success: false,
+      error: new Error('boom'),
+      config: cfg,
+      files: [],
+      upsertFile: () => [],
+    })
+
+    const snapshot = collector.getSnapshot()
+
+    expect(snapshot.run?.plugins.map((entry) => ({ name: entry.name, status: entry.status, error: entry.error }))).toStrictEqual([
+      { name: 'plugin-a', status: 'success', error: null },
+      { name: 'plugin-b', status: 'failed', error: 'boom' },
+    ])
+    expect(snapshot.pluginViews['plugin-a']?.schemas.map((schema) => schema.name)).toStrictEqual(['Pet'])
+    expect(snapshot.pluginViews['plugin-b']?.schemas.map((schema) => schema.name)).toStrictEqual(['Store'])
+  })
+
+  it('uses build files as the generated file set and reads only those contents from storage', async () => {
+    const hooks = new Hookable<KubbHooks>()
+    const storage = memoryStorage()
+    await storage.writeItem('gen/pet.ts', 'export type Pet = { id: string }')
+    await storage.writeItem('unrelated.ts', 'export const unrelated = true')
+    const cfg = { ...config(), storage }
+    const generatedFile = file('gen/pet.ts')
+    const collector = createHtmlReportCollector({ hooks })
+
+    await hooks.callHook('kubb:build:end', { config: cfg, outputDir: '/workspace/gen', files: [generatedFile] })
+    await hooks.callHook('kubb:generation:end', { config: cfg, storage, status: 'success', filesCreated: 1 })
+
+    const snapshot = collector.getSnapshot()
+
+    expect(snapshot.files).toStrictEqual([{ id: generatedFile.id, name: 'pet', baseName: 'pet.ts', path: 'gen/pet.ts' }])
+    expect(snapshot.generatedFiles).toStrictEqual({ [generatedFile.id]: 'export type Pet = { id: string }' })
+  })
+
+  it('uses generation-end diagnostics as the final source of truth without duplicating live diagnostics', async () => {
+    const hooks = new Hookable<KubbHooks>()
+    const cfg = config()
+    const diagnostic = {
+      code: Diagnostics.code.pluginWarning,
+      severity: 'warning',
+      message: 'Heads up',
+      plugin: 'plugin-a',
+    } as const
+    const collector = createHtmlReportCollector({ hooks })
+
+    await hooks.callHook('kubb:build:start', {
+      config: cfg,
+      adapter: { name: 'oas' },
+      meta: undefined,
+      files: [],
+      getPlugin: () => undefined,
+      upsertFile: () => [],
+    } as unknown as KubbHooks['kubb:build:start'][0])
+    await hooks.callHook('kubb:diagnostic', { diagnostic })
+    await hooks.callHook('kubb:generation:end', { config: cfg, storage: cfg.storage, diagnostics: [diagnostic], status: 'success' })
+
+    expect(collector.getSnapshot().run?.diagnostics).toStrictEqual([
+      { code: Diagnostics.code.pluginWarning, severity: 'warning', message: 'Heads up', plugin: 'plugin-a' },
+    ])
+  })
+
+  it('keeps same-message diagnostics separate when their locations differ', async () => {
+    const hooks = new Hookable<KubbHooks>()
+    const cfg = config()
+    const diagnostics: Array<ProblemDiagnostic> = [
+      {
+        code: Diagnostics.code.pluginWarning,
+        severity: 'warning',
+        message: 'Heads up',
+        plugin: 'plugin-a',
+        location: { kind: 'schema', pointer: '#/components/schemas/Pet' },
+      },
+      {
+        code: Diagnostics.code.pluginWarning,
+        severity: 'warning',
+        message: 'Heads up',
+        plugin: 'plugin-a',
+        location: { kind: 'schema', pointer: '#/components/schemas/Store' },
+      },
+    ]
+    const collector = createHtmlReportCollector({ hooks })
+
+    await hooks.callHook('kubb:build:start', {
+      config: cfg,
+      adapter: { name: 'oas' },
+      meta: undefined,
+      files: [],
+      getPlugin: () => undefined,
+      upsertFile: () => [],
+    } as unknown as KubbHooks['kubb:build:start'][0])
+    await hooks.callHook('kubb:generation:end', { config: cfg, storage: cfg.storage, diagnostics, status: 'success' })
+
+    expect(collector.getSnapshot().run?.diagnostics).toStrictEqual(diagnostics)
+  })
+
+  it('records successful completion state from generation end', async () => {
+    const hooks = new Hookable<KubbHooks>()
+    const cfg = config()
+    const collector = createHtmlReportCollector({ hooks })
+
+    await hooks.callHook('kubb:build:start', {
+      config: cfg,
+      adapter: { name: 'oas' },
+      meta: undefined,
+      files: [],
+      getPlugin: () => undefined,
+      upsertFile: () => [],
+    } as unknown as KubbHooks['kubb:build:start'][0])
+    await hooks.callHook('kubb:generation:end', { config: cfg, storage: cfg.storage, status: 'success' })
+
+    expect(collector.getSnapshot().run?.status).toBe('success')
+  })
+
+  it('keeps state isolated between collector instances', async () => {
+    const firstHooks = new Hookable<KubbHooks>()
+    const secondHooks = new Hookable<KubbHooks>()
+    const first = createHtmlReportCollector({ hooks: firstHooks, getInputNode: () => inputNode(['A']) })
+    const second = createHtmlReportCollector({ hooks: secondHooks, getInputNode: () => inputNode(['B']) })
+
+    await firstHooks.callHook('kubb:build:start', {
+      config: { ...config(), name: 'first' },
+      adapter: { name: 'oas' },
+      meta: undefined,
+      files: [],
+      getPlugin: () => undefined,
+      upsertFile: () => [],
+    } as unknown as KubbHooks['kubb:build:start'][0])
+    await secondHooks.callHook('kubb:build:start', {
+      config: { ...config(), name: 'second' },
+      adapter: { name: 'oas' },
+      meta: undefined,
+      files: [],
+      getPlugin: () => undefined,
+      upsertFile: () => [],
+    } as unknown as KubbHooks['kubb:build:start'][0])
+
+    expect(first.getSnapshot().run?.config).toBe('first')
+    expect(first.getSnapshot().ast?.schemas.map((schema) => schema.name)).toStrictEqual(['A'])
+    expect(second.getSnapshot().run?.config).toBe('second')
+    expect(second.getSnapshot().ast?.schemas.map((schema) => schema.name)).toStrictEqual(['B'])
+  })
+
+  it('stops collecting after disposal', async () => {
+    const hooks = new Hookable<KubbHooks>()
+    const collector = createHtmlReportCollector({ hooks })
+    const cfg = config()
+
+    collector.dispose()
+    await hooks.callHook('kubb:plugin:start', { plugin: plugin('plugin-a') })
+    await hooks.callHook('kubb:generation:end', { config: cfg, storage: cfg.storage, status: 'success' })
+
+    expect(collector.getSnapshot()).toStrictEqual({ run: null, ast: null, pluginViews: {}, files: [], generatedFiles: {} })
+  })
+})

--- a/packages/core/src/reporters/htmlReportCollector.ts
+++ b/packages/core/src/reporters/htmlReportCollector.ts
@@ -1,0 +1,321 @@
+import { getElapsedMs } from '@internals/utils'
+import type { FileNode, InputMeta, InputNode, OperationNode, SchemaNode } from '@kubb/ast'
+import { type Diagnostic, type DiagnosticSeverity, Diagnostics, type ProblemDiagnostic, type UpdateDiagnostic } from '../Diagnostics.ts'
+import type { Hookable } from '../Hookable.ts'
+import type { KubbHooks } from '../types.ts'
+
+/**
+ * Outcome of one plugin execution in the collected report state.
+ */
+export type HtmlReportPluginStatus = 'running' | 'success' | 'failed'
+
+/**
+ * One plugin's lifecycle summary and generated node counts.
+ */
+export type HtmlReportPluginRun = {
+  name: string
+  status: HtmlReportPluginStatus
+  duration: number | null
+  error: string | null
+  schemaCount: number
+  operationCount: number
+}
+
+/**
+ * A diagnostic reduced to the fields the future report UI displays.
+ */
+export type HtmlReportDiagnostic = {
+  code: string
+  severity: DiagnosticSeverity
+  message: string
+  plugin: string | null
+  location?: ProblemDiagnostic['location']
+}
+
+/**
+ * The run summary shown by the future static report UI.
+ */
+export type HtmlReportRunSummary = {
+  id: number
+  config: string | null
+  status: 'running' | 'success' | 'failed'
+  duration: number | null
+  fileCount: number
+  schemaCount: number
+  operationCount: number
+  plugins: Array<HtmlReportPluginRun>
+  diagnostics: Array<HtmlReportDiagnostic>
+}
+
+/**
+ * Canonical AST captured from the driver before disposal.
+ */
+export type HtmlReportAstSnapshot = {
+  schemas: Array<SchemaNode>
+  operations: Array<OperationNode>
+  meta: InputMeta | undefined
+}
+
+/**
+ * Nodes a plugin received after its own filtering and transforms.
+ */
+export type HtmlReportPluginView = {
+  schemas: Array<SchemaNode>
+  operations: Array<OperationNode>
+}
+
+/**
+ * A generated file entry safe for the future file browser.
+ */
+export type HtmlReportFileEntry = {
+  id: string
+  name: string
+  baseName: string
+  path: string
+}
+
+/**
+ * Complete in-memory report data for the future static HTML reporter.
+ */
+export type HtmlReportSnapshot = {
+  run: HtmlReportRunSummary | null
+  ast: HtmlReportAstSnapshot | null
+  pluginViews: Record<string, HtmlReportPluginView>
+  files: Array<HtmlReportFileEntry>
+  generatedFiles: Record<string, string>
+}
+
+/**
+ * Active collector attached to one hook bus.
+ */
+export type HtmlReportCollector = {
+  getSnapshot(): HtmlReportSnapshot
+  dispose(): void
+  [Symbol.dispose](): void
+}
+
+type CreateHtmlReportCollectorOptions = {
+  hooks: Hookable<KubbHooks>
+  getInputNode?: () => InputNode | null | undefined
+}
+
+function clone<T>(value: T): T {
+  // Hook payloads can reference nodes that the driver continues to transform. Keep the report
+  // independent from those objects, especially because the canonical AST must not become a view
+  // of a later plugin execution.
+  return structuredClone(value)
+}
+
+function createRun(id: number, config: string | null): HtmlReportRunSummary {
+  return {
+    id,
+    config,
+    status: 'running',
+    duration: null,
+    fileCount: 0,
+    schemaCount: 0,
+    operationCount: 0,
+    plugins: [],
+    diagnostics: [],
+  }
+}
+
+function fileEntry(file: FileNode): HtmlReportFileEntry {
+  return {
+    id: file.id,
+    name: file.name,
+    baseName: file.baseName,
+    path: file.path,
+  }
+}
+
+function createAstSnapshot(inputNode: InputNode): HtmlReportAstSnapshot {
+  // Generate hooks expose the node/plugin view, not the original input graph. The canonical AST is
+  // therefore captured only from the driver's input node at build start.
+  return clone({
+    schemas: inputNode.schemas,
+    operations: inputNode.operations,
+    meta: inputNode.meta,
+  })
+}
+
+function getPluginRun(run: HtmlReportRunSummary | null, name: string): HtmlReportPluginRun | undefined {
+  return run?.plugins.find((plugin) => plugin.name === name)
+}
+
+function toDiagnostic(diagnostic: ProblemDiagnostic | UpdateDiagnostic): HtmlReportDiagnostic {
+  const serialized = Diagnostics.serialize(diagnostic)
+
+  return {
+    code: diagnostic.code,
+    severity: diagnostic.severity,
+    message: diagnostic.message,
+    plugin: 'plugin' in diagnostic ? (diagnostic.plugin ?? null) : null,
+    ...(serialized.location ? { location: serialized.location } : {}),
+  }
+}
+
+function collectDiagnostics(diagnostics: ReadonlyArray<Diagnostic>): Array<HtmlReportDiagnostic> {
+  return diagnostics.filter((diagnostic) => !Diagnostics.isPerformance(diagnostic)).map(toDiagnostic)
+}
+
+function dedupeDiagnostics(diagnostics: ReadonlyArray<HtmlReportDiagnostic>): Array<HtmlReportDiagnostic> {
+  // Keep the first occurrence and use the serialized report shape as the identity. That shape
+  // includes location, so equal messages from different source nodes are not merged.
+  const seen = new Set<string>()
+  const result: Array<HtmlReportDiagnostic> = []
+
+  for (const diagnostic of diagnostics) {
+    const key = JSON.stringify(diagnostic)
+    if (seen.has(key)) continue
+    seen.add(key)
+    result.push(diagnostic)
+  }
+
+  return result
+}
+
+function emptySnapshot(): HtmlReportSnapshot {
+  return {
+    run: null,
+    ast: null,
+    pluginViews: {},
+    files: [],
+    generatedFiles: {},
+  }
+}
+
+/**
+ * Attaches a standalone report collector to a Kubb hook bus. The caller owns the lifecycle and
+ * must call `dispose` before discarding the hook bus or reusing the collector's subscriptions.
+ */
+export function createHtmlReportCollector({ hooks, getInputNode }: CreateHtmlReportCollectorOptions): HtmlReportCollector {
+  let runId = 0
+  let run: HtmlReportRunSummary | null = null
+  let ast: HtmlReportAstSnapshot | null = null
+  let files: Array<HtmlReportFileEntry> = []
+  let diagnostics: Array<HtmlReportDiagnostic> = []
+  const pluginViews = new Map<string, HtmlReportPluginView>()
+  const generatedFiles = new Map<string, string>()
+
+  function viewFor(name: string): HtmlReportPluginView {
+    // Plugin names are the same identity used by KubbDriver. Creating the view lazily also keeps
+    // generation events useful when a fixture or host emits them without plugin:start.
+    let view = pluginViews.get(name)
+    if (!view) {
+      view = { schemas: [], operations: [] }
+      pluginViews.set(name, view)
+    }
+    return view
+  }
+
+  function reset(config: string | null): void {
+    // A collector may observe more than one build. Replace every run-scoped container so files,
+    // diagnostics, and plugin views from an earlier build cannot leak into the next snapshot.
+    runId += 1
+    run = createRun(runId, config)
+    ast = null
+    files = []
+    diagnostics = []
+    pluginViews.clear()
+    generatedFiles.clear()
+  }
+
+  const unhook = hooks.addHooks({
+    'kubb:build:start': ({ config }) => {
+      reset(config.name ?? null)
+
+      const inputNode = getInputNode?.()
+      if (!inputNode || !run) return
+
+      ast = createAstSnapshot(inputNode)
+      run.schemaCount = ast.schemas.length
+      run.operationCount = ast.operations.length
+    },
+
+    'kubb:plugin:start': ({ plugin }) => {
+      if (!run || getPluginRun(run, plugin.name)) return
+      run.plugins.push({ name: plugin.name, status: 'running', duration: null, error: null, schemaCount: 0, operationCount: 0 })
+    },
+
+    'kubb:plugin:end': ({ plugin, duration, success, error }) => {
+      const entry = getPluginRun(run, plugin.name)
+      if (!entry) return
+
+      entry.status = success ? 'success' : 'failed'
+      entry.duration = duration
+      entry.error = error?.message ?? null
+    },
+
+    'kubb:generate:schema': (node, ctx) => {
+      const view = viewFor(ctx.plugin.name)
+      view.schemas.push(clone(node))
+
+      const entry = getPluginRun(run, ctx.plugin.name)
+      if (entry) entry.schemaCount = view.schemas.length
+    },
+
+    'kubb:generate:operation': (node, ctx) => {
+      const view = viewFor(ctx.plugin.name)
+      view.operations.push(clone(node))
+
+      const entry = getPluginRun(run, ctx.plugin.name)
+      if (entry) entry.operationCount = view.operations.length
+    },
+
+    'kubb:diagnostic': ({ diagnostic }) => {
+      diagnostics = dedupeDiagnostics([...diagnostics, toDiagnostic(diagnostic)])
+      if (run) run.diagnostics = diagnostics
+    },
+
+    'kubb:build:end': ({ files: nextFiles }) => {
+      files = nextFiles.map(fileEntry)
+      if (run) run.fileCount = files.length
+    },
+
+    'kubb:generation:end': async ({ diagnostics: finalDiagnostics, status, hrStart, storage }) => {
+      // generation:end carries the complete diagnostic list after output processing. It replaces
+      // the live list so a diagnostic emitted earlier through kubb:diagnostic is not duplicated.
+      if (finalDiagnostics) {
+        diagnostics = dedupeDiagnostics(collectDiagnostics(finalDiagnostics))
+      }
+
+      // build:end is the authoritative file list. Read only those paths; storage may contain
+      // unrelated keys and a missing item is represented by the storage contract as null.
+      for (const file of files) {
+        const content = await storage.readItem(file.path)
+        if (content !== null) generatedFiles.set(file.id, content)
+      }
+
+      if (!run) return
+
+      run.diagnostics = diagnostics
+      if (status) run.status = status
+      if (hrStart) run.duration = Math.round(getElapsedMs(hrStart))
+    },
+  })
+
+  return {
+    getSnapshot() {
+      if (!run && !ast && files.length === 0 && pluginViews.size === 0 && generatedFiles.size === 0) return emptySnapshot()
+
+      // Return detached data so consumers of the future static data source cannot mutate the
+      // collector while it is still subscribed to lifecycle hooks.
+      return {
+        run: run ? clone(run) : null,
+        ast: ast ? clone(ast) : null,
+        pluginViews: Object.fromEntries([...pluginViews.entries()].map(([name, view]) => [name, clone(view)])),
+        files: clone(files),
+        generatedFiles: Object.fromEntries(generatedFiles),
+      }
+    },
+    dispose() {
+      // addHooks returns one unsubscriber for the whole group, including every lifecycle listener
+      // registered above.
+      unhook()
+    },
+    [Symbol.dispose]() {
+      this.dispose()
+    },
+  }
+}


### PR DESCRIPTION
## 🎯 Changes

  Adds the internal static HTML report data collector for `@kubb/core`.

  The collector:

  - Subscribes to the existing Kubb lifecycle hooks.
  - Captures the canonical AST at `kubb:build:start`.
  - Keeps canonical AST data separate from per-plugin schema/operation views.
  - Collects run summaries, plugin executions, generated file metadata and contents, and diagnostics.
  - Supports isolated instances and explicit disposal.
  - Does not depend on `@kubb/devtools`, RPC, WebSocket, devframe, Vue, HTML generation, or CLI reporter wiring.

  Adds focused unit tests covering:

  - Canonical AST versus plugin views.
  - Multiple plugins and ordering.
  - Generated files and contents.
  - Diagnostics and deduplication.
  - Lifecycle completion.
  - State isolation and cleanup.

Related to #3933. 
This is PR 1 of the stacked implementation and does not close the issue

  ## ✅ Checklist

  - [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
  - [x] I have tested this code locally with `pnpm run test`.

  ## 🚀 Release Impact

  - [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
  - [ ] This change is for the docs (no release).