### PR TITLE
Feat/3933 html reporter static UI

### DIFF
--- a/packages/core/src/reporters/htmlReportCollector.test.ts
+++ b/packages/core/src/reporters/htmlReportCollector.test.ts
@@ -1,0 +1,310 @@
+import { ast, type InputNode } from '@kubb/ast'
+import { describe, expect, it } from 'vitest'
+import { type ProblemDiagnostic, Diagnostics } from '../Diagnostics.ts'
+import { memoryStorage } from '../storages/memoryStorage.ts'
+import type { Config, KubbHooks } from '../types.ts'
+import { Hookable } from '../Hookable.ts'
+import { createHtmlReportCollector } from './htmlReportCollector.ts'
+
+function config(): Config {
+  return {
+    name: 'petstore',
+    root: '/workspace',
+    input: './petstore.yaml',
+    output: { path: './gen' },
+    parsers: [],
+    reporters: [],
+    plugins: [],
+    storage: memoryStorage(),
+  } as unknown as Config
+}
+
+function inputNode(names: Array<string>): InputNode {
+  return ast.factory.createInput({
+    meta: { title: 'Petstore', circularNames: [], enumNames: [] },
+    schemas: names.map((name) => ast.factory.createSchema({ type: 'object', name, properties: [] })),
+    operations: [],
+  })
+}
+
+function plugin(name: string) {
+  return { name } as KubbHooks['kubb:plugin:start'][0]['plugin']
+}
+
+function generatorContext(pluginName: string, cfg = config()) {
+  return {
+    config: cfg,
+    plugin: plugin(pluginName),
+  } as unknown as KubbHooks['kubb:generate:schema'][1]
+}
+
+function file(path: string) {
+  return ast.factory.createFile({
+    path,
+    baseName: path.split('/').at(-1) as `${string}.${string}`,
+    sources: [ast.factory.createSource({ nodes: [ast.factory.createText(`export const ${path.replaceAll(/[^a-z0-9]/gi, '_')} = true`)] })],
+  })
+}
+
+describe('createHtmlReportCollector', () => {
+  it('keeps the canonical AST separate from the plugin view', async () => {
+    const hooks = new Hookable<KubbHooks>()
+    const canonical = inputNode(['A', 'B', 'C'])
+    const collector = createHtmlReportCollector({ hooks, getInputNode: () => canonical })
+    const cfg = config()
+
+    await hooks.callHook('kubb:build:start', {
+      config: cfg,
+      adapter: { name: 'oas' },
+      meta: canonical.meta,
+      files: [],
+      getPlugin: () => undefined,
+      upsertFile: () => [],
+    } as unknown as KubbHooks['kubb:build:start'][0])
+    await hooks.callHook('kubb:plugin:start', { plugin: plugin('plugin-a') })
+    await hooks.callHook('kubb:generate:schema', canonical.schemas[0]!, generatorContext('plugin-a', cfg))
+
+    const snapshot = collector.getSnapshot()
+
+    expect(snapshot.ast?.schemas.map((schema) => schema.name)).toStrictEqual(['A', 'B', 'C'])
+    expect(snapshot.pluginViews['plugin-a']?.schemas.map((schema) => schema.name)).toStrictEqual(['A'])
+    expect(snapshot.run?.schemaCount).toBe(3)
+    expect(snapshot.run?.plugins[0]).toMatchObject({ name: 'plugin-a', schemaCount: 1 })
+  })
+
+  it('does not mutate the canonical AST when a plugin receives a transformed node', async () => {
+    const hooks = new Hookable<KubbHooks>()
+    const canonical = inputNode(['Pet'])
+    const collector = createHtmlReportCollector({ hooks, getInputNode: () => canonical })
+    const cfg = config()
+
+    await hooks.callHook('kubb:build:start', {
+      config: cfg,
+      adapter: { name: 'oas' },
+      meta: canonical.meta,
+      files: [],
+      getPlugin: () => undefined,
+      upsertFile: () => [],
+    } as unknown as KubbHooks['kubb:build:start'][0])
+    await hooks.callHook('kubb:plugin:start', { plugin: plugin('plugin-a') })
+    await hooks.callHook('kubb:generate:schema', ast.factory.createSchema({ type: 'string', name: 'Pet' }), generatorContext('plugin-a', cfg))
+
+    const snapshot = collector.getSnapshot()
+
+    expect(snapshot.ast?.schemas[0]).toMatchObject({ name: 'Pet', type: 'object' })
+    expect(snapshot.pluginViews['plugin-a']?.schemas[0]).toMatchObject({ name: 'Pet', type: 'string' })
+  })
+
+  it('records plugin lifecycle and associates schema and operation events with the plugin that received them', async () => {
+    const hooks = new Hookable<KubbHooks>()
+    const canonical = ast.factory.createInput({
+      meta: { circularNames: [], enumNames: [] },
+      schemas: [ast.factory.createSchema({ type: 'object', name: 'Pet', properties: [] })],
+      operations: [ast.factory.createOperation({ operationId: 'getPet', method: 'GET', path: '/pets/{petId}' })],
+    })
+    const collector = createHtmlReportCollector({ hooks, getInputNode: () => canonical })
+    const cfg = config()
+
+    await hooks.callHook('kubb:build:start', {
+      config: cfg,
+      adapter: { name: 'oas' },
+      meta: canonical.meta,
+      files: [],
+      getPlugin: () => undefined,
+      upsertFile: () => [],
+    } as unknown as KubbHooks['kubb:build:start'][0])
+    await hooks.callHook('kubb:plugin:start', { plugin: plugin('plugin-a') })
+    await hooks.callHook('kubb:generate:schema', canonical.schemas[0]!, generatorContext('plugin-a', cfg))
+    await hooks.callHook('kubb:generate:operation', canonical.operations[0]!, generatorContext('plugin-a', cfg))
+    await hooks.callHook('kubb:plugin:end', {
+      plugin: plugin('plugin-a'),
+      duration: 12,
+      success: true,
+      config: cfg,
+      files: [],
+      upsertFile: () => [],
+    })
+
+    const snapshot = collector.getSnapshot()
+
+    expect(snapshot.run?.plugins).toStrictEqual([{ name: 'plugin-a', status: 'success', duration: 12, error: null, schemaCount: 1, operationCount: 1 }])
+    expect(snapshot.pluginViews['plugin-a']?.operations.map((operation) => operation.operationId)).toStrictEqual(['getPet'])
+  })
+
+  it('preserves multiple plugin executions in order without overwriting their views', async () => {
+    const hooks = new Hookable<KubbHooks>()
+    const canonical = inputNode(['Pet', 'Store'])
+    const collector = createHtmlReportCollector({ hooks, getInputNode: () => canonical })
+    const cfg = config()
+
+    await hooks.callHook('kubb:build:start', {
+      config: cfg,
+      adapter: { name: 'oas' },
+      meta: canonical.meta,
+      files: [],
+      getPlugin: () => undefined,
+      upsertFile: () => [],
+    } as unknown as KubbHooks['kubb:build:start'][0])
+    await hooks.callHook('kubb:plugin:start', { plugin: plugin('plugin-a') })
+    await hooks.callHook('kubb:generate:schema', canonical.schemas[0]!, generatorContext('plugin-a', cfg))
+    await hooks.callHook('kubb:plugin:end', { plugin: plugin('plugin-a'), duration: 8, success: true, config: cfg, files: [], upsertFile: () => [] })
+    await hooks.callHook('kubb:plugin:start', { plugin: plugin('plugin-b') })
+    await hooks.callHook('kubb:generate:schema', canonical.schemas[1]!, generatorContext('plugin-b', cfg))
+    await hooks.callHook('kubb:plugin:end', {
+      plugin: plugin('plugin-b'),
+      duration: 5,
+      success: false,
+      error: new Error('boom'),
+      config: cfg,
+      files: [],
+      upsertFile: () => [],
+    })
+
+    const snapshot = collector.getSnapshot()
+
+    expect(snapshot.run?.plugins.map((entry) => ({ name: entry.name, status: entry.status, error: entry.error }))).toStrictEqual([
+      { name: 'plugin-a', status: 'success', error: null },
+      { name: 'plugin-b', status: 'failed', error: 'boom' },
+    ])
+    expect(snapshot.pluginViews['plugin-a']?.schemas.map((schema) => schema.name)).toStrictEqual(['Pet'])
+    expect(snapshot.pluginViews['plugin-b']?.schemas.map((schema) => schema.name)).toStrictEqual(['Store'])
+  })
+
+  it('uses build files as the generated file set and reads only those contents from storage', async () => {
+    const hooks = new Hookable<KubbHooks>()
+    const storage = memoryStorage()
+    await storage.writeItem('gen/pet.ts', 'export type Pet = { id: string }')
+    await storage.writeItem('unrelated.ts', 'export const unrelated = true')
+    const cfg = { ...config(), storage }
+    const generatedFile = file('gen/pet.ts')
+    const collector = createHtmlReportCollector({ hooks })
+
+    await hooks.callHook('kubb:build:end', { config: cfg, outputDir: '/workspace/gen', files: [generatedFile] })
+    await hooks.callHook('kubb:generation:end', { config: cfg, storage, status: 'success', filesCreated: 1 })
+
+    const snapshot = collector.getSnapshot()
+
+    expect(snapshot.files).toStrictEqual([{ id: generatedFile.id, name: 'pet', baseName: 'pet.ts', path: 'gen/pet.ts' }])
+    expect(snapshot.generatedFiles).toStrictEqual({ [generatedFile.id]: 'export type Pet = { id: string }' })
+  })
+
+  it('uses generation-end diagnostics as the final source of truth without duplicating live diagnostics', async () => {
+    const hooks = new Hookable<KubbHooks>()
+    const cfg = config()
+    const diagnostic = {
+      code: Diagnostics.code.pluginWarning,
+      severity: 'warning',
+      message: 'Heads up',
+      plugin: 'plugin-a',
+    } as const
+    const collector = createHtmlReportCollector({ hooks })
+
+    await hooks.callHook('kubb:build:start', {
+      config: cfg,
+      adapter: { name: 'oas' },
+      meta: undefined,
+      files: [],
+      getPlugin: () => undefined,
+      upsertFile: () => [],
+    } as unknown as KubbHooks['kubb:build:start'][0])
+    await hooks.callHook('kubb:diagnostic', { diagnostic })
+    await hooks.callHook('kubb:generation:end', { config: cfg, storage: cfg.storage, diagnostics: [diagnostic], status: 'success' })
+
+    expect(collector.getSnapshot().run?.diagnostics).toStrictEqual([
+      { code: Diagnostics.code.pluginWarning, severity: 'warning', message: 'Heads up', plugin: 'plugin-a' },
+    ])
+  })
+
+  it('keeps same-message diagnostics separate when their locations differ', async () => {
+    const hooks = new Hookable<KubbHooks>()
+    const cfg = config()
+    const diagnostics: Array<ProblemDiagnostic> = [
+      {
+        code: Diagnostics.code.pluginWarning,
+        severity: 'warning',
+        message: 'Heads up',
+        plugin: 'plugin-a',
+        location: { kind: 'schema', pointer: '#/components/schemas/Pet' },
+      },
+      {
+        code: Diagnostics.code.pluginWarning,
+        severity: 'warning',
+        message: 'Heads up',
+        plugin: 'plugin-a',
+        location: { kind: 'schema', pointer: '#/components/schemas/Store' },
+      },
+    ]
+    const collector = createHtmlReportCollector({ hooks })
+
+    await hooks.callHook('kubb:build:start', {
+      config: cfg,
+      adapter: { name: 'oas' },
+      meta: undefined,
+      files: [],
+      getPlugin: () => undefined,
+      upsertFile: () => [],
+    } as unknown as KubbHooks['kubb:build:start'][0])
+    await hooks.callHook('kubb:generation:end', { config: cfg, storage: cfg.storage, diagnostics, status: 'success' })
+
+    expect(collector.getSnapshot().run?.diagnostics).toStrictEqual(diagnostics)
+  })
+
+  it('records successful completion state from generation end', async () => {
+    const hooks = new Hookable<KubbHooks>()
+    const cfg = config()
+    const collector = createHtmlReportCollector({ hooks })
+
+    await hooks.callHook('kubb:build:start', {
+      config: cfg,
+      adapter: { name: 'oas' },
+      meta: undefined,
+      files: [],
+      getPlugin: () => undefined,
+      upsertFile: () => [],
+    } as unknown as KubbHooks['kubb:build:start'][0])
+    await hooks.callHook('kubb:generation:end', { config: cfg, storage: cfg.storage, status: 'success' })
+
+    expect(collector.getSnapshot().run?.status).toBe('success')
+  })
+
+  it('keeps state isolated between collector instances', async () => {
+    const firstHooks = new Hookable<KubbHooks>()
+    const secondHooks = new Hookable<KubbHooks>()
+    const first = createHtmlReportCollector({ hooks: firstHooks, getInputNode: () => inputNode(['A']) })
+    const second = createHtmlReportCollector({ hooks: secondHooks, getInputNode: () => inputNode(['B']) })
+
+    await firstHooks.callHook('kubb:build:start', {
+      config: { ...config(), name: 'first' },
+      adapter: { name: 'oas' },
+      meta: undefined,
+      files: [],
+      getPlugin: () => undefined,
+      upsertFile: () => [],
+    } as unknown as KubbHooks['kubb:build:start'][0])
+    await secondHooks.callHook('kubb:build:start', {
+      config: { ...config(), name: 'second' },
+      adapter: { name: 'oas' },
+      meta: undefined,
+      files: [],
+      getPlugin: () => undefined,
+      upsertFile: () => [],
+    } as unknown as KubbHooks['kubb:build:start'][0])
+
+    expect(first.getSnapshot().run?.config).toBe('first')
+    expect(first.getSnapshot().ast?.schemas.map((schema) => schema.name)).toStrictEqual(['A'])
+    expect(second.getSnapshot().run?.config).toBe('second')
+    expect(second.getSnapshot().ast?.schemas.map((schema) => schema.name)).toStrictEqual(['B'])
+  })
+
+  it('stops collecting after disposal', async () => {
+    const hooks = new Hookable<KubbHooks>()
+    const collector = createHtmlReportCollector({ hooks })
+    const cfg = config()
+
+    collector.dispose()
+    await hooks.callHook('kubb:plugin:start', { plugin: plugin('plugin-a') })
+    await hooks.callHook('kubb:generation:end', { config: cfg, storage: cfg.storage, status: 'success' })
+
+    expect(collector.getSnapshot()).toStrictEqual({ run: null, ast: null, pluginViews: {}, files: [], generatedFiles: {} })
+  })
+})

--- a/packages/core/src/reporters/htmlReportCollector.ts
+++ b/packages/core/src/reporters/htmlReportCollector.ts
@@ -1,0 +1,321 @@
+import { getElapsedMs } from '@internals/utils'
+import type { FileNode, InputMeta, InputNode, OperationNode, SchemaNode } from '@kubb/ast'
+import { type Diagnostic, type DiagnosticSeverity, Diagnostics, type ProblemDiagnostic, type UpdateDiagnostic } from '../Diagnostics.ts'
+import type { Hookable } from '../Hookable.ts'
+import type { KubbHooks } from '../types.ts'
+
+/**
+ * Outcome of one plugin execution in the collected report state.
+ */
+export type HtmlReportPluginStatus = 'running' | 'success' | 'failed'
+
+/**
+ * One plugin's lifecycle summary and generated node counts.
+ */
+export type HtmlReportPluginRun = {
+  name: string
+  status: HtmlReportPluginStatus
+  duration: number | null
+  error: string | null
+  schemaCount: number
+  operationCount: number
+}
+
+/**
+ * A diagnostic reduced to the fields the future report UI displays.
+ */
+export type HtmlReportDiagnostic = {
+  code: string
+  severity: DiagnosticSeverity
+  message: string
+  plugin: string | null
+  location?: ProblemDiagnostic['location']
+}
+
+/**
+ * The run summary shown by the future static report UI.
+ */
+export type HtmlReportRunSummary = {
+  id: number
+  config: string | null
+  status: 'running' | 'success' | 'failed'
+  duration: number | null
+  fileCount: number
+  schemaCount: number
+  operationCount: number
+  plugins: Array<HtmlReportPluginRun>
+  diagnostics: Array<HtmlReportDiagnostic>
+}
+
+/**
+ * Canonical AST captured from the driver before disposal.
+ */
+export type HtmlReportAstSnapshot = {
+  schemas: Array<SchemaNode>
+  operations: Array<OperationNode>
+  meta: InputMeta | undefined
+}
+
+/**
+ * Nodes a plugin received after its own filtering and transforms.
+ */
+export type HtmlReportPluginView = {
+  schemas: Array<SchemaNode>
+  operations: Array<OperationNode>
+}
+
+/**
+ * A generated file entry safe for the future file browser.
+ */
+export type HtmlReportFileEntry = {
+  id: string
+  name: string
+  baseName: string
+  path: string
+}
+
+/**
+ * Complete in-memory report data for the future static HTML reporter.
+ */
+export type HtmlReportSnapshot = {
+  run: HtmlReportRunSummary | null
+  ast: HtmlReportAstSnapshot | null
+  pluginViews: Record<string, HtmlReportPluginView>
+  files: Array<HtmlReportFileEntry>
+  generatedFiles: Record<string, string>
+}
+
+/**
+ * Active collector attached to one hook bus.
+ */
+export type HtmlReportCollector = {
+  getSnapshot(): HtmlReportSnapshot
+  dispose(): void
+  [Symbol.dispose](): void
+}
+
+type CreateHtmlReportCollectorOptions = {
+  hooks: Hookable<KubbHooks>
+  getInputNode?: () => InputNode | null | undefined
+}
+
+function clone<T>(value: T): T {
+  // Hook payloads can reference nodes that the driver continues to transform. Keep the report
+  // independent from those objects, especially because the canonical AST must not become a view
+  // of a later plugin execution.
+  return structuredClone(value)
+}
+
+function createRun(id: number, config: string | null): HtmlReportRunSummary {
+  return {
+    id,
+    config,
+    status: 'running',
+    duration: null,
+    fileCount: 0,
+    schemaCount: 0,
+    operationCount: 0,
+    plugins: [],
+    diagnostics: [],
+  }
+}
+
+function fileEntry(file: FileNode): HtmlReportFileEntry {
+  return {
+    id: file.id,
+    name: file.name,
+    baseName: file.baseName,
+    path: file.path,
+  }
+}
+
+function createAstSnapshot(inputNode: InputNode): HtmlReportAstSnapshot {
+  // Generate hooks expose the node/plugin view, not the original input graph. The canonical AST is
+  // therefore captured only from the driver's input node at build start.
+  return clone({
+    schemas: inputNode.schemas,
+    operations: inputNode.operations,
+    meta: inputNode.meta,
+  })
+}
+
+function getPluginRun(run: HtmlReportRunSummary | null, name: string): HtmlReportPluginRun | undefined {
+  return run?.plugins.find((plugin) => plugin.name === name)
+}
+
+function toDiagnostic(diagnostic: ProblemDiagnostic | UpdateDiagnostic): HtmlReportDiagnostic {
+  const serialized = Diagnostics.serialize(diagnostic)
+
+  return {
+    code: diagnostic.code,
+    severity: diagnostic.severity,
+    message: diagnostic.message,
+    plugin: 'plugin' in diagnostic ? (diagnostic.plugin ?? null) : null,
+    ...(serialized.location ? { location: serialized.location } : {}),
+  }
+}
+
+function collectDiagnostics(diagnostics: ReadonlyArray<Diagnostic>): Array<HtmlReportDiagnostic> {
+  return diagnostics.filter((diagnostic) => !Diagnostics.isPerformance(diagnostic)).map(toDiagnostic)
+}
+
+function dedupeDiagnostics(diagnostics: ReadonlyArray<HtmlReportDiagnostic>): Array<HtmlReportDiagnostic> {
+  // Keep the first occurrence and use the serialized report shape as the identity. That shape
+  // includes location, so equal messages from different source nodes are not merged.
+  const seen = new Set<string>()
+  const result: Array<HtmlReportDiagnostic> = []
+
+  for (const diagnostic of diagnostics) {
+    const key = JSON.stringify(diagnostic)
+    if (seen.has(key)) continue
+    seen.add(key)
+    result.push(diagnostic)
+  }
+
+  return result
+}
+
+function emptySnapshot(): HtmlReportSnapshot {
+  return {
+    run: null,
+    ast: null,
+    pluginViews: {},
+    files: [],
+    generatedFiles: {},
+  }
+}
+
+/**
+ * Attaches a standalone report collector to a Kubb hook bus. The caller owns the lifecycle and
+ * must call `dispose` before discarding the hook bus or reusing the collector's subscriptions.
+ */
+export function createHtmlReportCollector({ hooks, getInputNode }: CreateHtmlReportCollectorOptions): HtmlReportCollector {
+  let runId = 0
+  let run: HtmlReportRunSummary | null = null
+  let ast: HtmlReportAstSnapshot | null = null
+  let files: Array<HtmlReportFileEntry> = []
+  let diagnostics: Array<HtmlReportDiagnostic> = []
+  const pluginViews = new Map<string, HtmlReportPluginView>()
+  const generatedFiles = new Map<string, string>()
+
+  function viewFor(name: string): HtmlReportPluginView {
+    // Plugin names are the same identity used by KubbDriver. Creating the view lazily also keeps
+    // generation events useful when a fixture or host emits them without plugin:start.
+    let view = pluginViews.get(name)
+    if (!view) {
+      view = { schemas: [], operations: [] }
+      pluginViews.set(name, view)
+    }
+    return view
+  }
+
+  function reset(config: string | null): void {
+    // A collector may observe more than one build. Replace every run-scoped container so files,
+    // diagnostics, and plugin views from an earlier build cannot leak into the next snapshot.
+    runId += 1
+    run = createRun(runId, config)
+    ast = null
+    files = []
+    diagnostics = []
+    pluginViews.clear()
+    generatedFiles.clear()
+  }
+
+  const unhook = hooks.addHooks({
+    'kubb:build:start': ({ config }) => {
+      reset(config.name ?? null)
+
+      const inputNode = getInputNode?.()
+      if (!inputNode || !run) return
+
+      ast = createAstSnapshot(inputNode)
+      run.schemaCount = ast.schemas.length
+      run.operationCount = ast.operations.length
+    },
+
+    'kubb:plugin:start': ({ plugin }) => {
+      if (!run || getPluginRun(run, plugin.name)) return
+      run.plugins.push({ name: plugin.name, status: 'running', duration: null, error: null, schemaCount: 0, operationCount: 0 })
+    },
+
+    'kubb:plugin:end': ({ plugin, duration, success, error }) => {
+      const entry = getPluginRun(run, plugin.name)
+      if (!entry) return
+
+      entry.status = success ? 'success' : 'failed'
+      entry.duration = duration
+      entry.error = error?.message ?? null
+    },
+
+    'kubb:generate:schema': (node, ctx) => {
+      const view = viewFor(ctx.plugin.name)
+      view.schemas.push(clone(node))
+
+      const entry = getPluginRun(run, ctx.plugin.name)
+      if (entry) entry.schemaCount = view.schemas.length
+    },
+
+    'kubb:generate:operation': (node, ctx) => {
+      const view = viewFor(ctx.plugin.name)
+      view.operations.push(clone(node))
+
+      const entry = getPluginRun(run, ctx.plugin.name)
+      if (entry) entry.operationCount = view.operations.length
+    },
+
+    'kubb:diagnostic': ({ diagnostic }) => {
+      diagnostics = dedupeDiagnostics([...diagnostics, toDiagnostic(diagnostic)])
+      if (run) run.diagnostics = diagnostics
+    },
+
+    'kubb:build:end': ({ files: nextFiles }) => {
+      files = nextFiles.map(fileEntry)
+      if (run) run.fileCount = files.length
+    },
+
+    'kubb:generation:end': async ({ diagnostics: finalDiagnostics, status, hrStart, storage }) => {
+      // generation:end carries the complete diagnostic list after output processing. It replaces
+      // the live list so a diagnostic emitted earlier through kubb:diagnostic is not duplicated.
+      if (finalDiagnostics) {
+        diagnostics = dedupeDiagnostics(collectDiagnostics(finalDiagnostics))
+      }
+
+      // build:end is the authoritative file list. Read only those paths; storage may contain
+      // unrelated keys and a missing item is represented by the storage contract as null.
+      for (const file of files) {
+        const content = await storage.readItem(file.path)
+        if (content !== null) generatedFiles.set(file.id, content)
+      }
+
+      if (!run) return
+
+      run.diagnostics = diagnostics
+      if (status) run.status = status
+      if (hrStart) run.duration = Math.round(getElapsedMs(hrStart))
+    },
+  })
+
+  return {
+    getSnapshot() {
+      if (!run && !ast && files.length === 0 && pluginViews.size === 0 && generatedFiles.size === 0) return emptySnapshot()
+
+      // Return detached data so consumers of the future static data source cannot mutate the
+      // collector while it is still subscribed to lifecycle hooks.
+      return {
+        run: run ? clone(run) : null,
+        ast: ast ? clone(ast) : null,
+        pluginViews: Object.fromEntries([...pluginViews.entries()].map(([name, view]) => [name, clone(view)])),
+        files: clone(files),
+        generatedFiles: Object.fromEntries(generatedFiles),
+      }
+    },
+    dispose() {
+      // addHooks returns one unsubscriber for the whole group, including every lifecycle listener
+      // registered above.
+      unhook()
+    },
+    [Symbol.dispose]() {
+      this.dispose()
+    },
+  }
+}

--- a/packages/devtools/client/index.html
+++ b/packages/devtools/client/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Kubb DevTools</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/devtools/client/src/App.vue
+++ b/packages/devtools/client/src/App.vue
@@ -1,0 +1,187 @@
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import AstPanel from './components/AstPanel.vue'
+import FilesPanel from './components/FilesPanel.vue'
+import PipelinePanel from './components/PipelinePanel.vue'
+import { connect, connected, connectionError, run } from './devtools'
+
+const tab = ref<'pipeline' | 'ast' | 'files'>('pipeline')
+const dark = ref(false)
+
+onMounted(() => {
+  // tokens.css has no prefers-color-scheme block on purpose, so the class is ours to set.
+  dark.value = window.matchMedia('(prefers-color-scheme: dark)').matches
+  applyTheme()
+  connect()
+})
+
+function applyTheme() {
+  document.documentElement.classList.toggle('dark', dark.value)
+}
+
+function toggleTheme() {
+  dark.value = !dark.value
+  applyTheme()
+}
+
+const status = computed(() => run.value?.status ?? 'running')
+
+const elapsed = computed(() => {
+  if (run.value?.duration === null || run.value?.duration === undefined) return null
+  const ms = run.value.duration
+  return ms >= 1000 ? `${(ms / 1000).toFixed(2)}s` : `${ms}ms`
+})
+</script>
+
+<template>
+  <div class="app">
+    <header>
+      <div class="brand">
+        <span class="mark">kubb</span>
+        <span class="title">DevTools</span>
+        <span v-if="run?.config" class="config">{{ run.config }}</span>
+      </div>
+
+      <nav>
+        <button type="button" :class="{ active: tab === 'pipeline' }" @click="tab = 'pipeline'">Pipeline</button>
+        <button type="button" :class="{ active: tab === 'ast' }" @click="tab = 'ast'">AST</button>
+        <button type="button" :class="{ active: tab === 'files' }" @click="tab = 'files'">Files</button>
+      </nav>
+
+      <div class="meta">
+        <span class="status" :data-status="status">{{ status }}</span>
+        <span v-if="elapsed" class="elapsed">{{ elapsed }}</span>
+        <button type="button" class="theme" @click="toggleTheme">{{ dark ? '☾' : '☀' }}</button>
+      </div>
+    </header>
+
+    <p v-if="connectionError" class="banner error">Could not connect: {{ connectionError }}</p>
+    <p v-else-if="!connected" class="banner">Connecting…</p>
+
+    <main>
+      <PipelinePanel v-show="tab === 'pipeline'" />
+      <AstPanel v-show="tab === 'ast'" />
+      <FilesPanel v-show="tab === 'files'" />
+    </main>
+  </div>
+</template>
+
+<style scoped>
+.app {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0 1rem;
+  height: var(--ui-header-height, 3rem);
+  border-bottom: 1px solid var(--kubb-line);
+  flex: none;
+}
+
+.brand {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.mark {
+  color: var(--kubb-brand);
+  font-weight: 700;
+}
+
+.title {
+  font-weight: 600;
+}
+
+.config {
+  color: var(--kubb-text-3);
+  font-family: var(--kubb-font-mono);
+  font-size: 0.75rem;
+}
+
+nav {
+  display: flex;
+  gap: 0.25rem;
+}
+
+nav button {
+  padding: 0.3rem 0.75rem;
+  border: 1px solid transparent;
+  border-radius: var(--kubb-radius-md, 0.375rem);
+  background: transparent;
+  color: var(--kubb-text-2);
+  font-size: 0.85rem;
+}
+
+nav button.active {
+  border-color: var(--kubb-line);
+  background: var(--kubb-bg-soft);
+  color: var(--kubb-text);
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.78rem;
+}
+
+.status {
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+}
+
+.status[data-status='running'] {
+  color: var(--kubb-warning);
+}
+
+.status[data-status='success'] {
+  color: var(--kubb-success);
+}
+
+.status[data-status='failed'] {
+  color: var(--kubb-danger);
+}
+
+.elapsed {
+  color: var(--kubb-text-3);
+  font-family: var(--kubb-font-mono);
+}
+
+.theme {
+  border: 1px solid var(--kubb-line);
+  border-radius: var(--kubb-radius-md, 0.375rem);
+  background: transparent;
+  padding: 0.15rem 0.45rem;
+  color: var(--kubb-text-2);
+}
+
+.banner {
+  margin: 0;
+  padding: 0.4rem 1rem;
+  background: var(--kubb-bg-soft);
+  color: var(--kubb-text-2);
+  font-size: 0.8rem;
+}
+
+.banner.error {
+  color: var(--kubb-danger);
+}
+
+main {
+  flex: 1;
+  min-height: 0;
+  padding: 1rem;
+}
+
+main > * {
+  height: 100%;
+}
+</style>

--- a/packages/devtools/client/src/components/AstNode.vue
+++ b/packages/devtools/client/src/components/AstNode.vue
@@ -1,0 +1,119 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+
+type Props = {
+  label: string
+  value: unknown
+  depth?: number
+  /** Renders the row dimmed, used for nodes a plugin never received. */
+  muted?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), { depth: 0, muted: false })
+
+const open = ref(props.depth < 1)
+
+const isBranch = computed(() => typeof props.value === 'object' && props.value !== null)
+
+// AST nodes carry every optional field explicitly, so an unfiltered tree is mostly
+// `undefined` rows. Hiding them is what makes the panel readable.
+const entries = computed<Array<[string, unknown]>>(() => {
+  if (!isBranch.value) return []
+  if (Array.isArray(props.value)) return props.value.map((item, index) => [String(index), item])
+  return Object.entries(props.value as Record<string, unknown>).filter(([, value]) => value !== undefined)
+})
+
+// The AST's own discriminators are worth surfacing on the collapsed row, so a closed
+// branch still says what it is.
+const badge = computed(() => {
+  if (!isBranch.value || Array.isArray(props.value)) return null
+  const record = props.value as Record<string, unknown>
+  const name = typeof record.name === 'string' ? record.name : null
+  const kind = typeof record.type === 'string' ? record.type : typeof record.kind === 'string' ? record.kind : null
+  return [name, kind].filter(Boolean).join(' · ') || null
+})
+
+const preview = computed(() => {
+  if (Array.isArray(props.value)) return `[${props.value.length}]`
+  if (isBranch.value) return badge.value ?? '{…}'
+  if (typeof props.value === 'string') return `"${props.value}"`
+  return String(props.value)
+})
+
+const color = computed(() => {
+  if (Array.isArray(props.value)) return 'var(--kubb-viz-teal)'
+  if (isBranch.value) return 'var(--kubb-viz-indigo)'
+  if (typeof props.value === 'string') return 'var(--kubb-viz-green)'
+  return 'var(--kubb-viz-violet)'
+})
+</script>
+
+<template>
+  <div class="ast-node" :class="{ muted }">
+    <button v-if="isBranch" class="ast-row" type="button" @click="open = !open">
+      <span class="ast-caret">{{ open ? '▾' : '▸' }}</span>
+      <span class="ast-label">{{ label }}</span>
+      <span class="ast-preview" :style="{ color }">{{ preview }}</span>
+    </button>
+    <div v-else class="ast-row leaf">
+      <span class="ast-caret" />
+      <span class="ast-label">{{ label }}</span>
+      <span class="ast-preview" :style="{ color }">{{ preview }}</span>
+    </div>
+
+    <div v-if="isBranch && open" class="ast-children">
+      <AstNode v-for="[key, child] in entries" :key="key" :label="key" :value="child" :depth="depth + 1" :muted="muted" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.ast-node.muted {
+  opacity: 0.45;
+}
+
+.ast-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  width: 100%;
+  padding: 0.15rem 0.35rem;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  font-family: var(--kubb-font-mono);
+  font-size: 0.8rem;
+  text-align: left;
+  color: var(--kubb-text);
+}
+
+.ast-row:hover {
+  background: var(--kubb-bg-soft);
+}
+
+.ast-row.leaf:hover {
+  background: transparent;
+}
+
+.ast-caret {
+  width: 0.75rem;
+  flex: none;
+  color: var(--kubb-text-3);
+}
+
+.ast-label {
+  color: var(--kubb-text-2);
+}
+
+.ast-preview {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ast-children {
+  margin-left: 0.75rem;
+  border-left: 1px solid var(--kubb-line-soft);
+  padding-left: 0.35rem;
+}
+</style>

--- a/packages/devtools/client/src/components/AstPanel.vue
+++ b/packages/devtools/client/src/components/AstPanel.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { type AstSnapshot, fetchAst, run } from '../devtools'
+import AstNode from './AstNode.vue'
+
+const ast = ref<AstSnapshot | null>(null)
+const filter = ref('')
+const tab = ref<'schemas' | 'operations'>('schemas')
+
+async function load() {
+  ast.value = await fetchAst()
+}
+
+// The run id changes on every build, including watch rebuilds, so this refetches
+// without the panel needing its own reload affordance.
+watch(() => run.value?.id, load, { immediate: true })
+
+function nameOf(node: Record<string, unknown>): string {
+  if (typeof node.name === 'string') return node.name
+  if (typeof node.operationId === 'string') return node.operationId
+  if (typeof node.path === 'string') return node.path
+  return 'unnamed'
+}
+
+const nodes = computed(() => {
+  const list = tab.value === 'schemas' ? (ast.value?.schemas ?? []) : (ast.value?.operations ?? [])
+  const needle = filter.value.trim().toLowerCase()
+  if (!needle) return list
+  return list.filter((node) => nameOf(node).toLowerCase().includes(needle))
+})
+</script>
+
+<template>
+  <div class="panel">
+    <div class="toolbar">
+      <div class="tabs">
+        <button type="button" :class="{ active: tab === 'schemas' }" @click="tab = 'schemas'">
+          Schemas <span class="count">{{ ast?.schemas.length ?? 0 }}</span>
+        </button>
+        <button type="button" :class="{ active: tab === 'operations' }" @click="tab = 'operations'">
+          Operations <span class="count">{{ ast?.operations.length ?? 0 }}</span>
+        </button>
+      </div>
+      <input v-model="filter" class="filter" type="search" placeholder="Filter by name" />
+    </div>
+
+    <p v-if="!ast" class="empty">No AST captured yet. It is snapshotted when a build starts.</p>
+    <p v-else-if="!nodes.length" class="empty">Nothing matches this filter.</p>
+
+    <div v-else class="tree">
+      <AstNode v-for="(node, index) in nodes" :key="index" :label="nameOf(node)" :value="node" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-bottom: 0.75rem;
+}
+
+.tabs {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.tabs button {
+  padding: 0.3rem 0.7rem;
+  border: 1px solid transparent;
+  border-radius: var(--kubb-radius-md, 0.375rem);
+  background: transparent;
+  color: var(--kubb-text-2);
+  font-size: 0.85rem;
+}
+
+.tabs button.active {
+  border-color: var(--kubb-line);
+  background: var(--kubb-bg-soft);
+  color: var(--kubb-text);
+}
+
+.count {
+  color: var(--kubb-text-3);
+  font-family: var(--kubb-font-mono);
+  font-size: 0.75rem;
+}
+
+.filter {
+  width: 14rem;
+  padding: 0.3rem 0.6rem;
+  border: 1px solid var(--kubb-line);
+  border-radius: var(--kubb-radius-md, 0.375rem);
+  background: var(--kubb-bg);
+  color: var(--kubb-text);
+  font-size: 0.85rem;
+}
+
+.tree {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  border: 1px solid var(--kubb-line);
+  border-radius: var(--kubb-radius-lg, 0.5rem);
+  background: var(--kubb-bg-soft);
+  padding: 0.5rem;
+}
+
+.empty {
+  color: var(--kubb-text-3);
+  font-size: 0.875rem;
+}
+</style>

--- a/packages/devtools/client/src/components/FilesPanel.vue
+++ b/packages/devtools/client/src/components/FilesPanel.vue
@@ -1,0 +1,142 @@
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { type FileEntry, fetchFiles, readGeneratedFile, run } from '../devtools'
+import { highlight } from '../highlight'
+
+const files = ref<Array<FileEntry>>([])
+const selected = ref<FileEntry | null>(null)
+const content = ref<string | null>(null)
+const highlighted = ref('')
+const loading = ref(false)
+
+watch(
+  () => run.value?.id,
+  async () => {
+    files.value = await fetchFiles()
+  },
+  { immediate: true },
+)
+
+// Files only land in the store at `kubb:build:end`, so the count moving is the cue to refetch.
+watch(
+  () => run.value?.fileCount,
+  async () => {
+    files.value = await fetchFiles()
+  },
+)
+
+async function select(file: FileEntry) {
+  selected.value = file
+  loading.value = true
+  highlighted.value = ''
+  content.value = await readGeneratedFile(file.id)
+  loading.value = false
+
+  if (content.value !== null) {
+    highlighted.value = await highlight(content.value, file.baseName)
+  }
+}
+</script>
+
+<template>
+  <div class="panel">
+    <div class="list">
+      <p v-if="!files.length" class="empty">No files written yet.</p>
+      <button v-for="file in files" :key="file.id" type="button" class="file" :class="{ active: selected?.id === file.id }" @click="select(file)">
+        {{ file.baseName }}
+        <span class="path">{{ file.path }}</span>
+      </button>
+    </div>
+
+    <div class="preview">
+      <p v-if="!selected" class="empty">Select a file to read what Kubb wrote.</p>
+      <p v-else-if="loading" class="empty">Reading…</p>
+      <p v-else-if="content === null" class="empty">Could not read this file from disk. It may not have been flushed yet.</p>
+      <div v-else class="code" v-html="highlighted" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.panel {
+  display: grid;
+  grid-template-columns: 22rem 1fr;
+  gap: 1rem;
+  height: 100%;
+  min-height: 0;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-height: 0;
+  overflow: auto;
+  padding-right: 0.25rem;
+}
+
+.file {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  padding: 0.35rem 0.5rem;
+  border: 1px solid transparent;
+  border-radius: var(--kubb-radius-md, 0.375rem);
+  background: transparent;
+  text-align: left;
+  color: var(--kubb-text);
+  font-family: var(--kubb-font-mono);
+  font-size: 0.8rem;
+}
+
+.file:hover {
+  background: var(--kubb-bg-soft);
+}
+
+.file.active {
+  border-color: var(--kubb-brand);
+  background: var(--kubb-brand-dim);
+}
+
+.path {
+  color: var(--kubb-text-3);
+  font-size: 0.7rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.preview {
+  min-height: 0;
+  overflow: auto;
+  border: 1px solid var(--kubb-line);
+  border-radius: var(--kubb-radius-lg, 0.5rem);
+  background: var(--kubb-bg-soft);
+}
+
+.preview > .empty {
+  padding: 0.75rem;
+}
+
+.preview :deep(pre.shiki) {
+  margin: 0;
+  padding: 0.75rem;
+  background: transparent !important;
+  font-family: var(--kubb-font-mono);
+  font-size: 0.78rem;
+  line-height: 1.5;
+  white-space: pre;
+}
+
+/* tokens.css deliberately has no prefers-color-scheme block, so this only fires once the
+   app sets .dark on the root itself — see App.vue's theme toggle. */
+.dark .preview :deep(.shiki),
+.dark .preview :deep(.shiki span) {
+  color: var(--shiki-dark) !important;
+}
+
+.empty {
+  color: var(--kubb-text-3);
+  font-size: 0.875rem;
+}
+</style>

--- a/packages/devtools/client/src/components/PipelinePanel.vue
+++ b/packages/devtools/client/src/components/PipelinePanel.vue
@@ -1,0 +1,324 @@
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { type AstSnapshot, fetchAst, fetchPluginView, run } from '../devtools'
+
+type NodeKind = 'schema' | 'operation'
+
+type Entry = {
+  name: string
+  kind: NodeKind
+}
+
+const selected = ref<string | null>(null)
+const ast = ref<AstSnapshot | null>(null)
+const view = ref<AstSnapshot | null>(null)
+
+const plugins = computed(() => run.value?.plugins ?? [])
+
+function nameOf(node: Record<string, unknown>): string {
+  if (typeof node.name === 'string') return node.name
+  if (typeof node.operationId === 'string') return node.operationId
+  return 'unnamed'
+}
+
+function entryKey(entry: Entry): string {
+  return `${entry.kind}:${entry.name}`
+}
+
+function toEntries(nodes: Array<Record<string, unknown>>, kind: NodeKind): Array<Entry> {
+  return nodes.map((node) => ({ name: nameOf(node), kind }))
+}
+
+function entriesOf(snapshot: AstSnapshot | null): Array<Entry> {
+  if (!snapshot) return []
+  return [...toEntries(snapshot.schemas, 'schema'), ...toEntries(snapshot.operations, 'operation')]
+}
+
+watch(
+  () => run.value?.id,
+  async () => {
+    ast.value = await fetchAst()
+  },
+  { immediate: true },
+)
+
+watch(selected, async (name) => {
+  view.value = name ? await fetchPluginView(name) : null
+})
+
+const received = computed(() => entriesOf(view.value))
+
+// The whole point of the panel: the canonical schemas and operations a plugin never received,
+// because its `include` / `exclude` filtered them out.
+const skipped = computed(() => {
+  const seen = new Set(received.value.map(entryKey))
+  return entriesOf(ast.value).filter((entry) => !seen.has(entryKey(entry)))
+})
+
+function durationLabel(ms: number | null): string {
+  if (ms === null) return '…'
+  return ms >= 1000 ? `${(ms / 1000).toFixed(2)}s` : `${ms}ms`
+}
+
+const maxDuration = computed(() => Math.max(1, ...plugins.value.map((plugin) => plugin.duration ?? 0)))
+</script>
+
+<template>
+  <div class="panel">
+    <div class="plugins">
+      <p v-if="!plugins.length" class="empty">No plugins have run yet.</p>
+      <button
+        v-for="plugin in plugins"
+        :key="plugin.name"
+        type="button"
+        class="plugin"
+        :class="{ active: selected === plugin.name }"
+        @click="selected = selected === plugin.name ? null : plugin.name"
+      >
+        <span class="dot" :data-status="plugin.status" />
+        <span class="name">{{ plugin.name }}</span>
+        <span class="counts">{{ plugin.schemaCount }} schemas · {{ plugin.operationCount }} operations</span>
+        <span class="bar-track">
+          <span class="bar" :style="{ width: `${((plugin.duration ?? 0) / maxDuration) * 100}%` }" />
+        </span>
+        <span class="duration">{{ durationLabel(plugin.duration) }}</span>
+      </button>
+    </div>
+
+    <div v-if="selected" class="detail">
+      <h3>{{ selected }}</h3>
+      <p class="hint">
+        What this plugin received during the walk, against the canonical AST — schemas and operations both. A skipped node was filtered out by the plugin's
+        <code>include</code> / <code>exclude</code> / <code>override</code>.
+      </p>
+
+      <div class="columns">
+        <section>
+          <h4>
+            Received <span class="count">{{ received.length }}</span>
+          </h4>
+          <ul>
+            <li v-for="entry in received" :key="entryKey(entry)">
+              <span class="kind-badge" :data-kind="entry.kind" :title="entry.kind">{{ entry.kind === 'schema' ? 'S' : 'O' }}</span>
+              {{ entry.name }}
+            </li>
+          </ul>
+        </section>
+        <section>
+          <h4>
+            Skipped <span class="count">{{ skipped.length }}</span>
+          </h4>
+          <ul class="skipped">
+            <li v-for="entry in skipped" :key="entryKey(entry)">
+              <span class="kind-badge" :data-kind="entry.kind" :title="entry.kind">{{ entry.kind === 'schema' ? 'S' : 'O' }}</span>
+              {{ entry.name }}
+            </li>
+          </ul>
+        </section>
+      </div>
+    </div>
+
+    <div v-if="run?.diagnostics.length" class="diagnostics">
+      <h4>Diagnostics</h4>
+      <ul>
+        <li v-for="(diagnostic, index) in run.diagnostics" :key="index" :data-severity="diagnostic.severity">
+          <code>{{ diagnostic.code }}</code>
+          <span>{{ diagnostic.message }}</span>
+          <span v-if="diagnostic.plugin" class="owner">{{ diagnostic.plugin }}</span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  height: 100%;
+  min-height: 0;
+  overflow: auto;
+}
+
+.plugins {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.plugin {
+  display: grid;
+  grid-template-columns: 0.6rem 14rem 1fr 8rem 4rem;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.45rem 0.6rem;
+  border: 1px solid transparent;
+  border-radius: var(--kubb-radius-md, 0.375rem);
+  background: transparent;
+  text-align: left;
+  color: var(--kubb-text);
+  font-size: 0.85rem;
+}
+
+.plugin:hover {
+  background: var(--kubb-bg-soft);
+}
+
+.plugin.active {
+  border-color: var(--kubb-brand);
+  background: var(--kubb-brand-dim);
+}
+
+.dot {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  background: var(--kubb-text-3);
+}
+
+.dot[data-status='running'] {
+  background: var(--kubb-warning);
+}
+
+.dot[data-status='success'] {
+  background: var(--kubb-success);
+}
+
+.dot[data-status='failed'] {
+  background: var(--kubb-danger);
+}
+
+.name {
+  font-family: var(--kubb-font-mono);
+}
+
+.counts {
+  color: var(--kubb-text-3);
+  font-size: 0.75rem;
+}
+
+.bar-track {
+  height: 0.35rem;
+  border-radius: 999px;
+  background: var(--kubb-bg-mute);
+  overflow: hidden;
+}
+
+.bar {
+  display: block;
+  height: 100%;
+  background: var(--kubb-brand);
+}
+
+.duration {
+  color: var(--kubb-text-2);
+  font-family: var(--kubb-font-mono);
+  font-size: 0.75rem;
+  text-align: right;
+}
+
+.detail {
+  border: 1px solid var(--kubb-line);
+  border-radius: var(--kubb-radius-lg, 0.5rem);
+  background: var(--kubb-bg-soft);
+  padding: 0.85rem;
+}
+
+.detail h3 {
+  margin: 0 0 0.25rem;
+  font-family: var(--kubb-font-mono);
+  font-size: 0.9rem;
+}
+
+.hint {
+  margin: 0 0 0.75rem;
+  color: var(--kubb-text-3);
+  font-size: 0.8rem;
+}
+
+.columns {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.columns h4 {
+  margin: 0 0 0.35rem;
+  font-size: 0.8rem;
+}
+
+.count {
+  color: var(--kubb-text-3);
+  font-family: var(--kubb-font-mono);
+}
+
+.columns ul {
+  margin: 0;
+  padding: 0;
+  max-height: 14rem;
+  overflow: auto;
+  list-style: none;
+  font-family: var(--kubb-font-mono);
+  font-size: 0.75rem;
+}
+
+.columns li {
+  padding: 0.1rem 0;
+}
+
+.skipped li {
+  color: var(--kubb-text-3);
+  text-decoration: line-through;
+}
+
+.kind-badge {
+  display: inline-block;
+  width: 1.1rem;
+  margin-right: 0.35rem;
+  border-radius: 3px;
+  color: var(--kubb-bg);
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-align: center;
+  text-decoration: none;
+}
+
+.kind-badge[data-kind='schema'] {
+  background: var(--kubb-viz-indigo);
+}
+
+.kind-badge[data-kind='operation'] {
+  background: var(--kubb-viz-teal);
+}
+
+.diagnostics ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-size: 0.8rem;
+}
+
+.diagnostics li {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.2rem 0;
+}
+
+.diagnostics li[data-severity='error'] code {
+  color: var(--kubb-danger);
+}
+
+.diagnostics li[data-severity='warning'] code {
+  color: var(--kubb-warning);
+}
+
+.owner {
+  color: var(--kubb-text-3);
+}
+
+.empty {
+  color: var(--kubb-text-3);
+  font-size: 0.875rem;
+}
+</style>

--- a/packages/devtools/client/src/devtools.test.ts
+++ b/packages/devtools/client/src/devtools.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import {
+  connect,
+  createStaticDataSource,
+  fetchAst,
+  fetchFiles,
+  fetchPluginNames,
+  fetchPluginView,
+  readGeneratedFile,
+  run,
+  setStaticReportData,
+  type StaticReportSnapshot,
+} from './devtools'
+
+function snapshot(): StaticReportSnapshot {
+  return {
+    run: {
+      id: 1,
+      config: 'petstore',
+      status: 'success',
+      duration: 42,
+      fileCount: 1,
+      schemaCount: 3,
+      operationCount: 0,
+      plugins: [
+        { name: 'plugin-a', status: 'success', duration: 10, error: null, schemaCount: 1, operationCount: 0 },
+        { name: 'plugin-b', status: 'success', duration: 20, error: null, schemaCount: 0, operationCount: 0 },
+      ],
+      diagnostics: [],
+    },
+    ast: { schemas: [{ name: 'A' }, { name: 'B' }, { name: 'C' }], operations: [], meta: undefined },
+    pluginViews: {
+      'plugin-a': { schemas: [{ name: 'A' }], operations: [] },
+      'plugin-b': { schemas: [{ name: 'B' }], operations: [] },
+    },
+    files: [{ id: 'file-1', name: 'pet', baseName: 'pet.ts', path: 'gen/pet.ts' }],
+    generatedFiles: { 'file-1': 'export type Pet = {}' },
+  }
+}
+
+describe('createStaticDataSource', () => {
+  it('exposes the run summary and connects without a network', async () => {
+    const input = snapshot()
+    const source = createStaticDataSource(input)
+
+    await expect(source.connect()).resolves.toBeUndefined()
+    expect(source.run).toMatchObject({ id: 1, status: 'success', duration: 42 })
+
+    input.run!.config = 'caller mutation'
+    source.run!.plugins[0]!.name = 'ui mutation'
+
+    expect(source.run?.config).toBe('petstore')
+    expect(source.run?.plugins[0]?.name).toBe('plugin-a')
+  })
+
+  it('returns the canonical AST separately from plugin views', async () => {
+    const source = createStaticDataSource(snapshot())
+
+    expect(await source.fetchAst()).toStrictEqual({ schemas: [{ name: 'A' }, { name: 'B' }, { name: 'C' }], operations: [], meta: undefined })
+    expect(await source.fetchPluginView('plugin-a')).toStrictEqual({ schemas: [{ name: 'A' }], operations: [], meta: undefined })
+  })
+
+  it('returns plugin names, files, and generated contents from the snapshot', async () => {
+    const source = createStaticDataSource(snapshot())
+
+    await expect(source.fetchPluginNames()).resolves.toStrictEqual(['plugin-a', 'plugin-b'])
+    await expect(source.fetchFiles()).resolves.toStrictEqual([{ id: 'file-1', name: 'pet', baseName: 'pet.ts', path: 'gen/pet.ts' }])
+    await expect(source.readGeneratedFile('file-1')).resolves.toBe('export type Pet = {}')
+  })
+
+  it('returns null for an unknown plugin or file', async () => {
+    const source = createStaticDataSource(snapshot())
+
+    await expect(source.fetchPluginView('missing')).resolves.toBeNull()
+    await expect(source.readGeneratedFile('missing')).resolves.toBeNull()
+  })
+
+  it('configures the module API consumed by the presentation components', async () => {
+    setStaticReportData(snapshot())
+
+    await expect(connect()).resolves.toBeUndefined()
+    expect(run.value?.config).toBe('petstore')
+    await expect(fetchAst()).resolves.toMatchObject({ schemas: [{ name: 'A' }, { name: 'B' }, { name: 'C' }] })
+    await expect(fetchPluginNames()).resolves.toStrictEqual(['plugin-a', 'plugin-b'])
+    await expect(fetchPluginView('plugin-a')).resolves.toMatchObject({ schemas: [{ name: 'A' }] })
+    await expect(fetchFiles()).resolves.toHaveLength(1)
+    await expect(readGeneratedFile('file-1')).resolves.toBe('export type Pet = {}')
+  })
+})

--- a/packages/devtools/client/src/devtools.ts
+++ b/packages/devtools/client/src/devtools.ts
@@ -1,0 +1,148 @@
+import { ref } from 'vue'
+
+export type PluginRun = {
+  name: string
+  status: 'running' | 'success' | 'failed'
+  duration: number | null
+  error: string | null
+  schemaCount: number
+  operationCount: number
+}
+
+export type RunSummary = {
+  id: number
+  config: string | null
+  status: 'running' | 'success' | 'failed'
+  duration: number | null
+  fileCount: number
+  schemaCount: number
+  operationCount: number
+  plugins: Array<PluginRun>
+  diagnostics: Array<{ code: string; severity: string; message: string; plugin: string | null }>
+}
+
+export type FileEntry = {
+  id: string
+  name: string
+  baseName: string
+  path: string
+}
+
+export type AstSnapshot = {
+  schemas: Array<Record<string, unknown>>
+  operations: Array<Record<string, unknown>>
+  meta?: Record<string, unknown>
+}
+
+type PluginView = Pick<AstSnapshot, 'schemas' | 'operations'>
+
+export type StaticReportSnapshot = {
+  run: RunSummary | null
+  ast: AstSnapshot | null
+  pluginViews: Record<string, PluginView>
+  files: Array<FileEntry>
+  generatedFiles: Record<string, string>
+}
+
+export type StaticDataSource = {
+  readonly run: RunSummary | null
+  connect(): Promise<void>
+  fetchAst(): Promise<AstSnapshot | null>
+  fetchPluginNames(): Promise<Array<string>>
+  fetchPluginView(name: string): Promise<AstSnapshot | null>
+  fetchFiles(): Promise<Array<FileEntry>>
+  readGeneratedFile(id: string): Promise<string | null>
+}
+
+const emptySnapshot: StaticReportSnapshot = {
+  run: null,
+  ast: null,
+  pluginViews: {},
+  files: [],
+  generatedFiles: {},
+}
+
+function clone<T>(value: T): T {
+  return structuredClone(value)
+}
+
+/**
+ * Adapts one completed core snapshot to the API used by the presentation components. The source
+ * owns a clone so a component cannot mutate the payload supplied by the HTML host.
+ */
+export function createStaticDataSource(snapshot: StaticReportSnapshot): StaticDataSource {
+  const data = clone(snapshot)
+
+  return {
+    get run() {
+      return data.run ? clone(data.run) : null
+    },
+    async connect() {},
+    async fetchAst() {
+      return data.ast ? clone(data.ast) : null
+    },
+    async fetchPluginNames() {
+      return Object.keys(data.pluginViews)
+    },
+    async fetchPluginView(name) {
+      const view = data.pluginViews[name]
+      return view ? { ...clone(view), meta: undefined } : null
+    },
+    async fetchFiles() {
+      return clone(data.files)
+    },
+    async readGeneratedFile(id) {
+      return data.generatedFiles[id] ?? null
+    },
+  }
+}
+
+const activeSource = { current: createStaticDataSource(emptySnapshot) }
+
+export const run = ref<RunSummary | null>(null)
+export const connected = ref(false)
+export const connectionError = ref<string | null>(null)
+
+/**
+ * Replaces the payload consumed by the shared UI API. The future HTML entry point can call this
+ * before mounting Vue, without exposing the snapshot through a browser global or a network layer.
+ */
+export function setStaticReportData(snapshot: StaticReportSnapshot): void {
+  activeSource.current = createStaticDataSource(snapshot)
+  run.value = activeSource.current.run
+  connected.value = false
+  connectionError.value = null
+}
+
+/**
+ * Keeps the historical UI lifecycle intact. A static report has no handshake or transport; the
+ * promise resolves after the in-memory source is marked ready.
+ */
+export async function connect(): Promise<void> {
+  try {
+    await activeSource.current.connect()
+    connected.value = true
+  } catch (error) {
+    connectionError.value = error instanceof Error ? error.message : String(error)
+  }
+}
+
+export function fetchAst(): Promise<AstSnapshot | null> {
+  return activeSource.current.fetchAst()
+}
+
+export function fetchPluginNames(): Promise<Array<string>> {
+  return activeSource.current.fetchPluginNames()
+}
+
+export function fetchPluginView(name: string): Promise<AstSnapshot | null> {
+  return activeSource.current.fetchPluginView(name)
+}
+
+export function fetchFiles(): Promise<Array<FileEntry>> {
+  return activeSource.current.fetchFiles()
+}
+
+export function readGeneratedFile(id: string): Promise<string | null> {
+  return activeSource.current.readGeneratedFile(id)
+}

--- a/packages/devtools/client/src/env.d.ts
+++ b/packages/devtools/client/src/env.d.ts
@@ -1,0 +1,6 @@
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue'
+
+  const component: DefineComponent<object, object, unknown>
+  export default component
+}

--- a/packages/devtools/client/src/highlight.ts
+++ b/packages/devtools/client/src/highlight.ts
@@ -1,0 +1,82 @@
+import type { HighlighterCore } from '@shikijs/core'
+
+const LANGUAGE_BY_EXTENSION: Record<string, string> = {
+  ts: 'typescript',
+  mts: 'typescript',
+  cts: 'typescript',
+  tsx: 'tsx',
+  js: 'javascript',
+  mjs: 'javascript',
+  cjs: 'javascript',
+  jsx: 'jsx',
+  json: 'json',
+  md: 'markdown',
+  yaml: 'yaml',
+  yml: 'yaml',
+}
+
+/**
+ * Maps a file's extension to a shiki grammar id, falling back to `text` (a hard-coded shiki
+ * bypass needing no grammar) rather than guessing at one this highlighter doesn't carry.
+ */
+export function languageFor(baseName: string): string {
+  const extension = baseName.split('.').pop() ?? ''
+  return LANGUAGE_BY_EXTENSION[extension] ?? 'text'
+}
+
+let highlighter: Promise<HighlighterCore> | null = null
+
+/**
+ * A hand-picked grammar and theme set, imported from the scoped `@shikijs/*` packages rather
+ * than the umbrella `shiki` package. `shiki` unconditionally depends on
+ * `@shikijs/engine-oniguruma` (and its wasm-grammar-compiler chain) even though this highlighter
+ * only ever uses the JS regex engine, so depending on it would install that whole tree for
+ * nothing — `@shikijs/core` + `@shikijs/engine-javascript` don't carry it.
+ *
+ * `@shikijs/langs` and `@shikijs/themes` are each a single package bundling every language and
+ * theme shiki knows — using one grammar or all of them costs the same on disk, so the language
+ * list here is chosen for the browser chunk it produces, not for install size.
+ *
+ * Every import here is dynamic, so shiki only downloads once the Files panel is actually
+ * opened — the Pipeline and AST tabs, the default view, never pay for it.
+ */
+function getHighlighter(): Promise<HighlighterCore> {
+  highlighter ??= (async () => {
+    const [{ createHighlighterCore }, { createJavaScriptRegexEngine }, light, dark, typescript, tsx, javascript, jsx, json, markdown, yaml] = await Promise.all(
+      [
+        import('@shikijs/core'),
+        import('@shikijs/engine-javascript'),
+        import('@shikijs/themes/github-light'),
+        import('@shikijs/themes/github-dark'),
+        import('@shikijs/langs/typescript'),
+        import('@shikijs/langs/tsx'),
+        import('@shikijs/langs/javascript'),
+        import('@shikijs/langs/jsx'),
+        import('@shikijs/langs/json'),
+        import('@shikijs/langs/markdown'),
+        import('@shikijs/langs/yaml'),
+      ],
+    )
+
+    return createHighlighterCore({
+      themes: [light.default, dark.default],
+      langs: [typescript.default, tsx.default, javascript.default, jsx.default, json.default, markdown.default, yaml.default],
+      engine: createJavaScriptRegexEngine(),
+    })
+  })()
+
+  return highlighter
+}
+
+/**
+ * Renders `code` as theme-aware syntax-highlighted HTML, matching `baseName`'s extension to a
+ * grammar. Same light/dark pairing `kubb-labs/platform` uses for its own code panels, so the
+ * output tracks the app's `.dark` toggle via `--shiki-dark` the same way.
+ */
+export async function highlight(code: string, baseName: string): Promise<string> {
+  const core = await getHighlighter()
+  return core.codeToHtml(code, {
+    lang: languageFor(baseName),
+    themes: { light: 'github-light', dark: 'github-dark' },
+  })
+}

--- a/packages/devtools/client/src/main.ts
+++ b/packages/devtools/client/src/main.ts
@@ -1,0 +1,5 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import './styles/index.css'
+
+createApp(App).mount('#app')

--- a/packages/devtools/client/src/styles/index.css
+++ b/packages/devtools/client/src/styles/index.css
@@ -1,0 +1,40 @@
+@import './tokens.css';
+
+/*
+ * The panels are styled entirely from the Kubb tokens above, so there is no
+ * component library or utility framework here. `--ui-header-height` is the one
+ * layout value the tokens do not carry.
+ */
+:root {
+  --ui-header-height: 3rem;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#app {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  background: var(--kubb-bg);
+  color: var(--kubb-text);
+  font-family: var(--kubb-font-sans);
+}
+
+button,
+[role='button'],
+a[href] {
+  cursor: pointer;
+}
+
+input,
+button {
+  font-family: inherit;
+}

--- a/packages/devtools/client/src/styles/tokens.css
+++ b/packages/devtools/client/src/styles/tokens.css
@@ -1,0 +1,512 @@
+/*
+ * Copied from kubb-labs/platform: packages/ui/src/tokens.css
+ * That file is the source of truth. Re-copy it rather than editing here.
+ */
+@import url('https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700;800&display=swap');
+
+/* =========================================================================
+ * Kubb Design System — CSS Variables
+ * v1.0 · 2026
+ *
+ * Drop this file into your site's <head> before any other stylesheet:
+ *   <link rel="stylesheet" href="/tokens.css" />
+ *
+ * All tokens are on :root so they inherit everywhere. Dark-mode overrides
+ * apply when the site puts `.dark` or data-theme="dark" on the root element.
+ * There is no `prefers-color-scheme` auto block on purpose: frameworks like
+ * VitePress signal light mode by *removing* `.dark` (never adding `.light`),
+ * so an OS-preference fallback would override an explicit light choice.
+ * Sites that want to follow the OS must resolve the preference themselves
+ * and set the class — VitePress and Nuxt color-mode already do.
+ * ========================================================================= */
+
+:root {
+  /* ---------------------------------------------------------------------
+   * BRAND — orange, the primary signal
+   * ------------------------------------------------------------------- */
+  --kubb-brand: #f58517;
+  --kubb-brand-light: #ff9940;
+  --kubb-brand-lighter: #ffb366;
+  --kubb-brand-lightest: #ffd9b3;
+  --kubb-brand-dark: #854811; /* use for brand-on-white text */
+  --kubb-brand-darker: #5c3208;
+  --kubb-brand-soft: #f3c796;
+  --kubb-brand-dim: rgba(245, 133, 23, 0.08);
+
+  /* Hero gradient partner */
+  --kubb-coral: #f7797d;
+
+  /* ---------------------------------------------------------------------
+   * ACCENT SPECTRUM — reserved for sponsor CTA, rainbow borders,
+   * landing-page moments. Not for body UI.
+   * ------------------------------------------------------------------- */
+  --kubb-accent-red: #ff6565;
+  --kubb-accent-pink: #ff64f9;
+  --kubb-accent-purple: #6b5fff;
+  --kubb-accent-blue: #4d8aff;
+  --kubb-accent-green: #5bff89;
+  --kubb-accent-yellow: #ffee55;
+  --kubb-accent-orange: #ff6d1b;
+
+  /* ---------------------------------------------------------------------
+   * NEUTRALS — light mode defaults
+   * ------------------------------------------------------------------- */
+  --kubb-bg: #ffffff;
+  --kubb-bg-soft: #f6f7f8;
+  --kubb-bg-mute: #eef0f2;
+  --kubb-text: #1a1b1e;
+  --kubb-text-2: #4b5563;
+  --kubb-text-3: #9ca3af;
+  --kubb-line: #e5e7eb;
+  --kubb-line-soft: #eef0f2;
+  --kubb-ink: #1a1b1e; /* deepest */
+  --kubb-surface: #161618; /* bg-alt dark tile */
+
+  /* Status */
+  --kubb-success: #10b981;
+  --kubb-warning: #f59e0b;
+  --kubb-danger: #ef4444;
+
+  /* ---------------------------------------------------------------------
+   * GRADIENTS
+   * ------------------------------------------------------------------- */
+  --kubb-gradient-hero: linear-gradient(120deg, #f58517 30%, #f7797d);
+  --kubb-gradient-hero-image: linear-gradient(-45deg, #f58517 50%, #e3c09d 50%);
+  --kubb-gradient-sponsor: linear-gradient(
+    90deg,
+    var(--kubb-accent-orange),
+    var(--kubb-accent-yellow),
+    var(--kubb-accent-green),
+    var(--kubb-accent-blue),
+    var(--kubb-accent-purple),
+    var(--kubb-accent-pink),
+    var(--kubb-accent-red)
+  );
+
+  /* ---------------------------------------------------------------------
+   * TYPOGRAPHY
+   * ------------------------------------------------------------------- */
+  --kubb-font-sans: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --kubb-font-mono: 'Fira Code', Menlo, Monaco, Consolas, 'Courier New', monospace;
+
+  /* Font sizes (Tailwind-aligned) */
+  --kubb-text-xs: 0.75rem; /* 12 */
+  --kubb-text-sm: 0.875rem; /* 14 */
+  --kubb-text-base: 1rem; /* 16 */
+  --kubb-text-lg: 1.125rem; /* 18 */
+  --kubb-text-xl: 1.25rem; /* 20 */
+  --kubb-text-2xl: 1.5rem; /* 24 */
+  --kubb-text-3xl: 1.875rem; /* 30 */
+  --kubb-text-4xl: 2.25rem; /* 36 */
+  --kubb-text-5xl: 3rem; /* 48 */
+  --kubb-text-6xl: 3.75rem; /* 60 */
+  --kubb-text-7xl: 4.5rem; /* 72 */
+  --kubb-text-8xl: 6rem; /* 96 */
+
+  /* Weights */
+  --kubb-weight-normal: 400;
+  --kubb-weight-medium: 500;
+  --kubb-weight-semibold: 600;
+  --kubb-weight-bold: 700;
+  --kubb-weight-extrabold: 800;
+
+  /* Line heights */
+  --kubb-leading-tight: 1.2;
+  --kubb-leading-snug: 1.35;
+  --kubb-leading-normal: 1.55;
+  --kubb-leading-relaxed: 1.7;
+  --kubb-leading-loose: 1.75;
+
+  /* Letter-spacing (display headings lean tight) */
+  --kubb-tracking-tightest: -0.035em;
+  --kubb-tracking-tighter: -0.03em;
+  --kubb-tracking-tight: -0.02em;
+  --kubb-tracking-snug: -0.01em;
+  --kubb-tracking-normal: 0;
+  --kubb-tracking-wide: 0.02em;
+  --kubb-tracking-wider: 0.05em;
+  --kubb-tracking-widest: 0.08em;
+
+  /* ---------------------------------------------------------------------
+   * SPACING — 4px base unit
+   * ------------------------------------------------------------------- */
+  --kubb-space-0: 0;
+  --kubb-space-px: 1px;
+  --kubb-space-0-5: 0.125rem; /* 2  */
+  --kubb-space-1: 0.25rem; /* 4  */
+  --kubb-space-1-5: 0.375rem; /* 6  */
+  --kubb-space-2: 0.5rem; /* 8  */
+  --kubb-space-3: 0.75rem; /* 12 */
+  --kubb-space-4: 1rem; /* 16 */
+  --kubb-space-5: 1.25rem; /* 20 */
+  --kubb-space-6: 1.5rem; /* 24 */
+  --kubb-space-8: 2rem; /* 32 */
+  --kubb-space-10: 2.5rem; /* 40 */
+  --kubb-space-12: 3rem; /* 48 */
+  --kubb-space-14: 3.5rem; /* 56 */
+  --kubb-space-16: 4rem; /* 64 */
+  --kubb-space-20: 5rem; /* 80 */
+  --kubb-space-24: 6rem; /* 96 */
+  --kubb-space-32: 8rem; /* 128 */
+
+  /* ---------------------------------------------------------------------
+   * RADIUS
+   * ------------------------------------------------------------------- */
+  --kubb-radius-none: 0;
+  --kubb-radius-sm: 2px;
+  --kubb-radius: 4px;
+  --kubb-radius-md: 6px;
+  --kubb-radius-lg: 8px; /* inputs, code blocks */
+  --kubb-radius-xl: 12px; /* buttons, cards */
+  --kubb-radius-2xl: 16px; /* feature tiles */
+  --kubb-radius-3xl: 24px; /* hero tiles */
+  --kubb-radius-full: 9999px;
+
+  /* ---------------------------------------------------------------------
+   * ELEVATION / SHADOW
+   * ------------------------------------------------------------------- */
+  --kubb-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --kubb-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.06);
+  --kubb-shadow-lg: 0 12px 24px rgba(0, 0, 0, 0.1);
+  --kubb-shadow-xl: 0 20px 40px rgba(0, 0, 0, 0.12);
+  --kubb-shadow-glow: 0 0 40px rgba(245, 133, 23, 0.35);
+  --kubb-shadow-glow-soft: 0 0 40px rgba(245, 133, 23, 0.2);
+
+  /* ---------------------------------------------------------------------
+   * LAYOUT
+   * ------------------------------------------------------------------- */
+  --kubb-max-layout: 1440px; /* outer page container  */
+  --kubb-max-content: 1200px; /* marketing / feature grid */
+  --kubb-max-doc: 680px; /* prose measure */
+  --kubb-gutter: 1.5rem; /* 24 */
+  --kubb-section-py: 5rem; /* 80 */
+
+  /* ---------------------------------------------------------------------
+   * MOTION
+   * ------------------------------------------------------------------- */
+  --kubb-duration-fast: 150ms;
+  --kubb-duration: 200ms;
+  --kubb-duration-slow: 300ms;
+  --kubb-duration-slower: 500ms;
+
+  --kubb-ease-out: cubic-bezier(0.4, 0, 0.2, 1); /* default UI */
+  --kubb-ease-in: cubic-bezier(0.4, 0, 1, 1); /* exits */
+  --kubb-ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1); /* hover */
+  --kubb-ease-linear: linear; /* decorative */
+
+  /* ---------------------------------------------------------------------
+   * Z-INDEX
+   * ------------------------------------------------------------------- */
+  --kubb-z-base: 0;
+  --kubb-z-raised: 10;
+  --kubb-z-sticky: 20;
+  --kubb-z-overlay: 30;
+  --kubb-z-modal: 40;
+  --kubb-z-toast: 50;
+
+  /* ---------------------------------------------------------------------
+   * SEMANTIC ALIASES — what most components should actually consume.
+   * Prefer these over the raw scales above.
+   * ------------------------------------------------------------------- */
+  --kubb-color-primary: var(--kubb-brand);
+  --kubb-color-primary-hover: var(--kubb-brand-dark);
+  --kubb-color-primary-subtle: var(--kubb-brand-dim);
+  --kubb-color-primary-contrast: #ffffff; /* text on brand */
+  --kubb-color-link: var(--kubb-brand-dark); /* brand on white = AA */
+
+  --kubb-color-bg: var(--kubb-bg);
+  --kubb-color-bg-elevated: var(--kubb-bg);
+  --kubb-color-bg-subtle: var(--kubb-bg-soft);
+  --kubb-color-border: var(--kubb-line);
+  --kubb-color-text: var(--kubb-text);
+  --kubb-color-text-muted: var(--kubb-text-2);
+  --kubb-color-text-subtle: var(--kubb-text-3);
+
+  --kubb-focus-ring: 0 0 0 3px rgba(245, 133, 23, 0.35);
+
+  /* ---------------------------------------------------------------------
+   * VISUALIZATION — accents for diagrams and animated docs components.
+   * Darkened for readable text/icons on light backgrounds; the dark
+   * overrides restore the bright hues the diagrams were designed with.
+   * Raw hex only where no kubb token passes AA on light backgrounds.
+   * ------------------------------------------------------------------- */
+  --kubb-viz-orange: #bc4c00; /* brand orange darkened to pass AA on white */
+  --kubb-viz-teal: #0f766e;
+  --kubb-viz-green: #047857;
+  --kubb-viz-blue: #2563eb;
+  --kubb-viz-indigo: #4f46e5;
+  --kubb-viz-violet: #7c3aed;
+  --kubb-viz-purple: #9333ea;
+
+  /* ---------------------------------------------------------------------
+   * TERMINAL — a real terminal window has one dark theme no matter what
+   * the surrounding page looks like, so the body/text palette below is
+   * fixed and not overridden in dark mode. The macOS-style title bar
+   * (--kubb-terminal-bar-*) follows the page's light/dark mode instead,
+   * like a native window's title bar would, as does the card's shadow
+   * (reusing --kubb-shadow-xl, subtle on light and stronger on dark) and
+   * its outer border, which stays off in light mode and only shows in
+   * dark mode so the card still reads against a dark page background.
+   * ------------------------------------------------------------------- */
+  --kubb-terminal-bg: #0d1117;
+  --kubb-terminal-shadow: var(--kubb-shadow-xl);
+  --kubb-terminal-text: #e6edf3;
+  --kubb-terminal-text-dim: rgba(255, 255, 255, 0.45);
+  --kubb-terminal-text-subtle: rgba(255, 255, 255, 0.35);
+  --kubb-terminal-accent: var(--kubb-brand);
+  --kubb-terminal-blue: #79c0ff;
+  --kubb-terminal-green: #3fb950;
+  --kubb-terminal-yellow: #f0a93b;
+  --kubb-terminal-red: #ff7b72;
+
+  --kubb-terminal-bar-bg: #e4e4e6;
+  --kubb-terminal-bar-border: rgba(0, 0, 0, 0.1);
+  --kubb-terminal-bar-text: rgba(0, 0, 0, 0.45);
+}
+
+/* =========================================================================
+ * DARK MODE — VitePress sets `.dark` on <html>; also support manual override
+ * via <html data-theme="dark">.
+ * ========================================================================= */
+.dark,
+[data-theme='dark'] {
+  --kubb-bg: #1a1b1e;
+  --kubb-bg-soft: #161618;
+  --kubb-bg-mute: rgba(68, 76, 91, 0.2);
+  --kubb-text: #f3f4f6;
+  --kubb-text-2: #9ca3af;
+  --kubb-text-3: #6b7280;
+  --kubb-line: rgba(255, 255, 255, 0.08);
+  --kubb-line-soft: rgba(255, 255, 255, 0.05);
+
+  --kubb-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --kubb-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.25);
+  --kubb-shadow-lg: 0 12px 24px rgba(0, 0, 0, 0.35);
+  --kubb-shadow-xl: 0 20px 40px rgba(0, 0, 0, 0.45);
+
+  /* Dark mode: use a lighter brand tone for brand-on-dark text links */
+  --kubb-color-link: var(--kubb-brand-lighter);
+  --kubb-color-bg-elevated: #222328;
+  --kubb-color-bg-subtle: #1f2024;
+  --kubb-color-border: rgba(255, 255, 255, 0.08);
+
+  --kubb-viz-orange: var(--kubb-brand);
+  --kubb-viz-teal: #14b8a6;
+  --kubb-viz-green: var(--kubb-success);
+  --kubb-viz-blue: var(--kubb-accent-blue);
+  --kubb-viz-indigo: #6366f1;
+  --kubb-viz-violet: #8b5cf6;
+  --kubb-viz-purple: #a855f7;
+
+  --kubb-terminal-bar-bg: #3a3a3c;
+  --kubb-terminal-bar-border: rgba(255, 255, 255, 0.08);
+  --kubb-terminal-bar-text: rgba(255, 255, 255, 0.4);
+}
+
+/* =========================================================================
+ * OPTIONAL — opinionated resets & utility classes.
+ * Remove this block if you only want the tokens.
+ * ========================================================================= */
+
+html {
+  font-family: var(--kubb-font-sans);
+  color: var(--kubb-color-text);
+  background: var(--kubb-color-bg);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+code,
+kbd,
+pre,
+samp {
+  font-family: var(--kubb-font-mono);
+}
+
+/* ---- Button ------------------------------------------------------------- */
+.kubb-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--kubb-space-2);
+  padding: var(--kubb-space-3) var(--kubb-space-6);
+  font: var(--kubb-weight-semibold) var(--kubb-text-base) / 1.4 var(--kubb-font-sans);
+  border-radius: var(--kubb-radius-xl);
+  border: 1px solid transparent;
+  cursor: pointer;
+  text-decoration: none;
+  transition: all var(--kubb-duration) var(--kubb-ease-out);
+  white-space: nowrap;
+}
+.kubb-btn:focus-visible {
+  outline: 2px solid var(--kubb-brand);
+  outline-offset: 2px;
+}
+.kubb-btn--primary {
+  background: var(--kubb-brand);
+  color: var(--kubb-color-primary-contrast);
+  border-color: var(--kubb-brand);
+}
+.kubb-btn--primary:hover {
+  background: var(--kubb-brand-dark);
+  border-color: var(--kubb-brand-dark);
+}
+.kubb-btn--secondary {
+  background: var(--kubb-bg);
+  color: var(--kubb-brand);
+  border-color: var(--kubb-brand);
+}
+.kubb-btn--secondary:hover {
+  background: var(--kubb-brand-dim);
+}
+.kubb-btn--ghost {
+  background: transparent;
+  color: var(--kubb-color-text);
+  border-color: var(--kubb-line);
+}
+.kubb-btn--ghost:hover {
+  border-color: var(--kubb-brand);
+  color: var(--kubb-brand);
+  background: var(--kubb-brand-dim);
+}
+.kubb-btn--sm {
+  padding: var(--kubb-space-2) var(--kubb-space-4);
+  font-size: var(--kubb-text-sm);
+}
+.kubb-btn--lg {
+  padding: var(--kubb-space-4) var(--kubb-space-8);
+  font-size: var(--kubb-text-lg);
+}
+
+/* ---- Sponsor (rainbow border) ------------------------------------------- */
+.kubb-btn--sponsor {
+  border: 2px solid transparent;
+  border-radius: var(--kubb-radius-full);
+  padding: 0 var(--kubb-space-5);
+  line-height: 36px;
+  font-size: var(--kubb-text-sm);
+  font-weight: var(--kubb-weight-medium);
+  color: var(--kubb-color-text);
+  background: linear-gradient(var(--kubb-bg), var(--kubb-bg)), var(--kubb-gradient-sponsor);
+  background-origin: border-box;
+  background-clip: padding-box, border-box;
+  background-size: 200%;
+}
+.kubb-btn--sponsor:hover {
+  animation: kubb-spin 0.5s linear infinite;
+}
+
+/* ---- Gradient title helper --------------------------------------------- */
+.kubb-gradient-text {
+  background: var(--kubb-gradient-hero);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+
+/* ---- Badges ------------------------------------------------------------- */
+.kubb-badge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: var(--kubb-radius-full);
+  font-size: var(--kubb-text-xs);
+  font-weight: var(--kubb-weight-semibold);
+  line-height: 20px;
+}
+.kubb-badge--new {
+  background: #e0f7ea;
+  color: #1a8a4a;
+}
+.kubb-badge--beta {
+  background: #fff1d6;
+  color: #a06100;
+}
+.kubb-badge--core {
+  background: var(--kubb-brand-dim);
+  color: var(--kubb-brand-dark);
+}
+
+/* ---- Card / feature tile ----------------------------------------------- */
+.kubb-card {
+  background: var(--kubb-color-bg-elevated);
+  border: 1px solid var(--kubb-color-border);
+  border-radius: var(--kubb-radius-2xl);
+  padding: var(--kubb-space-6);
+  transition: all var(--kubb-duration-slow) var(--kubb-ease-out);
+}
+.kubb-card--hover:hover {
+  border-color: var(--kubb-brand);
+  transform: translateY(-4px);
+  box-shadow: var(--kubb-shadow-xl);
+}
+
+/* ---- Callout (tip) ------------------------------------------------------ */
+.kubb-callout {
+  border-left: 3px solid var(--kubb-brand);
+  background: var(--kubb-brand-dim);
+  color: var(--kubb-brand-darker);
+  padding: var(--kubb-space-4) var(--kubb-space-5);
+  border-radius: var(--kubb-radius-lg);
+  font-size: var(--kubb-text-sm);
+}
+
+/* ---- Form field -------------------------------------------------------- */
+.kubb-input,
+.kubb-select {
+  font: var(--kubb-text-sm) / 1.4 var(--kubb-font-sans);
+  padding: var(--kubb-space-3);
+  border: 1px solid var(--kubb-line);
+  border-radius: var(--kubb-radius-lg);
+  background: var(--kubb-bg);
+  color: var(--kubb-color-text);
+  outline: none;
+  transition:
+    border-color var(--kubb-duration-fast) var(--kubb-ease-out),
+    box-shadow var(--kubb-duration-fast) var(--kubb-ease-out);
+}
+.kubb-input:focus,
+.kubb-select:focus {
+  border-color: var(--kubb-brand);
+  box-shadow: var(--kubb-focus-ring);
+}
+
+/* ---- Animations -------------------------------------------------------- */
+@keyframes kubb-spin {
+  from {
+    background-position: 0;
+  }
+  to {
+    background-position: 200%;
+  }
+}
+@keyframes kubb-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+@keyframes kubb-fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Respect reduced-motion users */
+@media (prefers-reduced-motion: reduce) {
+  .kubb-btn,
+  .kubb-card {
+    transition: none;
+  }
+  .kubb-btn--sponsor:hover {
+    animation: none;
+  }
+}

--- a/packages/devtools/client/tsconfig.json
+++ b/packages/devtools/client/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "jsx": "preserve",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue", "vite.config.ts"]
+}

--- a/packages/devtools/client/vite.config.ts
+++ b/packages/devtools/client/vite.config.ts
@@ -1,0 +1,11 @@
+import vue from '@vitejs/plugin-vue'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  base: './',
+  plugins: [vue()],
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+  },
+})

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@kubb/devtools",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Static report presentation client for Kubb.",
+  "license": "MIT",
+  "type": "module",
+  "scripts": {
+    "build": "vite build client",
+    "lint": "oxlint .",
+    "test": "vitest --passWithNoTests",
+    "typecheck": "tsc -p ./client/tsconfig.json --noEmit --emitDeclarationOnly false"
+  },
+  "dependencies": {
+    "vue": "^3.5.24"
+  },
+  "devDependencies": {
+    "@shikijs/core": "^4.4.3",
+    "@shikijs/engine-javascript": "^4.4.3",
+    "@shikijs/langs": "^4.4.3",
+    "@shikijs/themes": "^4.4.3",
+    "@vitejs/plugin-vue": "^6.0.1",
+    "oxlint": "catalog:",
+    "typescript": "catalog:",
+    "vite": "^8.2.2",
+    "vitest": "catalog:"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,40 @@ importers:
         specifier: workspace:*
         version: link:../../internals/utils
 
+  packages/devtools:
+    dependencies:
+      vue:
+        specifier: ^3.5.24
+        version: 3.5.42(typescript@6.0.3)
+    devDependencies:
+      '@shikijs/core':
+        specifier: ^4.4.3
+        version: 4.4.3
+      '@shikijs/engine-javascript':
+        specifier: ^4.4.3
+        version: 4.4.3
+      '@shikijs/langs':
+        specifier: ^4.4.3
+        version: 4.4.3
+      '@shikijs/themes':
+        specifier: ^4.4.3
+        version: 4.4.3
+      '@vitejs/plugin-vue':
+        specifier: ^6.0.1
+        version: 6.0.8(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))
+      oxlint:
+        specifier: 'catalog:'
+        version: 1.81.0
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vite:
+        specifier: ^8.2.2
+        version: 8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.11(@types/node@22.20.1)(@vitest/coverage-v8@4.1.11)(@vitest/ui@4.1.11)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))
+
   packages/kit:
     dependencies:
       '@kubb/ast':
@@ -462,12 +496,21 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.29.7':
     resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -1549,6 +1592,33 @@ packages:
     resolution: {integrity: sha512-yqROK9U96ElasEL4Wl/+PIjQZlqrQXVUUpXk9PA6xBnrp8KdEv7at8pR5gsZkvddJfYVwLILPlctyqUg4u4YZA==}
     engines: {node: '>=22'}
 
+  '@shikijs/core@4.4.3':
+    resolution: {integrity: sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@4.4.3':
+    resolution: {integrity: sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs@4.4.3':
+    resolution: {integrity: sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==}
+    engines: {node: '>=20'}
+
+  '@shikijs/primitive@4.4.3':
+    resolution: {integrity: sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/themes@4.4.3':
+    resolution: {integrity: sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.4.3':
+    resolution: {integrity: sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==}
+    engines: {node: '>=20'}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1610,11 +1680,17 @@ packages:
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
   '@types/http-proxy@1.17.17':
     resolution: {integrity: sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -1634,13 +1710,26 @@ packages:
   '@types/ua-parser-js@0.7.39':
     resolution: {integrity: sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg==}
 
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@ungap/structured-clone@1.4.0':
+    resolution: {integrity: sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ==}
 
   '@valibot/to-json-schema@1.7.1':
     resolution: {integrity: sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A==}
     peerDependencies:
       valibot: ^1.4.0
+
+  '@vitejs/plugin-vue@6.0.8':
+    resolution: {integrity: sha512-0ZjgOg7oO6farnNGup7yvoM/YXZV84OZxHAwtflItNa/6zzQyVb5LNxyea3FEKEX2XlagIKzrlH7wwxkKgtiew==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      vue: ^3.2.25
 
   '@vitest/coverage-v8@4.1.11':
     resolution: {integrity: sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==}
@@ -1685,8 +1774,35 @@ packages:
   '@vitest/utils@4.1.11':
     resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
 
+  '@vue/compiler-core@3.5.42':
+    resolution: {integrity: sha512-2Ye1ilMtKXxl8qZUrQ5j0CdgenFp/HFQmta6rfRyfEsTG69L6Wk+tWuNoHYHMx9E8tF2Slvdg1FuwDvAXdy1LQ==}
+
+  '@vue/compiler-dom@3.5.42':
+    resolution: {integrity: sha512-qbhQZEFmycr+ni/qyuccS4sucNN7VAbDfbkvNxWOX2VfgFm90MNs3/UhRNKoPMEIVn0F8gdlYjLPvqxHwHeQOA==}
+
+  '@vue/compiler-sfc@3.5.42':
+    resolution: {integrity: sha512-fkCAFB4okcAANGMThboWnScp/gzWjU0ZSkVnjTIiplmMDq2uq0tIB3j+xVu4rhv5rvOgBySCysudmbMd6xRRqw==}
+
+  '@vue/compiler-ssr@3.5.42':
+    resolution: {integrity: sha512-xmLk3wLkbizPAiLyomjgFFosf2ys9b5Ghb+oh/k2tnvipNz8OFrQOiTcWCzyK7MpBp9KkyGtfvgfLUivbmuGYA==}
+
+  '@vue/reactivity@3.5.42':
+    resolution: {integrity: sha512-TzNNfKpb7hDxbQltwAut8VDQA5YP+BuRlxntHUuRjyKwlMvmAPbs3unhCvieijifY6vFfVBwsS7wG/C7uq+bEQ==}
+
+  '@vue/runtime-core@3.5.42':
+    resolution: {integrity: sha512-9uACtuHs7vJGkm5Bp3xu4xRDLFTIYy5DgxpToVjqGIAhAEKwQfsaLvKINhM6nFVp6bZPRFGdDqd1g52MqKsotA==}
+
+  '@vue/runtime-dom@3.5.42':
+    resolution: {integrity: sha512-rsCmhiWLaRxGltLwhlCWyYkFn7WAbKRh0q17eZ1A6Dq6eqc2ACQ61IIryxz0LrsvCzHSilLA9JHovVwM8CNE2g==}
+
+  '@vue/server-renderer@3.5.42':
+    resolution: {integrity: sha512-2++5dUyYS4gvo7xQXSECUDhB7TS0aOl5SeVfC5qSq1Jgfhjvegw1zqhwTIR3imZ+QYPJQw9gfcFvXGAjGZ7ajQ==}
+
   '@vue/shared@3.5.40':
     resolution: {integrity: sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==}
+
+  '@vue/shared@3.5.42':
+    resolution: {integrity: sha512-2rPxex1jQf4jvl9MOHl6YaXCPcrNqz/FstMOEh3QWY+/OME9nQTvl9WYeCwhW7AFjaR0SnngZGlp/wkR6rkI6g==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -2009,9 +2125,18 @@ packages:
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
   chardet@2.2.0:
     resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
@@ -2034,6 +2159,9 @@ packages:
   co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -2079,6 +2207,9 @@ packages:
 
   crossws@0.3.5:
     resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   dataloader@2.2.3:
     resolution: {integrity: sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==}
@@ -2133,6 +2264,10 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
@@ -2147,6 +2282,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
@@ -2199,6 +2337,10 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   errx@0.1.2:
     resolution: {integrity: sha512-chfpPHmCerdo/rXr/nNvPZRkV4WwDRwzwnsJ0Uzz3tVi8Z41tDctRjduYy1138ii77AFlts1qvWtX3g/Acg91Q==}
 
@@ -2233,6 +2375,9 @@ packages:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -2472,11 +2617,20 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   hookable@6.1.1:
     resolution: {integrity: sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==}
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   http-assert@1.5.0:
     resolution: {integrity: sha512-uPpH7OKX4H25hBmU6G1jWNaqJGpTXxey+YOUizJUAgu0AjLUeC8D73hTrhvDS5D+GJN1DN1+hhc/eF/wpxtp0w==}
@@ -2832,6 +2986,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
@@ -2842,6 +2999,21 @@ packages:
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
 
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
@@ -2999,6 +3171,12 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
   only@0.0.2:
     resolution: {integrity: sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==}
 
@@ -3127,6 +3305,9 @@ packages:
     engines: {node: '>=10.13.0'}
     hasBin: true
 
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
@@ -3153,6 +3334,15 @@ packages:
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
     engines: {node: '>= 20.19.0'}
+
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
   remeda@2.45.0:
     resolution: {integrity: sha512-CTftZ0GJSox3CH77OhJemj20sXXUScH/kpkExD6t2LP3IG+mPKASBMFkbvWtsvzhU+54gKcgH38WWVihfr7bCA==}
@@ -3297,6 +3487,9 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
@@ -3319,6 +3512,9 @@ packages:
 
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -3406,6 +3602,9 @@ packages:
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
   tsdown@0.22.14:
     resolution: {integrity: sha512-ule7Y+fsAN2iZbLDoo7C4KYljFJNJJ+fLshyn+9gozeTspVersWHxwdGB+Dm2hzA38s6muFnUTl0jK3vJm9ifQ==}
@@ -3503,6 +3702,21 @@ packages:
   undici@6.28.0:
     resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -3644,6 +3858,12 @@ packages:
     resolution: {integrity: sha512-sXMwN6DMHeouPfCxkxWkKAmxphWKEenHYY5H1nIBzU3PmDsmJp6kBXJdshjVdpMZuWCmL9SH7KFRx29AylpP6g==}
     engines: {node: '>=18.12.0'}
 
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
   vite@8.2.2:
     resolution: {integrity: sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3728,6 +3948,14 @@ packages:
       jsdom:
         optional: true
 
+  vue@3.5.42:
+    resolution: {integrity: sha512-4RyHQTbQvOPs3MfvUO1Sg0YRrKNnA0mAVtvpd12Tg1fKDN7OHBUl1IqSn8zGJjK9nI3NkNp8cgTpVrSZC5TTcA==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   watchpack@2.5.2:
     resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
     engines: {node: '>=10.13.0'}
@@ -3810,6 +4038,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
 snapshots:
 
   '@antfu/ni@30.5.0':
@@ -3839,9 +4070,18 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+
   '@babel/runtime@7.29.7': {}
 
   '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@babel/types@7.29.8':
     dependencies:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
@@ -4767,6 +5007,41 @@ snapshots:
     dependencies:
       '@scalar/openapi-types': 0.9.5
 
+  '@shikijs/core@4.4.3':
+    dependencies:
+      '@shikijs/primitive': 4.4.3
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/langs@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+
+  '@shikijs/primitive@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/themes@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+
+  '@shikijs/types@4.4.3':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.23':
@@ -4817,11 +5092,19 @@ snapshots:
 
   '@types/estree@1.0.9': {}
 
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/http-proxy@1.17.17':
     dependencies:
       '@types/node': 26.0.1
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/node@12.20.55': {}
 
@@ -4839,13 +5122,23 @@ snapshots:
 
   '@types/ua-parser-js@0.7.39': {}
 
+  '@types/unist@3.0.3': {}
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 26.0.1
 
+  '@ungap/structured-clone@1.4.0': {}
+
   '@valibot/to-json-schema@1.7.1(valibot@1.4.2(typescript@6.0.3))':
     dependencies:
       valibot: 1.4.2(typescript@6.0.3)
+
+  '@vitejs/plugin-vue@6.0.8(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0))(vue@3.5.42(typescript@6.0.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0)
+      vue: 3.5.42(typescript@6.0.3)
 
   '@vitest/coverage-v8@4.1.11(vitest@4.1.11)':
     dependencies:
@@ -4913,7 +5206,61 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  '@vue/compiler-core@3.5.42':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@vue/shared': 3.5.42
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
+  '@vue/compiler-dom@3.5.42':
+    dependencies:
+      '@vue/compiler-core': 3.5.42
+      '@vue/shared': 3.5.42
+
+  '@vue/compiler-sfc@3.5.42':
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@vue/compiler-core': 3.5.42
+      '@vue/compiler-dom': 3.5.42
+      '@vue/compiler-ssr': 3.5.42
+      '@vue/shared': 3.5.42
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.26
+      source-map-js: 1.2.1
+
+  '@vue/compiler-ssr@3.5.42':
+    dependencies:
+      '@vue/compiler-dom': 3.5.42
+      '@vue/shared': 3.5.42
+
+  '@vue/reactivity@3.5.42':
+    dependencies:
+      '@vue/shared': 3.5.42
+
+  '@vue/runtime-core@3.5.42':
+    dependencies:
+      '@vue/reactivity': 3.5.42
+      '@vue/shared': 3.5.42
+
+  '@vue/runtime-dom@3.5.42':
+    dependencies:
+      '@vue/reactivity': 3.5.42
+      '@vue/runtime-core': 3.5.42
+      '@vue/shared': 3.5.42
+      csstype: 3.2.3
+
+  '@vue/server-renderer@3.5.42':
+    dependencies:
+      '@vue/compiler-ssr': 3.5.42
+      '@vue/runtime-dom': 3.5.42
+      '@vue/shared': 3.5.42
+
   '@vue/shared@3.5.40': {}
+
+  '@vue/shared@3.5.42': {}
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -5214,7 +5561,13 @@ snapshots:
 
   caniuse-lite@1.0.30001799: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
 
   chardet@2.2.0: {}
 
@@ -5241,6 +5594,8 @@ snapshots:
       consola: 3.4.2
 
   co@4.6.0: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@2.20.3: {}
 
@@ -5280,6 +5635,8 @@ snapshots:
   crossws@0.3.5:
     dependencies:
       uncrypto: 0.1.3
+
+  csstype@3.2.3: {}
 
   dataloader@2.2.3: {}
 
@@ -5321,6 +5678,8 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   destr@2.0.5: {}
 
   destroy@1.2.0: {}
@@ -5328,6 +5687,10 @@ snapshots:
   detect-indent@6.1.0: {}
 
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   dir-glob@3.0.1:
     dependencies:
@@ -5366,6 +5729,8 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  entities@7.0.1: {}
 
   errx@0.1.2: {}
 
@@ -5413,6 +5778,8 @@ snapshots:
   escape-html@1.0.3: {}
 
   esprima@4.0.1: {}
+
+  estree-walker@2.0.2: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -5657,9 +6024,29 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
   hookable@6.1.1: {}
 
   html-escaper@2.0.2: {}
+
+  html-void-elements@3.0.0: {}
 
   http-assert@1.5.0:
     dependencies:
@@ -6007,11 +6394,40 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.4.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
   media-typer@0.3.0: {}
 
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
 
   micromatch@4.0.8:
     dependencies:
@@ -6110,6 +6526,14 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
 
   only@0.0.2: {}
 
@@ -6240,6 +6664,8 @@ snapshots:
 
   prettier@2.8.8: {}
 
+  property-information@7.2.0: {}
+
   quansync@0.2.11: {}
 
   quansync@1.0.0: {}
@@ -6265,6 +6691,16 @@ snapshots:
       picomatch: 2.3.2
 
   readdirp@5.0.0: {}
+
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
 
   remeda@2.45.0: {}
 
@@ -6442,6 +6878,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   spawndamnit@3.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -6458,6 +6896,11 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@4.2.0: {}
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
 
   strip-ansi@6.0.1:
     dependencies:
@@ -6542,6 +6985,8 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
+  trim-lines@3.0.1: {}
+
   tsdown@0.22.14(typescript@6.0.3):
     dependencies:
       ansis: 4.3.1
@@ -6618,6 +7063,29 @@ snapshots:
 
   undici@6.28.0: {}
 
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   universalify@0.1.2: {}
 
   universalify@2.0.1: {}
@@ -6674,6 +7142,16 @@ snapshots:
 
   verkit@0.4.0: {}
 
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
   vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.51.2)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.33.0
@@ -6717,6 +7195,16 @@ snapshots:
       '@vitest/ui': 4.1.11(vitest@4.1.11)
     transitivePeerDependencies:
       - msw
+
+  vue@3.5.42(typescript@6.0.3):
+    dependencies:
+      '@vue/compiler-dom': 3.5.42
+      '@vue/compiler-sfc': 3.5.42
+      '@vue/runtime-dom': 3.5.42
+      '@vue/server-renderer': 3.5.42
+      '@vue/shared': 3.5.42
+    optionalDependencies:
+      typescript: 6.0.3
 
   watchpack@2.5.2:
     dependencies:
@@ -6820,3 +7308,5 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
## 🎯 Changes

  Adds the static presentation/data-source bridge for the HTML report.

  This PR:

  - Reuses the existing Vue presentation layer from the #3925 design.
  - Adds the private `@kubb/devtools` presentation package.
  - Adds a static data source compatible with the existing UI contract:
    - `run`
    - `connect()`
    - `fetchAst()`
    - `fetchPluginNames()`
    - `fetchPluginView(name)`
    - `fetchFiles()`
    - `readGeneratedFile(id)`
  - Maps the PR1 report snapshot directly to the existing AST, pipeline, and files panels.
  - Initializes static report data before mounting the Vue application.
  - Builds precompiled browser assets without restoring RPC, WebSocket, devframe, Studio, or live collector infrastructure.
  - Keeps the existing live behavior unchanged.

  Tests cover run data, canonical AST, plugin views, generated files, file contents, missing data, and static connection behavior.

  Related to #3933. This is PR 2 of the stacked implementation and does not close the issue.

  Depends on PR1, the internal static report collector.

  ## ✅ Checklist

  - [X] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
  - [X] I have tested this code locally with `pnpm run test`.

  Relevant package tests, lint, typecheck, and builds were run locally for `@kubb/core`, `@kubb/devtools`, and `@kubb/cli`.

  ## 🚀 Release Impact

  - [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
  - [ ] This change is for the docs (no release).