### PR TITLE
chore(ci): bump kubb-labs/config actions to the latest main

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
+        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
+        uses: kubb-labs/config/.github/setup@ec40df0e3e54565e006f6d92a2fce16ff43b14d8 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
+        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
+        uses: kubb-labs/config/.github/setup@ec40df0e3e54565e006f6d92a2fce16ff43b14d8 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,7 +57,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
+        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
         with:
           node-version: '22.22.3'
 
@@ -79,7 +79,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
+        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
         with:
           node-version: '22.22.3'
 
@@ -104,7 +104,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
+        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
         with:
           node-version: '22.22.3'
 
@@ -134,7 +134,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
+        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
         with:
           node-version: '22.22.3'
 
@@ -160,7 +160,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
+        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
         with:
           node-version: '22.22.3'
 
@@ -185,7 +185,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
+        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
         with:
           node-version: '22.22.3'
 
@@ -232,7 +232,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
+        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
         with:
           node-version: '22.22.3'
 
@@ -258,7 +258,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
+        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -57,7 +57,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
+        uses: kubb-labs/config/.github/setup@ec40df0e3e54565e006f6d92a2fce16ff43b14d8 # main
         with:
           node-version: '22.22.3'
 
@@ -79,7 +79,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
+        uses: kubb-labs/config/.github/setup@ec40df0e3e54565e006f6d92a2fce16ff43b14d8 # main
         with:
           node-version: '22.22.3'
 
@@ -104,7 +104,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
+        uses: kubb-labs/config/.github/setup@ec40df0e3e54565e006f6d92a2fce16ff43b14d8 # main
         with:
           node-version: '22.22.3'
 
@@ -134,7 +134,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
+        uses: kubb-labs/config/.github/setup@ec40df0e3e54565e006f6d92a2fce16ff43b14d8 # main
         with:
           node-version: '22.22.3'
 
@@ -160,7 +160,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
+        uses: kubb-labs/config/.github/setup@ec40df0e3e54565e006f6d92a2fce16ff43b14d8 # main
         with:
           node-version: '22.22.3'
 
@@ -185,7 +185,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
+        uses: kubb-labs/config/.github/setup@ec40df0e3e54565e006f6d92a2fce16ff43b14d8 # main
         with:
           node-version: '22.22.3'
 
@@ -232,7 +232,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
+        uses: kubb-labs/config/.github/setup@ec40df0e3e54565e006f6d92a2fce16ff43b14d8 # main
         with:
           node-version: '22.22.3'
 
@@ -258,7 +258,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
+        uses: kubb-labs/config/.github/setup@ec40df0e3e54565e006f6d92a2fce16ff43b14d8 # main
         with:
           node-version: '22.22.3'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
+        uses: kubb-labs/config/.github/setup@ec40df0e3e54565e006f6d92a2fce16ff43b14d8 # main
         with:
           node-version: '22.22.3'
           cache: 'false'
@@ -49,7 +49,7 @@ jobs:
 
       - name: Release
         id: release
-        uses: kubb-labs/config/.github/actions/release@3699451578babc1c2d4ca46856cbf239b957759e # main
+        uses: kubb-labs/config/.github/actions/release@ec40df0e3e54565e006f6d92a2fce16ff43b14d8 # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Keeps tools/claude/.claude-plugin/plugin.json's version in step with the
@@ -94,7 +94,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
+        uses: kubb-labs/config/.github/setup@ec40df0e3e54565e006f6d92a2fce16ff43b14d8 # main
         with:
           node-version: '22.22.3'
           cache: 'false'
@@ -108,7 +108,7 @@ jobs:
       # version independently.
       - name: Promote
         id: promote
-        uses: kubb-labs/config/.github/actions/promote@3699451578babc1c2d4ca46856cbf239b957759e # main
+        uses: kubb-labs/config/.github/actions/promote@ec40df0e3e54565e006f6d92a2fce16ff43b14d8 # main
         with:
           staged-packages: ${{ needs.release.outputs.staged_packages }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
+        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
         with:
           node-version: '22.22.3'
           cache: 'false'
@@ -49,7 +49,7 @@ jobs:
 
       - name: Release
         id: release
-        uses: kubb-labs/config/.github/actions/release@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
+        uses: kubb-labs/config/.github/actions/release@3699451578babc1c2d4ca46856cbf239b957759e # main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Keeps tools/claude/.claude-plugin/plugin.json's version in step with the
@@ -94,7 +94,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Tools
-        uses: kubb-labs/config/.github/setup@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
+        uses: kubb-labs/config/.github/setup@3699451578babc1c2d4ca46856cbf239b957759e # main
         with:
           node-version: '22.22.3'
           cache: 'false'
@@ -108,7 +108,7 @@ jobs:
       # version independently.
       - name: Promote
         id: promote
-        uses: kubb-labs/config/.github/actions/promote@4327cff1a448d0069abe884c0599924b96f9bcb1 # main
+        uses: kubb-labs/config/.github/actions/promote@3699451578babc1c2d4ca46856cbf239b957759e # main
         with:
           staged-packages: ${{ needs.release.outputs.staged_packages }}
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes

Follow-up to #4016. `kubb-labs/config`'s main has moved twice since: first to `3699451` (the pnpm 12.3.4 pin), then to `ec40df0` (a fix for staged npm publishing, where safe-chain's pnpm shim was breaking the OIDC token exchange). Every `kubb-labs/config/.github/*` reference in this repo now points at `ec40df0`.

Both commits are CI-tooling changes in the config repo. This diff changes nothing about what this repo publishes or how it builds.

## How to test

- Step 1: `git checkout claude/pnpm-version-12-3-4-nvm9sc`
- Step 2: Run `grep -rn kubb-labs/config .github/workflows` and confirm every reference names `ec40df0e3e54565e006f6d92a2fce16ff43b14d8`.
- Step 3: Check CI on this PR. Every job that calls `kubb-labs/config/.github/setup` resolves the new SHA and still sets up Node and pnpm.

## Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [ ] I have tested this code locally with `pnpm run test`.

The diff is action SHAs only, so the workflow runs on this PR are the check that matters.

## Release impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).
- [ ] This change is breaking, and the body says what breaks and what a user has to do.

CI configuration only. No published code changes, so no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TzcudVQVta9AfGsycmbPgM