### PR TITLE
fix(adapter-oas): infer an implicit discriminator for undeclared oneOf unions

### DIFF
--- a/.changeset/infer-implicit-discriminator.md
+++ b/.changeset/infer-implicit-discriminator.md
@@ -1,0 +1,9 @@
+---
+'@kubb/adapter-oas': patch
+'@kubb/ast': patch
+---
+
+A `oneOf`/`anyOf` without a declared OpenAPI `discriminator` now infers one when a property
+carries a distinct single literal value on every branch. `UnionSchemaNode.discriminatorPropertyName`
+is set from that inference, so every printer that narrows on it (`plugin-zod`, `plugin-faker`)
+picks it up without reimplementing the same scan.

--- a/packages/adapter-oas/src/emit/converters/composition.ts
+++ b/packages/adapter-oas/src/emit/converters/composition.ts
@@ -134,17 +134,19 @@ export function convertUnion({ schema, name, nullable, defaultValue, rawOptions,
   const ctx = { schema, name, nullable, defaultValue }
   const unionMembers = [...(schema.oneOf ?? []), ...(schema.anyOf ?? [])]
   const strategy: 'one' | 'any' = schema.oneOf ? 'one' : 'any'
-  const unionExtras = {
-    discriminatorPropertyName: isDiscriminator(schema) ? schema.discriminator.propertyName : undefined,
-    strategy,
-  }
+  const explicitDiscriminatorPropertyName = isDiscriminator(schema) ? schema.discriminator.propertyName : undefined
   const discriminator = isDiscriminator(schema) ? schema.discriminator : undefined
   const { oneOf: _o, anyOf: _a, discriminator: _d, ...memberBaseSchema } = schema
   const sharedPropertiesNode = schema.properties ? parse({ schema: memberBaseSchema as SchemaObject, name }, rawOptions) : undefined
 
   if (sharedPropertiesNode || discriminator) {
     const members = narrowUnionMembers({ unionMembers, discriminator, sharedPropertiesNode, parse, rawOptions, name, refs })
-    const unionNode = createNode(ctx, { type: 'union', ...unionExtras, members })
+    const unionNode = createNode(ctx, {
+      type: 'union',
+      strategy,
+      members,
+      discriminatorPropertyName: explicitDiscriminatorPropertyName ?? ast.inferDiscriminatorPropertyName(members),
+    })
 
     if (!sharedPropertiesNode) {
       return unionNode
@@ -153,10 +155,12 @@ export function convertUnion({ schema, name, nullable, defaultValue, rawOptions,
     return createNode(ctx, { type: 'intersection', members: [unionNode, sharedPropertiesNode] })
   }
 
+  const members = unionMembers.map((s) => parse({ schema: s as SchemaObject, name }, rawOptions))
   const unionNode = createNode(ctx, {
     type: 'union',
-    ...unionExtras,
-    members: unionMembers.map((s) => parse({ schema: s as SchemaObject, name }, rawOptions)),
+    strategy,
+    members,
+    discriminatorPropertyName: explicitDiscriminatorPropertyName ?? ast.inferDiscriminatorPropertyName(members),
   })
 
   return ast.applyMacros(unionNode, [macroSimplifyUnion], { depth: 'shallow' })

--- a/packages/adapter-oas/src/parser.test.ts
+++ b/packages/adapter-oas/src/parser.test.ts
@@ -1294,6 +1294,34 @@ describe('parseSchema oneOf / anyOf', () => {
     expect(ast.narrowSchema(node, 'union')?.discriminatorPropertyName).toBeUndefined()
   })
 
+  it('infers discriminatorPropertyName when a property carries a distinct literal per branch', () => {
+    // No `discriminator` keyword, and the branches differ beyond that property too.
+    const node = parseSchema(ctx, {
+      schema: {
+        oneOf: [
+          { type: 'object', properties: { error: { type: 'string', enum: ['validation_failed'] }, field: { type: 'string' } } },
+          { type: 'object', properties: { error: { type: 'string', enum: ['rate_limited'] }, retryAfter: { type: 'integer' } } },
+        ],
+      },
+    })
+
+    expect(ast.narrowSchema(node, 'union')?.discriminatorPropertyName).toBe('error')
+  })
+
+  it('does not infer discriminatorPropertyName when no property has a single literal on every branch', () => {
+    // `state` is the only shared property, but each branch carries two literal values for it.
+    const node = parseSchema(ctx, {
+      schema: {
+        oneOf: [
+          { type: 'object', properties: { state: { type: 'string', enum: ['open', 'reopened'] } } },
+          { type: 'object', properties: { state: { type: 'string', enum: ['closed', 'archived'] } } },
+        ],
+      },
+    })
+
+    expect(ast.narrowSchema(node, 'union')?.discriminatorPropertyName).toBeUndefined()
+  })
+
   it('parses oneOf with object members without explicit discriminator', () => {
     // Test case from issue #14: oneOf should be preserved for validation
     const node = parseSchema(ctx, {

--- a/packages/ast/src/utils/index.ts
+++ b/packages/ast/src/utils/index.ts
@@ -1,4 +1,4 @@
 export { extractStringsFromNodes } from './extractStringsFromNodes.ts'
 export { resolveRefName } from './refs.ts'
 export { collectImportedRefNames, collectUsedSchemaNames, findCircularSchemas, findCircularSchemasFromGraph } from './schemaGraph.ts'
-export { getSchemaLiteralValues, resolveSchemaProperties } from './schemaProperties.ts'
+export { getSchemaLiteralValues, inferDiscriminatorPropertyName, resolveSchemaProperties } from './schemaProperties.ts'

--- a/packages/ast/src/utils/schemaProperties.test.ts
+++ b/packages/ast/src/utils/schemaProperties.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { createProperty } from '../nodes/property.ts'
 import { createSchema } from '../nodes/schema.ts'
-import { getSchemaLiteralValues, resolveSchemaProperties } from './schemaProperties.ts'
+import { getSchemaLiteralValues, inferDiscriminatorPropertyName, resolveSchemaProperties } from './schemaProperties.ts'
 
 describe('resolveSchemaProperties', () => {
   it('finds properties through references and intersections', () => {
@@ -58,5 +58,30 @@ describe('getSchemaLiteralValues', () => {
     })
 
     expect(getSchemaLiteralValues(node)).toStrictEqual(['cat'])
+  })
+})
+
+describe('inferDiscriminatorPropertyName', () => {
+  it('treats a property found through both a ref and a local declaration as one literal', () => {
+    // An allOf member exposes `type` twice for the same value: once through its own ref, once
+    // through a sibling object in the same intersection. Without deduplication that reads as two
+    // conflicting literals and the branch is wrongly rejected.
+    const property = createProperty({ name: 'type', required: true, schema: createSchema({ type: 'enum', enumValues: ['dog'] }) })
+    const object = createSchema({ type: 'object', properties: [property] })
+    const ref = createSchema({ type: 'ref', name: 'Dog', schema: object })
+    const dogMember = createSchema({ type: 'intersection', members: [ref, createSchema({ type: 'object', properties: [property] })] })
+
+    const catMember = createSchema({
+      type: 'object',
+      properties: [createProperty({ name: 'type', required: true, schema: createSchema({ type: 'enum', enumValues: ['cat'] }) })],
+    })
+
+    expect(inferDiscriminatorPropertyName([dogMember, catMember])).toBe('type')
+  })
+
+  it('returns undefined when fewer than two members are given', () => {
+    const member = createSchema({ type: 'object', properties: [] })
+
+    expect(inferDiscriminatorPropertyName([member])).toBeUndefined()
   })
 })

--- a/packages/ast/src/utils/schemaProperties.ts
+++ b/packages/ast/src/utils/schemaProperties.ts
@@ -96,3 +96,58 @@ export function getSchemaLiteralValues(node: SchemaNode): ReadonlyArray<string |
   visit(node)
   return [...values]
 }
+
+/**
+ * Names of every property an object, resolved reference, or intersection exposes. Mirrors the
+ * traversal `resolveSchemaProperties` uses, minus the name filter.
+ */
+function collectPropertyNames(node: SchemaNode, visited: WeakSet<SchemaNode> = new WeakSet()): Set<string> {
+  if (visited.has(node)) return new Set()
+  visited.add(node)
+
+  if (node.type === 'object') return new Set(node.properties.map((property) => property.name))
+  if (node.type === 'ref') return node.schema ? collectPropertyNames(node.schema, visited) : new Set()
+
+  if (node.type === 'intersection') {
+    const names = new Set<string>()
+    for (const member of node.members ?? []) {
+      for (const name of collectPropertyNames(member, visited)) names.add(name)
+    }
+    return names
+  }
+
+  return new Set()
+}
+
+/**
+ * Infers an implicit discriminator for a `oneOf`/`anyOf` that never declares one: a property
+ * every member exposes with a distinct single literal value, the same shape a declared OpenAPI
+ * `discriminator` already narrows on.
+ *
+ * @example
+ * ```ts
+ * inferDiscriminatorPropertyName([dogSchema, catSchema]) // 'type'
+ * ```
+ */
+export function inferDiscriminatorPropertyName(members: ReadonlyArray<SchemaNode>): string | undefined {
+  if (members.length < 2) return undefined
+
+  let candidates: Set<string> | undefined
+  for (const member of members) {
+    const names = collectPropertyNames(member)
+    candidates = candidates ? new Set([...candidates].filter((name) => names.has(name))) : names
+  }
+
+  for (const name of candidates ?? []) {
+    const values = members.map((member) => {
+      const literals = resolveSchemaProperties({ node: member, propertyName: name }).flatMap((property) => getSchemaLiteralValues(property.schema))
+      return literals.length === 1 ? literals[0] : undefined
+    })
+
+    if (values.every((value) => value !== undefined) && new Set(values).size === members.length) {
+      return name
+    }
+  }
+
+  return undefined
+}

--- a/packages/ast/src/utils/schemaProperties.ts
+++ b/packages/ast/src/utils/schemaProperties.ts
@@ -97,10 +97,7 @@ export function getSchemaLiteralValues(node: SchemaNode): ReadonlyArray<string |
   return [...values]
 }
 
-/**
- * Names of every property an object, resolved reference, or intersection exposes. Mirrors the
- * traversal `resolveSchemaProperties` uses, minus the name filter.
- */
+// Names of every property an object, resolved reference, or intersection exposes.
 function collectPropertyNames(node: SchemaNode, visited: WeakSet<SchemaNode> = new WeakSet()): Set<string> {
   if (visited.has(node)) return new Set()
   visited.add(node)
@@ -120,14 +117,8 @@ function collectPropertyNames(node: SchemaNode, visited: WeakSet<SchemaNode> = n
 }
 
 /**
- * Infers an implicit discriminator for a `oneOf`/`anyOf` that never declares one: a property
- * every member exposes with a distinct single literal value, the same shape a declared OpenAPI
- * `discriminator` already narrows on.
- *
- * @example
- * ```ts
- * inferDiscriminatorPropertyName([dogSchema, catSchema]) // 'type'
- * ```
+ * Infers an implicit discriminator: a property every member exposes with a distinct single
+ * literal value, the same shape a declared OpenAPI `discriminator` already narrows on.
  */
 export function inferDiscriminatorPropertyName(members: ReadonlyArray<SchemaNode>): string | undefined {
   if (members.length < 2) return undefined

--- a/packages/ast/src/utils/schemaProperties.ts
+++ b/packages/ast/src/utils/schemaProperties.ts
@@ -131,8 +131,8 @@ export function inferDiscriminatorPropertyName(members: ReadonlyArray<SchemaNode
 
   for (const name of candidates ?? []) {
     const values = members.map((member) => {
-      const literals = resolveSchemaProperties({ node: member, propertyName: name }).flatMap((property) => getSchemaLiteralValues(property.schema))
-      return literals.length === 1 ? literals[0] : undefined
+      const literals = new Set(resolveSchemaProperties({ node: member, propertyName: name }).flatMap((property) => getSchemaLiteralValues(property.schema)))
+      return literals.size === 1 ? [...literals][0] : undefined
     })
 
     if (values.every((value) => value !== undefined) && new Set(values).size === members.length) {


### PR DESCRIPTION
## 🎯 Changes

A `oneOf`/`anyOf` without a declared OpenAPI `discriminator` left `UnionSchemaNode.discriminatorPropertyName`
unset. A printer that narrows on it either widened every branch to the whole union (`plugin-zod`) or
had to scan for the same implicit discriminator itself (`plugin-faker`, see kubb-labs/plugins#887).

`convertUnion` in `packages/adapter-oas/src/emit/converters/composition.ts` now infers a discriminator
when a property carries a distinct single literal on every branch, the same shape a declared
discriminator already narrows on. The inference itself lives in a new `inferDiscriminatorPropertyName`
export in `@kubb/ast` (`packages/ast/src/utils/schemaProperties.ts`), built on the existing
`resolveSchemaProperties`/`getSchemaLiteralValues` helpers, so any printer picks it up for free
instead of reimplementing the scan.

Related to kubb-labs/plugins#887.

## 🧪 How to test

- Step 1: `pnpm --filter @kubb/adapter-oas test`
- Step 2: Open `packages/adapter-oas/src/parser.test.ts`, search for "infers discriminatorPropertyName"
- Step 3: Both new cases pass: a distinct literal per branch sets the property name, two literals per branch leaves it undefined

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).
- [ ] This change is breaking, and the body says what breaks and what a user has to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TETDNeAaZuU7cAG6GViie

---
_Generated by [Claude Code](https://claude.ai/code/session_017TETDNeAaZuU7cAG6GViie)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatically identifies discriminating properties in `oneOf` and `anyOf` schemas when no OpenAPI discriminator is declared.
  - Generated validation and mock outputs can now narrow unions using these inferred discriminators.
  - Inference applies only when every branch has a distinct single literal value, avoiding ambiguous results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->