### PR TITLE
chore: pin pnpm to 12.3.4 and bump kubb-labs/config actions

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
+        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
+        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,7 +57,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
+        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
         with:
           node-version: '22.22.3'
 
@@ -79,7 +79,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
+        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
         with:
           node-version: '22.22.3'
 
@@ -104,7 +104,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
+        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
         with:
           node-version: '22.22.3'
 
@@ -134,7 +134,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
+        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
         with:
           node-version: '22.22.3'
 
@@ -160,7 +160,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
+        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
         with:
           node-version: '22.22.3'
 
@@ -185,7 +185,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
+        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
         with:
           node-version: '22.22.3'
 
@@ -232,7 +232,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
+        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
         with:
           node-version: '22.22.3'
 
@@ -258,7 +258,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
+        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
+        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
         with:
           node-version: '22.22.3'
           cache: 'false'
@@ -49,7 +49,7 @@ jobs:
 
       - name: Release
         id: release
-        uses: kubb-labs/config/.github/actions/release@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
+        uses: kubb-labs/config/.github/actions/release@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Keeps tools/claude/.claude-plugin/plugin.json's version in step with the
@@ -94,7 +94,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
+        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
         with:
           node-version: '22.22.3'
           cache: 'false'
@@ -108,7 +108,7 @@ jobs:
       # version independently.
       - name: Promote
         id: promote
-        uses: kubb-labs/config/.github/actions/promote@8315ece4b0abd547822f9b1f4c3d5544dd9b47e6 # main
+        uses: kubb-labs/config/.github/actions/promote@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
         with:
           staged-packages: ${{ needs.release.outputs.staged_packages }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "typescript": "catalog:",
     "vitest": "catalog:"
   },
-  "packageManager": "pnpm@12.4.0",
+  "packageManager": "pnpm@12.3.4",
   "engines": {
     "node": ">=22",
     "pnpm": ">=11.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,153 +7,96 @@ importers:
     configDependencies: {}
     packageManagerDependencies:
       pnpm:
-        specifier: 12.4.0
-        version: 12.4.0
+        specifier: 12.3.4
+        version: 12.3.4
 
 packages:
 
-  '@pnpm/exe.android-arm64@12.4.0':
-    resolution: {integrity: sha512-sAwslzCw74OpqK2P9l39cgdrRWHSqf5wEjB58JEzeVX6wdLvaHyg9i/GeRK5Ou6PZNA3AkD4yLO3c/y7UqOf8w==}
-    cpu: [arm64]
-    os: [android]
-
-  '@pnpm/exe.android-x64@12.4.0':
-    resolution: {integrity: sha512-Ps3Gz0OrqYjuRfhzeNqcvIow6QmNrU3BSzMxJu5rUCSl7inVUUFX2gZbNL9naQsNLoorKCdxUf4N+WI9Mr1WBg==}
-    cpu: [x64]
-    os: [android]
-
-  '@pnpm/exe.darwin-arm64@12.4.0':
-    resolution: {integrity: sha512-75EYiF8GuiTsnvP4cbZsviMBjohXUYtg2zjD4gdfhqxlU1y9Nj+KdEsbH4jfgB/FgyJSYPB2rqfmvvgLnRlVug==}
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    resolution: {integrity: sha512-PAyUol8T1+/+ViOiXAt51ECA+QnfXCqz6foL4bW+LsoX0NcVd5XVEM2mRQu+LV4oc7uRz9zf9U0P+XFfuQeDAw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pnpm/exe.darwin-x64@12.4.0':
-    resolution: {integrity: sha512-b74TzBg8lxl0lqZImGOXpRbAGcqVKX+UMckl3wG+KH52yYHI86VBJP86HbJX30HJ/EFeC6Tgbz2E4b5hhKRvdA==}
+  '@pnpm/exe.darwin-x64@12.3.4':
+    resolution: {integrity: sha512-fxP9JCk0Cdye+ePuj+GJJLMUMTqHGWRdb1dtv4How876uQ2ehxvenpgiYAir/ceO9PsYUZkFTtyZdx+rRu5QOA==}
     cpu: [x64]
     os: [darwin]
 
-  '@pnpm/exe.freebsd-x64@12.4.0':
-    resolution: {integrity: sha512-A45d6axdQIFNyNTYZAC64wh5+6LJ6dNKhNAoNMNi/EC5y9CRfv0GL3ZYDBqpkmsN9KMAkVsFWizq/Ng6xtjnhw==}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@pnpm/exe.linux-arm64-musl@12.4.0':
-    resolution: {integrity: sha512-yS6DNel7twfEUoW1yka1hpQrnhRe/s1JZ1MThVfgrmNQrNaPyHxQvAihm/GtL2CM6OeMV6z5532H/W/yDjQp5g==}
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    resolution: {integrity: sha512-FBOt0/7ye6O6q4AllVV5QMviB6qE6fqkeczV/+MDWQsmo+QJrlfsh6X7CpH/tClVpBZEyIbjpUoT8bNhCYBxEg==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-arm64@12.4.0':
-    resolution: {integrity: sha512-6npQUwq3D/WXbTgR4evApEKQ9ITznZ6Iz/dptcjBzA7+wSLTaYkK98Od2wsHCoPmEFb9tGtM+cvG82+wy0o9uA==}
+  '@pnpm/exe.linux-arm64@12.3.4':
+    resolution: {integrity: sha512-t71AVA7LRqiKTyZ5xMYaZc2n5DfdpMbfokZuiIOXHBOM03ECnF0t4iYwaBDqJgVjlKYUOwaF/bRQajGNA4cJ4w==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.linux-ppc64@12.4.0':
-    resolution: {integrity: sha512-7shJ4WytyvBEdjrbIDqx2gDAH7sr0HBDooTmnNQ7DlzcLeeGi7Yqir7gJjOTm6s9S1cVnT56IwmqnnwQMP1HTQ==}
-    cpu: [ppc64]
-    os: [linux]
-    libc: [glibc]
-
-  '@pnpm/exe.linux-riscv64@12.4.0':
-    resolution: {integrity: sha512-q03EGUFoe/oOU/67E3sEAePr3qjFu8xrsX+WOXTodcFXfO5FondC6TPs7BSwhTiV27j3jeDP56qhJP05pXn+vw==}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@pnpm/exe.linux-s390x@12.4.0':
-    resolution: {integrity: sha512-GZ5YellCtNnaLe9zVj9l3avlw9CbSzExUFDh7v+tVbLfOOfkkRLpx2lsw1ytJ/nFWvxF2TO6M6Q9JDT7q8svRg==}
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  '@pnpm/exe.linux-x64-musl@12.4.0':
-    resolution: {integrity: sha512-c8YyjVL39L48tRg9i3iw3d90fN6q84UjxlgWBhplcBOpzCgmglDVkPMtEAVDC+t9iobvYzs2hJnmTqLaA87MVA==}
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    resolution: {integrity: sha512-RPmk7Jb/aYaFvL2iyDN/AtMY+hUEsue732WmXpcuQ9tBpMnGyA5py7Z3+e+qmQaJ0zY/4ni9jJiyPBQHujmv6w==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-x64@12.4.0':
-    resolution: {integrity: sha512-SQVgRkcR4Xyqf8+VNbtY0rtcEnfDq48RhH30HWo2/UfqKEfle2rOMyGZOmN1DbMw4ZzG5mWYoC81O7ZqHFZcPw==}
+  '@pnpm/exe.linux-x64@12.3.4':
+    resolution: {integrity: sha512-2ZqOlSPkfwX1h5cR+FPiWf8+F+2hZT/3TvhUK5sigHqwaQCIiq8R7CGxhndKs63JtcLi2a1Qpo+wX/EoyfjyJQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.win32-arm64@12.4.0':
-    resolution: {integrity: sha512-ZamXPhx0X6APZJAIkcH+K9KAsKcTYwxEgOyTQ/NXE+2UHBT9bRnSQ91sBeY6ELNd58V5cmMAkXSW5xmU+2ry+w==}
+  '@pnpm/exe.win32-arm64@12.3.4':
+    resolution: {integrity: sha512-ANyrHqyqco6SXBysUTRF74itDyyraea7IbFsKFdNXTjcFnfycTDx37EwuhdpPYFNSIh2JhUG4fByclsRfiHX7w==}
     cpu: [arm64]
     os: [win32]
 
-  '@pnpm/exe.win32-x64@12.4.0':
-    resolution: {integrity: sha512-b8bLaprnpYi/2zN0M3H9RDAHuxCP3fmV5agPPwdp9fIdjNSUkV7V/RC3L4oWwbZvVgYEjjFLx1RuJOdltoKP6g==}
+  '@pnpm/exe.win32-x64@12.3.4':
+    resolution: {integrity: sha512-WH/KqBPY/hq2Tb7SgQltEZytimcjgKRaCRL/aM9CI0c67iKc5TVmHUhIiL3Ux9FB4bWn36i6XewUcScQI+zG8w==}
     cpu: [x64]
     os: [win32]
 
-  pnpm@12.4.0:
-    resolution: {integrity: sha512-N1NsJu1Aq0E0tlEeCfayfz67RWh0aPJAbKOAUnmk5coVjBkxNQrZd01qshCNcbPbrrOZQxWSlDdeTQU+jgVoXA==}
+  pnpm@12.3.4:
+    resolution: {integrity: sha512-lhqkH7B32joEpEHZ+OFevAyW2o73ELLrZ7+e58sGEOq9SPH9hfUc/+c4RnhfoPh8VqOocqHYk/hEZ0G1zORUVw==}
     engines: {node: '>=18.*'}
     hasBin: true
 
 snapshots:
 
-  '@pnpm/exe.android-arm64@12.4.0':
+  '@pnpm/exe.darwin-arm64@12.3.4':
     optional: true
 
-  '@pnpm/exe.android-x64@12.4.0':
+  '@pnpm/exe.darwin-x64@12.3.4':
     optional: true
 
-  '@pnpm/exe.darwin-arm64@12.4.0':
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
     optional: true
 
-  '@pnpm/exe.darwin-x64@12.4.0':
+  '@pnpm/exe.linux-arm64@12.3.4':
     optional: true
 
-  '@pnpm/exe.freebsd-x64@12.4.0':
+  '@pnpm/exe.linux-x64-musl@12.3.4':
     optional: true
 
-  '@pnpm/exe.linux-arm64-musl@12.4.0':
+  '@pnpm/exe.linux-x64@12.3.4':
     optional: true
 
-  '@pnpm/exe.linux-arm64@12.4.0':
+  '@pnpm/exe.win32-arm64@12.3.4':
     optional: true
 
-  '@pnpm/exe.linux-ppc64@12.4.0':
+  '@pnpm/exe.win32-x64@12.3.4':
     optional: true
 
-  '@pnpm/exe.linux-riscv64@12.4.0':
-    optional: true
-
-  '@pnpm/exe.linux-s390x@12.4.0':
-    optional: true
-
-  '@pnpm/exe.linux-x64-musl@12.4.0':
-    optional: true
-
-  '@pnpm/exe.linux-x64@12.4.0':
-    optional: true
-
-  '@pnpm/exe.win32-arm64@12.4.0':
-    optional: true
-
-  '@pnpm/exe.win32-x64@12.4.0':
-    optional: true
-
-  pnpm@12.4.0:
+  pnpm@12.3.4:
     optionalDependencies:
-      '@pnpm/exe.android-arm64': 12.4.0
-      '@pnpm/exe.android-x64': 12.4.0
-      '@pnpm/exe.darwin-arm64': 12.4.0
-      '@pnpm/exe.darwin-x64': 12.4.0
-      '@pnpm/exe.freebsd-x64': 12.4.0
-      '@pnpm/exe.linux-arm64': 12.4.0
-      '@pnpm/exe.linux-arm64-musl': 12.4.0
-      '@pnpm/exe.linux-ppc64': 12.4.0
-      '@pnpm/exe.linux-riscv64': 12.4.0
-      '@pnpm/exe.linux-s390x': 12.4.0
-      '@pnpm/exe.linux-x64': 12.4.0
-      '@pnpm/exe.linux-x64-musl': 12.4.0
-      '@pnpm/exe.win32-arm64': 12.4.0
-      '@pnpm/exe.win32-x64': 12.4.0
+      '@pnpm/exe.darwin-arm64': 12.3.4
+      '@pnpm/exe.darwin-x64': 12.3.4
+      '@pnpm/exe.linux-arm64': 12.3.4
+      '@pnpm/exe.linux-arm64-musl': 12.3.4
+      '@pnpm/exe.linux-x64': 12.3.4
+      '@pnpm/exe.linux-x64-musl': 12.3.4
+      '@pnpm/exe.win32-arm64': 12.3.4
+      '@pnpm/exe.win32-x64': 12.3.4
 
 ---
 lockfileVersion: '9.0'


### PR DESCRIPTION
## 🎯 Changes

Two build-tooling updates.

**pnpm pinned to 12.3.4**, down from 12.4.0.

- `packageManager` in `package.json` is now `pnpm@12.3.4`.
- `pnpm-lock.yaml` is regenerated so the `packageManagerDependencies` block and the `@pnpm/exe.*` entries match 12.3.4.
- No dependency versions change. `engines.pnpm` stays `>=11.0.0`, so it still allows the pinned version.

**`kubb-labs/config` actions bumped to the latest main.** All 14 `kubb-labs/config/.github/*` references move from `8315ece` to `4327cff`, the current tip of that repo's main branch. That commit carries the release action fix that stops on a skipped OIDC exchange instead of failing with a 401.

## 🧪 How to test

- Step 1: `git checkout claude/pnpm-version-12-3-4-nvm9sc`
- Step 2: Run `corepack pnpm install --frozen-lockfile`
- Step 3: The install succeeds and `corepack pnpm --version` prints `12.3.4`.
- Step 4: Check CI on this PR. Every job that calls `kubb-labs/config/.github/setup` resolves the new SHA and still sets up Node and pnpm.

## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

I verified the lockfile with `corepack pnpm install --frozen-lockfile --lockfile-only` and left the test suite and the workflow runs to CI, since the diff only touches the pnpm pin and the action SHAs.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).
- [ ] This change is breaking, and the body says what breaks and what a user has to do.

Repository tooling only. No published code changes, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzcudVQVta9AfGsycmbPgM