### PR TITLE
ci: stop running the PR pipeline on changes that cannot break it

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Jobs that publish something read this instead of running for every change.
   changes:
     name: Detect changes
     timeout-minutes: 5
@@ -34,17 +33,26 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 2
 
       - name: Filter paths
         id: filter
-        uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3.0.4
-        with:
-          filters: |
-            packages:
-              - 'packages/**'
-              - 'internals/**'
-              - 'configs/**'
-              - 'pnpm-lock.yaml'
+        env:
+          EVENT: ${{ github.event_name }}
+        run: |
+          # On a pull_request the checkout is the merge commit, so HEAD^1 is the base
+          # branch tip and this diff is exactly the files the pull request touches. A
+          # manual run has no base to compare against, so nothing is filtered out.
+          if [ "$EVENT" != 'pull_request' ]; then
+            echo 'packages=true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if git diff --name-only HEAD^1 HEAD | grep -qE '^(packages|internals|configs)/|^pnpm-lock\.yaml$'; then
+            echo 'packages=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'packages=false' >> "$GITHUB_OUTPUT"
+          fi
 
   build:
     name: Build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,24 +31,17 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 2
 
       - name: Filter paths
         id: filter
-        env:
-          EVENT: ${{ github.event_name }}
-        run: |
-          # The checkout is the merge commit, so HEAD^1 is the base branch tip.
-          if [ "$EVENT" != 'pull_request' ]; then
-            echo 'packages=true' >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if git diff --name-only HEAD^1 HEAD | grep -qE '^(packages|internals|configs)/|^pnpm-lock\.yaml$'; then
-            echo 'packages=true' >> "$GITHUB_OUTPUT"
-          else
-            echo 'packages=false' >> "$GITHUB_OUTPUT"
-          fi
+        uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3.0.4
+        with:
+          filters: |
+            packages:
+              - 'packages/**'
+              - 'internals/**'
+              - 'configs/**'
+              - 'pnpm-lock.yaml'
 
   build:
     name: Build

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,18 @@ name: PR
 
 on:
   workflow_dispatch:
+  # A pull request that touches only these paths cannot change what we build, so
+  # the whole workflow is skipped. autofix.ci has no filter and still formats and
+  # lints every pull request.
   pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - '.agents/**'
+      - '.claude/**'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/FUNDING.yml'
+      - 'assets/**'
+      - 'LICENSE'
 
 permissions: {}
 
@@ -11,6 +22,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Jobs that publish something read this instead of running for every change.
+  changes:
+    name: Detect changes
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      packages: ${{ steps.filter.outputs.packages }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Filter paths
+        id: filter
+        uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3.0.4
+        with:
+          filters: |
+            packages:
+              - 'packages/**'
+              - 'internals/**'
+              - 'configs/**'
+              - 'pnpm-lock.yaml'
+
   build:
     name: Build
     timeout-minutes: 15
@@ -99,7 +134,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@da8a350ddbedb4dd9cf54b05b7ef1a4298c4f0dc # main
@@ -118,8 +153,9 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    if: github.actor != 'github-actions[bot]' && github.event.pull_request.head.repo.full_name == github.repository
-    needs: build
+    # pkg-pr-new publishes real preview packages, so it only runs when a package changed.
+    if: github.actor != 'github-actions[bot]' && github.event.pull_request.head.repo.full_name == github.repository && needs.changes.outputs.packages == 'true'
+    needs: [build, changes]
     steps:
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -149,7 +185,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@da8a350ddbedb4dd9cf54b05b7ef1a4298c4f0dc # main
@@ -222,7 +258,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Setup Tools
         uses: kubb-labs/config/.github/setup@da8a350ddbedb4dd9cf54b05b7ef1a4298c4f0dc # main

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,9 +2,7 @@ name: PR
 
 on:
   workflow_dispatch:
-  # A pull request that touches only these paths cannot change what we build, so
-  # the whole workflow is skipped. autofix.ci has no filter and still formats and
-  # lints every pull request.
+  # Skips the whole workflow. autofix.ci is unfiltered and still formats these.
   pull_request:
     paths-ignore:
       - '**/*.md'
@@ -41,9 +39,7 @@ jobs:
         env:
           EVENT: ${{ github.event_name }}
         run: |
-          # On a pull_request the checkout is the merge commit, so HEAD^1 is the base
-          # branch tip and this diff is exactly the files the pull request touches. A
-          # manual run has no base to compare against, so nothing is filtered out.
+          # The checkout is the merge commit, so HEAD^1 is the base branch tip.
           if [ "$EVENT" != 'pull_request' ]; then
             echo 'packages=true' >> "$GITHUB_OUTPUT"
             exit 0
@@ -161,7 +157,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    # pkg-pr-new publishes real preview packages, so it only runs when a package changed.
+    # pkg-pr-new publishes preview packages, so gate it on a package changing.
     if: github.actor != 'github-actions[bot]' && github.event.pull_request.head.repo.full_name == github.repository && needs.changes.outputs.packages == 'true'
     needs: [build, changes]
     steps:


### PR DESCRIPTION
## 🎯 Changes

A pull request that touches only markdown, issue templates, or agent files runs all ten jobs today. [#4009](https://github.com/kubb-labs/kubb/pull/4009) changed two files under `.github/ISSUE_TEMPLATE/` and cost about 9.5 runner minutes across 10 jobs — and published preview npm packages through `pkg-pr-new` while it was at it.

Three changes to `.github/workflows/pr.yml`:

- **`paths-ignore` on the `pull_request` trigger.** Markdown, `.agents/`, `.claude/`, issue templates, `assets/`, `FUNDING.yml`, `LICENSE`. A pull request that also touches a code file still runs everything. `autofix.yml` keeps its unfiltered trigger, so formatting and linting still run on every pull request.
- **A `changes` job gates `prerelease`,** using `dorny/paths-filter` pinned to a commit SHA. Preview packages ship only when `packages/`, `internals/`, `configs/`, or the lockfile change.
- **`fetch-depth: 1` on `linting`, `benchmarks`, and `bun`.** None of them diff against the base ref, so full history was wasted.

Part of a four-repo pass. Companions in `kubb-labs/plugins`, `kubb-labs/platform`, and [stijnvanhulle/template#216](https://github.com/stijnvanhulle/template/pull/216) (merged).

## 🧪 How to test

- Step 1: This pull request touches only `.github/workflows/**`, which is **not** in `paths-ignore`, so the PR workflow must still run in full. A green run proves the filter did not over-match.
- Step 2: Confirm `Prerelease` is skipped on this run — no package changed here, so the gate should hold it back. It has been skipped on every head so far.
- Step 3: Push a commit touching only `README.md`. `PR` should report no new run; `autofix.ci` should still run. Then drop the commit.

Validated locally with `actionlint` and shellcheck (clean), plus a script asserting every `needs.<job>` and `steps.<id>` reference resolves.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`. — not run; this changes CI configuration only, and no source file is touched.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is for the docs (no release). — CI configuration only.
- [ ] This change is breaking, and the body says what breaks and what a user has to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHDJEF1k2g4n4DukFP6FeN