### PR TITLE
feat(studio): let a host slow its heartbeat to 60 seconds

### DIFF
--- a/.changeset/raise-heartbeat-ceiling.md
+++ b/.changeset/raise-heartbeat-ceiling.md
@@ -1,0 +1,15 @@
+---
+'@kubb/studio': minor
+---
+
+Let a host slow its heartbeat down to 60 seconds. `heartbeatInterval` was clamped to the 30-second
+default, so it could only ever be lowered, which made it useful in development and useless for
+cutting the traffic and database writes a long-lived agent costs.
+
+`agentDefaults.maxHeartbeatIntervalMs` (60000) is now the ceiling, separate from
+`agentDefaults.heartbeatIntervalMs` (30000), which stays the default. Nothing changes unless a host
+asks for a slower cadence.
+
+The ceiling is a protocol contract with Studio: Studio drops an agent from the active list once its
+stored ping is older than its liveness window, and it stores a ping at most once a minute, so a
+slower cadence would make a healthy agent look dead after one missed ping.

--- a/packages/studio/src/StudioSession.test.ts
+++ b/packages/studio/src/StudioSession.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import process from 'node:process'
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { agentDefaults } from './constants.ts'
 import { spyOnConsole } from './console.mock.ts'
 import { MockWebSocket } from './websocket.mock.ts'
 import type { AgentConnectResponse } from './protocol/index.ts'
@@ -222,8 +223,22 @@ describe('StudioSession', () => {
     await mockWs.trigger('open')
     vi.mocked(sendAgentMessage).mockClear()
 
-    await vi.advanceTimersByTimeAsync(30_000)
+    await vi.advanceTimersByTimeAsync(agentDefaults.maxHeartbeatIntervalMs)
 
+    expect(sendAgentMessage).toHaveBeenCalledWith(mockWs, { type: 'agent:ping' })
+  })
+
+  it('honors a slower heartbeat up to the ceiling, so a long-lived agent can cost less', async () => {
+    vi.useFakeTimers()
+
+    await connect({ ...options, heartbeatInterval: agentDefaults.maxHeartbeatIntervalMs })
+    await mockWs.trigger('open')
+    vi.mocked(sendAgentMessage).mockClear()
+
+    await vi.advanceTimersByTimeAsync(agentDefaults.heartbeatIntervalMs)
+    expect(sendAgentMessage).not.toHaveBeenCalledWith(mockWs, { type: 'agent:ping' })
+
+    await vi.advanceTimersByTimeAsync(agentDefaults.heartbeatIntervalMs)
     expect(sendAgentMessage).toHaveBeenCalledWith(mockWs, { type: 'agent:ping' })
   })
 

--- a/packages/studio/src/StudioSession.ts
+++ b/packages/studio/src/StudioSession.ts
@@ -50,6 +50,12 @@ export type StudioSessionOptions = {
   permissions?: Partial<AgentPermissions>
   root?: string
   retryInterval?: number
+  /**
+   * Milliseconds between keep-alive pings, clamped to `agentDefaults.maxHeartbeatIntervalMs`.
+   * Raise it to halve the traffic and database writes a long-lived agent costs, at the price of
+   * Studio taking that much longer to notice the agent has gone. Lower it in development to see
+   * connection state move immediately.
+   */
   heartbeatInterval?: number
   /**
    * Number of pool sessions this agent serves. Read by `createClient`, which opens one
@@ -112,7 +118,7 @@ function applyStudioDefaults(options: StudioSessionOptions): ResolvedOptions {
     // Studio counts an agent offline once its last ping is older than its liveness window, so a
     // slower cadence would make a healthy agent invisible. Clamped here rather than in a host's
     // env parsing, so every host is held to the contract.
-    heartbeatInterval: Math.min(options.heartbeatInterval ?? agentDefaults.heartbeatIntervalMs, agentDefaults.heartbeatIntervalMs),
+    heartbeatInterval: Math.min(options.heartbeatInterval ?? agentDefaults.heartbeatIntervalMs, agentDefaults.maxHeartbeatIntervalMs),
   }
 }
 

--- a/packages/studio/src/constants.ts
+++ b/packages/studio/src/constants.ts
@@ -11,10 +11,12 @@ export const defaultStudioUrl = 'https://kubb.studio'
 export const agentDefaults = {
   studioUrl: defaultStudioUrl,
   retryIntervalMs: 30_000,
-  /**
-   * Maximum heartbeat interval. Studio drops agents from the active list after ~90s without a ping,
-   * so a slower override would make a healthy agent look dead.
-   */
   heartbeatIntervalMs: 30_000,
+  /**
+   * Slowest heartbeat a host may ask for. Studio drops an agent from the active list once its
+   * stored ping is older than its liveness window, and it stores a ping at most once a minute, so
+   * a slower cadence would make a healthy agent look dead after a single missed ping.
+   */
+  maxHeartbeatIntervalMs: 60_000,
   poolSize: 1,
 } as const


### PR DESCRIPTION
## What changed

`heartbeatInterval` was clamped to the 30-second default:

```ts
heartbeatInterval: Math.min(options.heartbeatInterval ?? agentDefaults.heartbeatIntervalMs, agentDefaults.heartbeatIntervalMs)
```

The same constant was both the default and the ceiling, so a host could only ever lower the value.
That made the option useful in development and useless for its other job: cutting the traffic and
database writes a long-lived agent costs.

`agentDefaults.maxHeartbeatIntervalMs` (60000) is now the ceiling, separate from
`agentDefaults.heartbeatIntervalMs` (30000), which stays the default. Nothing changes unless a host
asks for a slower cadence.

## Why 60 seconds

The ceiling is a protocol contract with Studio, not an arbitrary number. Studio drops an agent from
the active list once its stored ping is older than its liveness window (150s), and it stores a ping
at most once a minute. At a 60s cadence the stored timestamp is at most 120s old after one missed
ping, which still reads as live. Anything slower would make a healthy agent look dead.

The clamp stays in `applyStudioDefaults` rather than in each host's env parsing, so every host is
held to the same contract.

## Who this unblocks

`kubb-labs/platform` reads `KUBB_AGENT_HEARTBEAT_INTERVAL` into this option for the Docker agent.
Until now that variable could only make the agent ping faster. It pairs with
[kubb-labs/platform#460](https://github.com/kubb-labs/platform/pull/460), which cuts what each ping
costs Studio's database.

## Verification

```bash
cd packages/studio && pnpm test    # 12 files, 188 tests pass
```

The existing clamp test now advances by the ceiling rather than a hardcoded 30000. A new test covers
the case the old code could not express: a 60s override is honored, with no ping at 30s and one at
60s.

`oxlint` and `tsc --noEmit` are clean for the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QBHG8woh2Era8LmPNABg69

---
_Generated by [Claude Code](https://claude.ai/code/session_01QBHG8woh2Era8LmPNABg69)_