### PR TITLE
chore: exclude @kubb/* and kubb from the 48-hour minimum release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,7 +22,10 @@ catalog:
 minimumReleaseAge: 2880 # 48 hours, matches CI's SAFE_CHAIN_MINIMUM_PACKAGE_AGE_HOURS
 # Native platform bindings are always co-published with their parent package in the same release.
 # Excluding them avoids false-positive ERR_PNPM_NO_MATURE_MATCHING_VERSION errors.
+# @kubb/* and kubb are our own packages, published from this repo, so the age limit doesn't apply.
 minimumReleaseAgeExclude:
   - "@types/*"
+  - "@kubb/*"
+  - "kubb"
 pmOnFail: warn
 resolutionMode: highest


### PR DESCRIPTION
## 🎯 Changes

`pnpm-workspace.yaml` sets a 48-hour `minimumReleaseAge` so pnpm won't install a package published in the last 48 hours, guarding against supply-chain attacks on freshly published malicious packages. `@kubb/*` and `kubb` are our own packages published from this repo, so that guard has no value for them and only slows down picking up a release right after it ships. Add them to `minimumReleaseAgeExclude`, matching the exclusion the `plugins` and `platform` repos already carry.

## 🧪 How to test

- Step 1: Open `pnpm-workspace.yaml`.
- Step 2: Check `minimumReleaseAgeExclude` includes `@kubb/*` and `kubb` alongside `@types/*`.
- Step 3: Run `pnpm install` and confirm it completes without a `ERR_PNPM_NO_MATURE_MATCHING_VERSION` error on a freshly published `@kubb/*` package.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`. (config-only change, no test suite covers `pnpm-workspace.yaml`)

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).
- [ ] This change is breaking, and the body says what breaks and what a user has to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GNWYx6TZFcjLrRtDd3nP5i

---
_Generated by [Claude Code](https://claude.ai/code/session_01GNWYx6TZFcjLrRtDd3nP5i)_