### PR TITLE
ci: add comment ratio check to PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -239,3 +239,25 @@ jobs:
 
       - name: Run the CLI under Bun
         run: bun packages/cli/bin/kubb.js --version
+
+  comment-ratio:
+    name: Comment ratio
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    if: github.actor != 'github-actions[bot]' && github.event_name == 'pull_request'
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Check comment ratio
+        uses: IgnaceMaes/comment-ratio@8667d710c02c19dcca42be02f97d5f6824012932 # v1.0.0
+        with:
+          max-comment-ratio: 0.15
+          exclude: |
+            **/mocks/**
+            **/__snapshots__/**


### PR DESCRIPTION
## 🎯 Changes

Adds the [comment-ratio](https://github.com/marketplace/actions/comment-ratio) action as a `Comment ratio` job in `.github/workflows/pr.yml`. The job counts the code and comment lines a pull request adds and fails when comments take up more than their share, which keeps agent-written code from over-narrating itself.

Settings:

- `max-comment-ratio: 0.15` instead of the action default of `0.05`. The `jsdoc` rule asks for a doc comment on every exported type, property, and function, and each one is a multi-line `/** ... */` block. At 5% a normal PR that adds a documented export would fail.
- `exclude: **/mocks/**, **/__snapshots__/**` so fixtures do not count.
- The job runs only on `pull_request`, since the action needs a base and head to compare and `pr.yml` also runs on `workflow_dispatch`.
- The action is pinned to commit `8667d710c02c19dcca42be02f97d5f6824012932` (`v1.0.0`), matching how every other action in this repo is pinned.

Markdown and other prose formats are excluded by the action itself, so docs edits do not affect the ratio.

To verify: open any pull request and check the `Comment ratio` job. It writes a job summary and keeps one sticky comment on the pull request up to date.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`. CI-only change; the workflow YAML was validated by parsing it.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release). CI configuration only, no published code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCDYwCk67B1eS6314fHqXc

---
_Generated by [Claude Code](https://claude.ai/code/session_01HCDYwCk67B1eS6314fHqXc)_