### PR TITLE
feat(templates): set the native GitHub issue type on bug and feature templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -3,6 +3,7 @@
 name: Bug Report
 description: Report an issue that should be fixed
 labels: [bug]
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,39 @@
+# Based on Bun's template
+
+name: Feature Request
+description: Suggest an idea or improvement for Kubb
+labels: [feature]
+type: Feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for suggesting a feature. It helps make `Kubb` better.
+  - type: textarea
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case this feature would address.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What is your proposed solution?
+      description: Describe the feature, option, or API you have in mind.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What alternatives have you considered?
+      description: Any workarounds or other approaches you have tried.
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Is there anything else you think we should know?
+  - type: checkboxes
+    attributes:
+      label: How can you help?
+      description: |
+        Votes show interest, but funding pays for the work. See [sponsorship tiers](https://kubb.dev/sponsors).
+      options:
+        - label: My team would fund this feature
+        - label: I intend to open a pull request for this


### PR DESCRIPTION
## 🎯 Changes

Set the native GitHub issue type on the bug template (`type: Bug`) and add a new feature-request template (`type: Feature`), so issues opened from these forms carry the right type automatically instead of relying only on labels.

## 🧪 How to test

- Step 1: Open a new issue from the "Bug Report" template and confirm it opens with the Bug type set.
- Step 2: Open a new issue from the "Feature Request" template and confirm it opens with the Feature type set.
- Step 3: Confirm both templates still render as valid GitHub issue-form YAML.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`. (Ran `pnpm format` and `pnpm lint:fix` clean; skipped `pnpm test` since only YAML issue templates changed.)

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release).
- [ ] This change is breaking, and the body says what breaks and what a user has to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019upxkXkdLJjM2c1N8PFNR5

---
_Generated by [Claude Code](https://claude.ai/code/session_019upxkXkdLJjM2c1N8PFNR5)_