### PR TITLE
chore: update kubb-labs/config setup action reference

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@da8a350ddbedb4dd9cf54b05b7ef1a4298c4f0dc # main
+        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@da8a350ddbedb4dd9cf54b05b7ef1a4298c4f0dc # main
+        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,7 +57,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@da8a350ddbedb4dd9cf54b05b7ef1a4298c4f0dc # main
+        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
         with:
           node-version: '22.22.3'
 
@@ -79,7 +79,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@da8a350ddbedb4dd9cf54b05b7ef1a4298c4f0dc # main
+        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
         with:
           node-version: '22.22.3'
 
@@ -104,7 +104,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@da8a350ddbedb4dd9cf54b05b7ef1a4298c4f0dc # main
+        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
         with:
           node-version: '22.22.3'
 
@@ -134,7 +134,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@da8a350ddbedb4dd9cf54b05b7ef1a4298c4f0dc # main
+        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
         with:
           node-version: '22.22.3'
 
@@ -160,7 +160,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@da8a350ddbedb4dd9cf54b05b7ef1a4298c4f0dc # main
+        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
         with:
           node-version: '22.22.3'
 
@@ -185,7 +185,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@da8a350ddbedb4dd9cf54b05b7ef1a4298c4f0dc # main
+        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
         with:
           node-version: '22.22.3'
 
@@ -232,7 +232,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@da8a350ddbedb4dd9cf54b05b7ef1a4298c4f0dc # main
+        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
         with:
           node-version: '22.22.3'
 
@@ -258,7 +258,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@da8a350ddbedb4dd9cf54b05b7ef1a4298c4f0dc # main
+        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@da8a350ddbedb4dd9cf54b05b7ef1a4298c4f0dc # main
+        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
         with:
           node-version: '22.22.3'
           cache: 'false'
@@ -49,7 +49,7 @@ jobs:
 
       - name: Release
         id: release
-        uses: kubb-labs/config/.github/actions/release@da8a350ddbedb4dd9cf54b05b7ef1a4298c4f0dc # main
+        uses: kubb-labs/config/.github/actions/release@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Keeps tools/claude/.claude-plugin/plugin.json's version in step with the
@@ -94,7 +94,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@da8a350ddbedb4dd9cf54b05b7ef1a4298c4f0dc # main
+        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
         with:
           node-version: '22.22.3'
           cache: 'false'
@@ -108,7 +108,7 @@ jobs:
       # version independently.
       - name: Promote
         id: promote
-        uses: kubb-labs/config/.github/actions/promote@da8a350ddbedb4dd9cf54b05b7ef1a4298c4f0dc # main
+        uses: kubb-labs/config/.github/actions/promote@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
         with:
           staged-packages: ${{ needs.release.outputs.staged_packages }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Update workflow references to use the latest kubb-labs/config commit that includes the OIDC trusted publishing fix.

This change addresses the issue where npm releases fail with a 401 error even though the trusted publisher is configured correctly. The fix removes the `registry-url` input from the setup-node action, which was interfering with OIDC token exchange.

## Details

- Updates all GitHub workflow files to reference the latest kubb-labs/config commit (`8315ece4b0abd547822f9b1f4c3d5544dd9b47e6`)
- This commit includes PR #37 which removes the problematic `registry-url` input from setup-node
- Each repo's own `.npmrc` already sets the registry URL, so no dependency on this input

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176nSgp9Pq5MmYs9sbQep7c

---
_Generated by [Claude Code](https://claude.ai/code/session_0176nSgp9Pq5MmYs9sbQep7c)_