### PR TITLE
feat(agents): add a /pr command and rewrite the pr skill for agents

### DIFF
--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -1,41 +1,140 @@
 ---
 name: pr
-description: Rules and checklist for preparing PRs, creating changesets, and releasing packages in the monorepo.
+description: Open or update a pull request in this monorepo. Covers the pre-push checks, the changeset decision, Conventional Commit titles, how to fill the PR template, and what to do once CI runs. Use when asked to open a PR, push a branch for review, fix a red PR, or judge whether a branch is ready to merge.
 ---
 
-# PR Skill
+# PR skill
 
-This skill instructs agents on PR preconditions, changeset usage, and reviewer expectations.
+Take a branch from "the code is written" to "a reviewer can merge this". Work the steps in
+order. When you cannot finish a step, say so in the PR body rather than skipping it quietly.
 
-## When to Use
+## When to use
 
-- When a user asks how to prepare a PR or what checks are required before merging
-- When guiding contributors to create changesets or update the changelog
+- Opening a pull request, or pushing a branch you expect to become one.
+- Updating a pull request after a review comment or a failing CI run.
+- Answering whether a branch is ready to merge.
 
-## What It Does
+## 1. Confirm the branch
 
-- Enforces the PR checklist: `format, lint, typecheck, tests`
-- Instructs on creating and using changesets for version bumps
-- Describes release/merge expectations and documentation updates
+Never commit to `main`. Check where you are, and branch from an up-to-date `main` if you are
+still on it:
 
-## Commands to Suggest
+```bash
+git status
+git branch --show-current
+git fetch origin main
+git switch -c <type>/<short-slug> origin/main
+```
+
+Use the same Conventional Commit type you plan to use in the title, so `feat/`, `fix/`,
+`docs/`, `chore/`, `refactor/`, `test/`, or `perf/`.
+
+## 2. Run the checks before you push
 
 ```bash
 pnpm format && pnpm lint:fix
 pnpm typecheck
 pnpm test
+```
+
+Run `pnpm build` too when you changed package source, because packages resolve each other
+through their build output.
+
+Everything has to pass before you push. Fix the root cause of a failure. Do not disable a lint
+rule, loosen a type, or skip a test to get a green run.
+
+## 3. Decide on a changeset
+
+A change that reaches a published package needs a changeset. A change confined to docs, CI,
+tests, or the agent files does not.
+
+```bash
 pnpm changeset
 ```
 
-## Checklist
+Pick `patch` for a fix, `minor` for a backwards-compatible feature, and `major` for a breaking
+change. Write the summary for a user reading the release notes, not for a reviewer reading the
+diff. The `changelog` skill has the wording conventions, and `/changeset` does this step for you.
 
-- [ ] CI green (unit tests, linters, typechecks)
-- [ ] Documentation updated if public behavior changed
-- [ ] No secrets in the PR
-- [ ] Appropriate version bump via changeset
+## 4. Cover the ripple effects
 
-## Related Skills
+An option or public API you changed shows up in more places than the diff:
 
-| Skill                                              | Use For                          |
-| -------------------------------------------------- | -------------------------------- |
-| **[../changelog/SKILL.md](../changelog/SKILL.md)** | Update changelogs and changesets |
+- Update the matching kubb.dev page as `AGENTS.md` describes, in this same PR.
+- Keep a documented default matching the destructuring default in the plugin's `plugin.ts`.
+- Never hand-edit `tools/claude/.claude-plugin/plugin.json`. The release syncs its version from
+  `tools/claude/package.json` through `pnpm sync:plugin-version`.
+
+## 5. Commit
+
+One Conventional Commit per logical change, in the imperative, with no trailing period:
+
+```
+feat(core): add a plugin resolver cache
+```
+
+Check `git diff --cached` before every commit. Never commit a secret, a token, a `.env` file, or
+a build artifact. Regenerate a lockfile with pnpm rather than editing it.
+
+## 6. Write the title and body
+
+### Title
+
+One Conventional Commit line, imperative, under 72 characters, no trailing period. It becomes
+the squash-merge commit, so write it for whoever reads the changelog later.
+
+### Body
+
+Fill `.github/pull_request_template.md`. Keep its headings and their order, replace each HTML
+comment with real content, and delete no section.
+
+Under **Changes**, write two to five sentences. Lead with what changed, then why. Name the
+package or file a reviewer should open first. Add `Closes #123` when the PR closes an issue.
+
+Under **Checklist**, tick a box only for something you actually did on this branch. An unticked
+box with a one-line reason under it is honest and useful. A ticked box you did not verify costs
+a reviewer their trust, so it is the one thing never to do here.
+
+Under **Release impact**, tick the changeset box when `.changeset/` gained a file in this branch,
+and the docs box when no published package changed.
+
+Keep the body in plain language: short sentences, active voice, exact paths and commands, no
+restating the request back at the reader.
+
+## 7. Push and open the PR
+
+```bash
+git push -u origin <branch>
+```
+
+Open the PR against `main`, ready for review rather than draft. One PR does one thing. When you
+notice unrelated work along the way, leave it out and mention it in the body instead.
+
+## 8. After CI runs
+
+A red PR is work now, whatever its review state.
+
+Read the failing job, reproduce the failure locally, fix the cause, and push again. Re-running a
+job is only worth it when the failure never reached a test body, such as a checkout or install
+error, or when the same commit passed before.
+
+Answer every review comment. Push the fix for a small, local ask. For a larger ask, reply with
+what you propose and let the author decide. Say what you changed and how the reviewer can check
+it.
+
+## Guardrails
+
+- Keep the diff to what was asked. Drive-by refactors belong in their own PR.
+- Never force-push a branch someone else may have checked out.
+- Run the `humanizer` skill over any user-facing markdown in the diff, including the changeset.
+- Run the `deslop` skill over generated code before you push.
+- Use USA English in the title, body, commits, and changeset.
+
+## Related skills
+
+| Skill | Use for |
+| --- | --- |
+| [changelog](../changelog/SKILL.md) | Changeset and release-note wording |
+| [deslop](../deslop/SKILL.md) | Stripping AI tells from the code in the diff |
+| [humanizer](../humanizer/SKILL.md) | Stripping AI tells from the prose in the diff |
+| [jsdoc](../jsdoc/SKILL.md) | Documenting a new or changed public API |

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -83,6 +83,17 @@ a build artifact. Regenerate a lockfile with pnpm rather than editing it.
 One Conventional Commit line, imperative, under 72 characters, no trailing period. It becomes
 the squash-merge commit, so write it for whoever reads the changelog later.
 
+Read the title off the branch you already named:
+
+1. Take the type from the branch prefix, so `feat/`, `fix/`, `docs/`, `chore/`, `refactor/`,
+   `test/`, or `perf/`.
+2. Turn the kebab-case slug into a sentence, imperative and in the present tense.
+3. Add the scope in parentheses when the change sits in one package.
+
+`feat/plugin-resolver-cache` becomes `feat(core): add a plugin resolver cache`.
+
+Put the issue number in the body with `Closes #123`, not in the title.
+
 ### Body
 
 Fill `.github/pull_request_template.md`. Keep its headings and their order, replace each HTML
@@ -101,14 +112,52 @@ and the docs box when no published package changed.
 Keep the body in plain language: short sentences, active voice, exact paths and commands, no
 restating the request back at the reader.
 
+### How to test
+
+Write numbered steps a reviewer can follow from a clean checkout, ending in the result they
+should see. When someone handed you steps, fix them before you paste them in: add the missing
+prerequisite, put them in order, replace a vague instruction with the exact command or path, and
+state the expected result. When you have no steps and cannot derive them from the diff, ask for
+them rather than leaving the section empty.
+
+Add a screenshot for a visible change, and a before and after when you changed something that
+already existed.
+
+### Impact
+
+Say who this reaches: someone using the published package, someone consuming the generated
+output, or nobody outside this repo. Name the breaking change and the migration step when there
+is one.
+
 ## 7. Push and open the PR
 
 ```bash
+git fetch origin main
+git pull --ff-only
 git push -u origin <branch>
+
+gh pr create \
+  --base main \
+  --title "<conventional commit title>" \
+  --body-file <body>.md \
+  --assignee @me
 ```
 
-Open the PR against `main`, ready for review rather than draft. One PR does one thing. When you
-notice unrelated work along the way, leave it out and mention it in the body instead.
+Use the `gh` CLI rather than a GitHub MCP server or any other bot token, so the PR is authored by
+whoever ran it and lands in their own list.
+
+Open it ready for review, not draft. Mark a draft ready with `gh pr ready` once the branch is
+finished and the checks pass.
+
+Add a label the repo already uses. `gh label list` shows them, and inventing one is worse than
+leaving the PR unlabeled.
+
+Squash the commits and delete the branch on merge, which `gh pr merge --squash --delete-branch`
+does in one step. When you do not have merge rights, say in the body that the PR is meant to be
+squashed.
+
+One PR does one thing. When you notice unrelated work along the way, leave it out and mention it
+in the body instead.
 
 ## 8. After CI runs
 

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -114,11 +114,17 @@ restating the request back at the reader.
 
 ### How to test
 
-Write numbered steps a reviewer can follow from a clean checkout, ending in the result they
-should see. When someone handed you steps, fix them before you paste them in: add the missing
-prerequisite, put them in order, replace a vague instruction with the exact command or path, and
-state the expected result. When you have no steps and cannot derive them from the diff, ask for
-them rather than leaving the section empty.
+Fill it as a short list, one step per line, replacing the placeholders:
+
+- Step 1: [Clear reproduction step]
+- Step 2: [Next step]
+- Step 3: [Expected result]
+
+Start from a clean checkout, and use a real command or path, not a description of one. When
+someone handed you steps, fix them before you paste them in: add the missing prerequisite, put
+them in order, replace a vague instruction with the exact command or path, and state the expected
+result. When you have no steps and cannot derive them from the diff, ask for them rather than
+leaving the section empty.
 
 Add a screenshot for a visible change, and a before and after when you changed something that
 already existed.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -5,19 +5,6 @@ description: Get the current branch ready for review and open the pull request
 
 !`git status --short --branch`
 
-!`git diff --stat origin/main...HEAD`
-
-Get this branch ready for review and open the pull request. Follow the `pr` skill for the full
-sequence, and treat `$ARGUMENTS` as extra context for the body when it is not empty.
-
-1. Run `pnpm format && pnpm lint:fix`, `pnpm typecheck`, and `pnpm test`, and fix what fails.
-2. Add a changeset when the branch touches a published package, or say why it needs none.
-3. Update the matching kubb.dev page when a public option changed.
-4. Commit anything outstanding with a Conventional Commit message.
-5. Bring the branch up to date with `git fetch origin main`, then `git push -u origin <branch>`.
-6. Derive the title from the branch name as one Conventional Commit line.
-7. Open the PR with `gh pr create --base main --assignee @me`, ready for review. Fill every
-   section of `.github/pull_request_template.md`, fill the how-to-test steps in place of
-   the placeholders, add a label the repo already uses, and tick only the boxes you verified.
-
-Report the PR URL and anything you left unticked.
+Follow the `pr` skill to get this branch ready for review and open the pull request. Treat
+`$ARGUMENTS` as extra context for the PR body when it is not empty. Report the PR URL and
+anything you left unticked.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -14,8 +14,11 @@ sequence, and treat `$ARGUMENTS` as extra context for the body when it is not em
 2. Add a changeset when the branch touches a published package, or say why it needs none.
 3. Update the matching kubb.dev page when a public option changed.
 4. Commit anything outstanding with a Conventional Commit message.
-5. Push with `git push -u origin <branch>`.
-6. Open the PR against `main`, ready for review, with the body filling every section of
-   `.github/pull_request_template.md`. Tick only the boxes you verified.
+5. Bring the branch up to date with `git fetch origin main`, then `git push -u origin <branch>`.
+6. Derive the title from the branch name as one Conventional Commit line.
+7. Open the PR with `gh pr create --base main --assignee @me`, ready for review. Fill every
+   section of `.github/pull_request_template.md`, give the how-to-test section numbered steps
+   ending in the expected result, add a label the repo already uses, and tick only the boxes
+   you verified.
 
 Report the PR URL and anything you left unticked.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,21 @@
+---
+argument-hint: [note to work into the PR body]
+description: Get the current branch ready for review and open the pull request
+---
+
+!`git status --short --branch`
+
+!`git diff --stat origin/main...HEAD`
+
+Get this branch ready for review and open the pull request. Follow the `pr` skill for the full
+sequence, and treat `$ARGUMENTS` as extra context for the body when it is not empty.
+
+1. Run `pnpm format && pnpm lint:fix`, `pnpm typecheck`, and `pnpm test`, and fix what fails.
+2. Add a changeset when the branch touches a published package, or say why it needs none.
+3. Update the matching kubb.dev page when a public option changed.
+4. Commit anything outstanding with a Conventional Commit message.
+5. Push with `git push -u origin <branch>`.
+6. Open the PR against `main`, ready for review, with the body filling every section of
+   `.github/pull_request_template.md`. Tick only the boxes you verified.
+
+Report the PR URL and anything you left unticked.

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -17,8 +17,7 @@ sequence, and treat `$ARGUMENTS` as extra context for the body when it is not em
 5. Bring the branch up to date with `git fetch origin main`, then `git push -u origin <branch>`.
 6. Derive the title from the branch name as one Conventional Commit line.
 7. Open the PR with `gh pr create --base main --assignee @me`, ready for review. Fill every
-   section of `.github/pull_request_template.md`, give the how-to-test section numbered steps
-   ending in the expected result, add a label the repo already uses, and tick only the boxes
-   you verified.
+   section of `.github/pull_request_template.md`, fill the how-to-test steps in place of
+   the placeholders, add a label the repo already uses, and tick only the boxes you verified.
 
 Report the PR URL and anything you left unticked.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,11 @@ Fill every section below, and tick a box only when you actually ran or verified 
 
 ## 🧪 How to test
 
-<!-- Numbered steps a reviewer can follow from a clean checkout, ending in the result they should see. Add a screenshot for a visible change. -->
+- Step 1: [Clear reproduction step]
+- Step 2: [Next step]
+- Step 3: [Expected result]
+
+<!-- Start from a clean checkout. Add a screenshot for a visible change. -->
 
 ## ✅ Checklist
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,8 @@
+<!--
+Agents: follow the `pr` skill (.agents/skills/pr/SKILL.md), or run /pr.
+Fill every section below, and tick a box only when you actually ran or verified it.
+-->
+
 ## 🎯 Changes
 
 <!-- What changes are made in this PR? Describe the change and its motivation. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,6 +7,10 @@ Fill every section below, and tick a box only when you actually ran or verified 
 
 <!-- What changes are made in this PR? Describe the change and its motivation. -->
 
+## 🧪 How to test
+
+<!-- Numbered steps a reviewer can follow from a clean checkout, ending in the result they should see. Add a screenshot for a visible change. -->
+
 ## ✅ Checklist
 
 - [ ] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
@@ -16,3 +20,4 @@ Fill every section below, and tick a box only when you actually ran or verified 
 
 - [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
 - [ ] This change is for the docs (no release).
+- [ ] This change is breaking, and the body says what breaks and what a user has to do.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,5 +75,5 @@ You have new skills. If any skill might be relevant then you MUST read it.
 - [documentation](.agents/skills/documentation/SKILL.md) - Use when writing blog posts or documentation markdown files - provides writing style guide (active voice, present tense), content structure patterns, and SEO optimization. Overrides brevity rules for proper grammar.
 - [humanizer](.agents/skills/humanizer/SKILL.md) - Remove AI writing patterns to make documentation sound natural, specific, and human. Covers content patterns, language patterns, style patterns, and communication patterns.
 - [jsdoc](.agents/skills/jsdoc/SKILL.md) - Full JSDoc format guide for TypeScript, covering @example formats (short, multi-line, multi-variant), tag usage (@default, @deprecated, what to avoid), documentation patterns for properties/enums/functions, and tag order.
-- [pr](.agents/skills/pr/SKILL.md) - Rules and checklist for preparing PRs, creating changesets, and releasing packages in the monorepo.
+- [pr](.agents/skills/pr/SKILL.md) - Open or update a pull request in this monorepo. Covers the pre-push checks, the changeset decision, Conventional Commit titles, how to fill the PR template, and what to do once CI runs.
 </skills>


### PR DESCRIPTION
## 🎯 Changes

The `pr` skill listed four commands and a checklist, but never said how to get from written code to an open pull request. An agent reading it still had to guess the title format, which sections of the PR template to fill, and whether a checkbox it had not verified was safe to tick.

The skill is now a numbered sequence: confirm the branch, run the pre-push checks, decide on a changeset, cover the ripple effects (the kubb.dev page, a documented default matching `plugin.ts`, never hand-editing the synced plugin version), commit, derive the title from the branch name, fill each section of `.github/pull_request_template.md`, open the PR with `gh` so it is authored by the person running it, then work a red CI run. A new `/pr` command runs that sequence.

The PR template gains a `How to test` section, a breaking-change row, and a comment at the top pointing agents at the skill.

Start with `.agents/skills/pr/SKILL.md`.

## 🧪 How to test

1. In Claude Code from the repo root, `/pr` loads with the argument hint `[note to work into the PR body]`.
2. Ask Claude "how do I open a PR here" and the `pr` skill loads, since `.claude/skills` already symlinks to `.agents/skills`.
3. `head -4 .github/pull_request_template.md` shows the agent pointer comment, and the file now has a `🧪 How to test` section between Changes and Checklist.

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

Neither is ticked on purpose. This branch touches only markdown under `.agents/` and `.claude/` plus the PR template, so no package code runs and the test suite covers nothing in the diff. The contributing guide asks for a fork, and this branch was pushed to the repo directly.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).
- [ ] This change is breaking, and the body says what breaks and what a user has to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LpMQ7Js2tj2JPVNBucecii

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpMQ7Js2tj2JPVNBucecii)_