### PR TITLE
feat(templates): promote the sponsors page in issue templates and funding fields

### DIFF
--- a/.changeset/tidy-otters-sponsor.md
+++ b/.changeset/tidy-otters-sponsor.md
@@ -1,0 +1,6 @@
+---
+'@kubb/core': patch
+---
+
+Add a `kubb.dev/sponsors` entry to each published package's `funding` field, alongside the
+existing GitHub Sponsors and Open Collective links.

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -66,3 +66,11 @@ body:
     attributes:
       label: Additional information
       description: Is there anything else you think we should know?
+  - type: checkboxes
+    attributes:
+      label: How can you help?
+      description: |
+        Votes show interest, but funding pays for the work. See [sponsorship tiers](https://kubb.dev/sponsors).
+      options:
+        - label: My team would fund a fix for this
+        - label: I intend to open a pull request fixing this

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,6 @@ contact_links:
   - name: Community Chat
     url: https://discord.gg/shfBFeczrm
     about: Please ask and answer questions here.
+  - name: Fund a feature 💰
+    url: https://kubb.dev/sponsors
+    about: Votes show interest, funding pays for the work.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,6 @@ contact_links:
   - name: Community Chat
     url: https://discord.gg/shfBFeczrm
     about: Please ask and answer questions here.
-  - name: Fund a feature 💰
+  - name: Fund a feature
     url: https://kubb.dev/sponsors
     about: Votes show interest, funding pays for the work.

--- a/packages/adapter-oas/package.json
+++ b/packages/adapter-oas/package.json
@@ -28,6 +28,10 @@
     {
       "type": "opencollective",
       "url": "https://opencollective.com/kubb"
+    },
+    {
+      "type": "custom",
+      "url": "https://kubb.dev/sponsors"
     }
   ],
   "files": [

--- a/packages/ast/package.json
+++ b/packages/ast/package.json
@@ -25,6 +25,10 @@
     {
       "type": "opencollective",
       "url": "https://opencollective.com/kubb"
+    },
+    {
+      "type": "custom",
+      "url": "https://kubb.dev/sponsors"
     }
   ],
   "files": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,6 +27,10 @@
     {
       "type": "opencollective",
       "url": "https://opencollective.com/kubb"
+    },
+    {
+      "type": "custom",
+      "url": "https://kubb.dev/sponsors"
     }
   ],
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,10 @@
     {
       "type": "opencollective",
       "url": "https://opencollective.com/kubb"
+    },
+    {
+      "type": "custom",
+      "url": "https://kubb.dev/sponsors"
     }
   ],
   "files": [

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -26,6 +26,10 @@
     {
       "type": "opencollective",
       "url": "https://opencollective.com/kubb"
+    },
+    {
+      "type": "custom",
+      "url": "https://kubb.dev/sponsors"
     }
   ],
   "files": [

--- a/packages/kubb/package.json
+++ b/packages/kubb/package.json
@@ -31,6 +31,10 @@
     {
       "type": "opencollective",
       "url": "https://opencollective.com/kubb"
+    },
+    {
+      "type": "custom",
+      "url": "https://kubb.dev/sponsors"
     }
   ],
   "bin": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -28,6 +28,10 @@
     {
       "type": "opencollective",
       "url": "https://opencollective.com/kubb"
+    },
+    {
+      "type": "custom",
+      "url": "https://kubb.dev/sponsors"
     }
   ],
   "bin": {

--- a/packages/parser-md/package.json
+++ b/packages/parser-md/package.json
@@ -27,6 +27,10 @@
     {
       "type": "opencollective",
       "url": "https://opencollective.com/kubb"
+    },
+    {
+      "type": "custom",
+      "url": "https://kubb.dev/sponsors"
     }
   ],
   "files": [

--- a/packages/parser-ts/package.json
+++ b/packages/parser-ts/package.json
@@ -26,6 +26,10 @@
     {
       "type": "opencollective",
       "url": "https://opencollective.com/kubb"
+    },
+    {
+      "type": "custom",
+      "url": "https://kubb.dev/sponsors"
     }
   ],
   "files": [

--- a/packages/plugin-barrel/package.json
+++ b/packages/plugin-barrel/package.json
@@ -26,6 +26,10 @@
     {
       "type": "opencollective",
       "url": "https://opencollective.com/kubb"
+    },
+    {
+      "type": "custom",
+      "url": "https://kubb.dev/sponsors"
     }
   ],
   "files": [

--- a/packages/renderer-jsx/package.json
+++ b/packages/renderer-jsx/package.json
@@ -26,6 +26,10 @@
     {
       "type": "opencollective",
       "url": "https://opencollective.com/kubb"
+    },
+    {
+      "type": "custom",
+      "url": "https://kubb.dev/sponsors"
     }
   ],
   "files": [

--- a/packages/studio/package.json
+++ b/packages/studio/package.json
@@ -27,6 +27,10 @@
     {
       "type": "opencollective",
       "url": "https://opencollective.com/kubb"
+    },
+    {
+      "type": "custom",
+      "url": "https://kubb.dev/sponsors"
     }
   ],
   "files": [

--- a/packages/unplugin-kubb/package.json
+++ b/packages/unplugin-kubb/package.json
@@ -33,6 +33,10 @@
     {
       "type": "opencollective",
       "url": "https://opencollective.com/kubb"
+    },
+    {
+      "type": "custom",
+      "url": "https://kubb.dev/sponsors"
     }
   ],
   "files": [


### PR DESCRIPTION
## 🎯 Changes

Point issue reporters and package consumers to the [sponsors page](https://kubb.dev/sponsors). Adds a "Fund a feature" contact link and a "how can you help" checkbox to the bug template, and lists `kubb.dev/sponsors` in every published package's `funding` field alongside GitHub Sponsors and Open Collective.

## 🧪 How to test

- Step 1: Open `.github/ISSUE_TEMPLATE/config.yml` and `bug.yml` and confirm the new entries render as valid GitHub issue-form YAML.
- Step 2: Inspect `packages/core/package.json` to confirm the `funding` array has three entries.
- Step 3: Run `pnpm changeset status` to see the new changeset targeting the fixed `@kubb/*` group.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`. (Ran `pnpm format` and `pnpm lint:fix` clean; skipped `pnpm test` since no source code changed, only JSON/YAML metadata.)

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).
- [ ] This change is breaking, and the body says what breaks and what a user has to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019upxkXkdLJjM2c1N8PFNR5

---
_Generated by [Claude Code](https://claude.ai/code/session_019upxkXkdLJjM2c1N8PFNR5)_