### PR TITLE
fix(adapter-oas): keep an octet-stream response body typed as a blob

### DIFF
--- a/.changeset/octet-stream-response-blob.md
+++ b/.changeset/octet-stream-response-blob.md
@@ -1,0 +1,6 @@
+---
+'@kubb/adapter-oas': patch
+---
+
+Keep a binary response body under `application/octet-stream` typed as a blob instead of falling
+back to `emptySchemaType`.

--- a/packages/adapter-oas/src/model/operations.ts
+++ b/packages/adapter-oas/src/model/operations.ts
@@ -1,4 +1,4 @@
-import { isReference, pickContentEntry } from '../oas.ts'
+import { getBinaryFallbackSchema, isReference, pickContentEntry } from '../oas.ts'
 import { getRequestBody, getRequestContent, getResponseByStatusCode } from '../operation.ts'
 import { dereferenceWithRef } from '../refs.ts'
 import type { Refs } from '../refs.ts'
@@ -37,7 +37,7 @@ export function getParameters({ document, operation }: { document: Document; ope
   return Array.from(paramMap.values())
 }
 
-function getResponseBody(responseBody: boolean | ResponseObject, contentType?: string): MediaTypeObject | false {
+function getResponseBody(responseBody: boolean | ResponseObject, contentType?: string): [string, MediaTypeObject] | false {
   if (!responseBody) return false
   if (isReference(responseBody)) return false
 
@@ -45,11 +45,10 @@ function getResponseBody(responseBody: boolean | ResponseObject, contentType?: s
   if (!body.content) return false
 
   if (contentType) {
-    return contentType in body.content ? body.content[contentType]! : false
+    return contentType in body.content ? [contentType, body.content[contentType]!] : false
   }
 
-  const picked = pickContentEntry(body.content)
-  return picked ? picked[1] : false
+  return pickContentEntry(body.content)
 }
 
 /**
@@ -82,7 +81,13 @@ export function getResponseSchema({
     return {}
   }
 
-  const schema = responseBody.schema
+  const [mediaType, entry] = responseBody
+  const schema = entry.schema
+
+  const binary = getBinaryFallbackSchema(mediaType, schema)
+  if (binary) {
+    return binary
+  }
 
   if (!schema) {
     return {}
@@ -119,11 +124,9 @@ export function getRequestSchema({
   const mediaType = Array.isArray(requestBody) ? requestBody[0] : options.contentType
   const schema = Array.isArray(requestBody) ? requestBody[1].schema : requestBody.schema
 
-  // OAS 3.1 (and the 3.0 -> 3.1 upgrade) drops the schema for an `application/octet-stream` body,
-  // leaving an empty media type object. Synthesize the binary schema so generators still emit a
-  // request body type for the operation.
-  if (mediaType === 'application/octet-stream' && (!schema || Object.keys(schema).length === 0)) {
-    return { type: 'string', contentMediaType: 'application/octet-stream' }
+  const binary = getBinaryFallbackSchema(mediaType, schema)
+  if (binary) {
+    return binary
   }
 
   if (!schema) {

--- a/packages/adapter-oas/src/oas.test.ts
+++ b/packages/adapter-oas/src/oas.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, expectTypeOf, it } from 'vitest'
-import { isDiscriminator, isNullable, isReference } from './oas.ts'
+import { getBinaryFallbackSchema, isDiscriminator, isNullable, isReference } from './oas.ts'
 import type { ReferenceObject, SchemaObject } from './types.ts'
 
 describe('isNullable', () => {
@@ -74,5 +74,29 @@ describe('isDiscriminator', () => {
   it('returns false for null / undefined', () => {
     expect(isDiscriminator(null)).toBe(false)
     expect(isDiscriminator(undefined)).toBe(false)
+  })
+})
+
+describe('getBinaryFallbackSchema', () => {
+  it('returns the binary schema for an octet-stream entry the 3.1 upgrade emptied out', () => {
+    expect(getBinaryFallbackSchema('application/octet-stream', undefined)).toEqual({
+      type: 'string',
+      contentMediaType: 'application/octet-stream',
+    })
+    expect(getBinaryFallbackSchema('application/octet-stream', {})).toEqual({
+      type: 'string',
+      contentMediaType: 'application/octet-stream',
+    })
+  })
+
+  it('returns undefined when the octet-stream entry carries a schema of its own', () => {
+    expect(getBinaryFallbackSchema('application/octet-stream', { type: 'object' })).toBeUndefined()
+    expect(getBinaryFallbackSchema('application/octet-stream', { $ref: '#/components/schemas/Pet' })).toBeUndefined()
+  })
+
+  it('returns undefined for any other media type', () => {
+    expect(getBinaryFallbackSchema('application/json', undefined)).toBeUndefined()
+    expect(getBinaryFallbackSchema('application/pdf', {})).toBeUndefined()
+    expect(getBinaryFallbackSchema(undefined, undefined)).toBeUndefined()
   })
 })

--- a/packages/adapter-oas/src/oas.ts
+++ b/packages/adapter-oas/src/oas.ts
@@ -41,20 +41,9 @@ export function isBinary(schema: SchemaObject): boolean {
 }
 
 /**
- * Returns the binary schema for a media type entry the OAS 3.1 upgrade emptied out, or `undefined`
- * when the entry carries a schema of its own.
- *
- * Converting a 3.0 document rewrites `format: 'binary'` into
- * `contentMediaType: '<media type>'`, then drops the schema when it only repeats the media type
- * key. An `application/octet-stream` body therefore arrives here as `{}`, and without this
- * fallback it resolves to the empty schema type instead of a blob.
- *
- * @example
- * ```ts
- * getBinaryFallbackSchema('application/octet-stream', undefined)
- * // { type: 'string', contentMediaType: 'application/octet-stream' }
- * getBinaryFallbackSchema('application/json', undefined) // undefined
- * ```
+ * Returns the binary schema for an `application/octet-stream` entry the OAS 3.1 upgrade emptied
+ * out, or `undefined` when the entry carries a schema of its own. Without the fallback such a
+ * body resolves to the empty schema type instead of a blob.
  */
 export function getBinaryFallbackSchema(mediaType: string | undefined, schema: SchemaObject | ReferenceObject | undefined): SchemaObject | undefined {
   if (mediaType !== 'application/octet-stream') return undefined

--- a/packages/adapter-oas/src/oas.ts
+++ b/packages/adapter-oas/src/oas.ts
@@ -41,6 +41,29 @@ export function isBinary(schema: SchemaObject): boolean {
 }
 
 /**
+ * Returns the binary schema for a media type entry the OAS 3.1 upgrade emptied out, or `undefined`
+ * when the entry carries a schema of its own.
+ *
+ * Converting a 3.0 document rewrites `format: 'binary'` into
+ * `contentMediaType: '<media type>'`, then drops the schema when it only repeats the media type
+ * key. An `application/octet-stream` body therefore arrives here as `{}`, and without this
+ * fallback it resolves to the empty schema type instead of a blob.
+ *
+ * @example
+ * ```ts
+ * getBinaryFallbackSchema('application/octet-stream', undefined)
+ * // { type: 'string', contentMediaType: 'application/octet-stream' }
+ * getBinaryFallbackSchema('application/json', undefined) // undefined
+ * ```
+ */
+export function getBinaryFallbackSchema(mediaType: string | undefined, schema: SchemaObject | ReferenceObject | undefined): SchemaObject | undefined {
+  if (mediaType !== 'application/octet-stream') return undefined
+  if (schema && Object.keys(schema).length > 0) return undefined
+
+  return { type: 'string', contentMediaType: 'application/octet-stream' }
+}
+
+/**
  * MIME type fragments that mark a media type as JSON-like.
  *
  * A content type is JSON when it contains any of these substrings. The `+json` entry catches

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -16,11 +16,7 @@ const emptyDocument: Document = {
   paths: {},
 } as Document
 
-/**
- * OAS 3.0 document whose binary bodies lose their schema on the upgrade to 3.1: the converter
- * rewrites `format: 'binary'` to `contentMediaType` and drops it when it repeats the media type
- * key, leaving `'application/octet-stream': {}`.
- */
+// OAS 3.0 document whose binary bodies lose their schema on the upgrade to 3.1.
 const binaryResponseDocument = {
   openapi: '3.0.2',
   info: { title: 'Test', version: '1.0.0' },

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -17,6 +17,40 @@ const emptyDocument: Document = {
 } as Document
 
 /**
+ * OAS 3.0 document whose binary bodies lose their schema on the upgrade to 3.1: the converter
+ * rewrites `format: 'binary'` to `contentMediaType` and drops it when it repeats the media type
+ * key, leaving `'application/octet-stream': {}`.
+ */
+const binaryResponseDocument = {
+  openapi: '3.0.2',
+  info: { title: 'Test', version: '1.0.0' },
+  paths: {
+    '/essay': {
+      get: {
+        operationId: 'downloadEssay',
+        responses: {
+          '200': {
+            description: 'Binary body',
+            content: { 'application/octet-stream': { schema: { type: 'string', format: 'binary' } } },
+          },
+        },
+      },
+    },
+    '/pdf': {
+      get: {
+        operationId: 'downloadPdf',
+        responses: {
+          '200': {
+            description: 'PDF body',
+            content: { 'application/pdf': { schema: { type: 'string', format: 'binary' } } },
+          },
+        },
+      },
+    },
+  },
+} as Document
+
+/**
  * Parses a single OpenAPI `SchemaObject` into a `SchemaNode`, mirroring the
  * `createSchemaParser().parseSchema` helper for single-schema test cases.
  */
@@ -565,6 +599,26 @@ describe('buildAst', () => {
       expect(uploadFile?.requestBody?.content).toHaveLength(1)
       expect(uploadFile?.requestBody?.content?.[0]?.contentType).toBe('application/octet-stream')
       expect(uploadFile?.requestBody?.content?.[0]?.schema?.type).toBe('blob')
+    })
+
+    it('keeps a binary response for an application/octet-stream body upgraded to 3.1', async () => {
+      const oas = await parseDocument(binaryResponseDocument)
+      const root = parseOas(oas)
+
+      const essay = root.operations.find((op) => op.operationId === 'downloadEssay')
+      const pdf = root.operations.find((op) => op.operationId === 'downloadPdf')
+
+      expect(essay?.responses[0]?.content?.[0]?.contentType).toBe('application/octet-stream')
+      expect(essay?.responses[0]?.content?.[0]?.schema?.type).toBe('blob')
+      expect(pdf?.responses[0]?.content?.[0]?.schema?.type).toBe('blob')
+    })
+
+    it('keeps a binary octet-stream response whatever emptySchemaType is configured', async () => {
+      const oas = await parseDocument(binaryResponseDocument)
+      const root = parseOas(oas, { emptySchemaType: 'void' })
+      const essay = root.operations.find((op) => op.operationId === 'downloadEssay')
+
+      expect(essay?.responses[0]?.content?.[0]?.schema?.type).toBe('blob')
     })
 
     it('populates response.content with a single entry when the response has one content type', async () => {


### PR DESCRIPTION
<!--
Agents: follow the `pr` skill (.agents/skills/pr/SKILL.md), or run /pr.
Fill every section below, and tick a box only when you actually ran or verified it.
-->

## 🎯 Changes

Closes #4011

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [X] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).
- [ ] This change is breaking, and the body says what breaks and what a user has to do.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Binary `application/octet-stream` request and response bodies now retain their `blob` typing when schemas are empty or missing.
  * Binary response parsing remains correctly typed even when `emptySchemaType: 'void'` is configured.
  * Existing schemas and non-binary media types continue to be handled unchanged.

* **Tests**
  * Added coverage for binary fallback behavior across supported schema and media type scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->