### PR TITLE
feat(studio): report peer dependency versions

### DIFF
--- a/.changeset/tidy-ants-report.md
+++ b/.changeset/tidy-ants-report.md
@@ -1,0 +1,5 @@
+---
+'@kubb/studio': minor
+---
+
+Report installed peer dependency versions and missing dependencies with each generation result.

--- a/packages/studio/src/protocol/index.ts
+++ b/packages/studio/src/protocol/index.ts
@@ -192,7 +192,14 @@ export type KubbHooks = {
   'kubb:error': [ctx: { message: string; stack?: string }]
   'kubb:debug': [ctx: { logs: Array<string>; fileName?: string }]
   'kubb:generation:start': [ctx: { name?: string; plugins: number }]
-  'kubb:generation:end': [ctx: { config: Config; storage: Record<string, string> }]
+  'kubb:generation:end': [
+    ctx: {
+      config: Config
+      storage: Record<string, string>
+      peerDependencies: Record<string, string>
+      missingDependencies: Array<string>
+    },
+  ]
   'kubb:generation:summary': [ctx: { duration: number; fileCount: number; failedPlugins: number; status: 'success' | 'failed' }]
   'kubb:lifecycle:start': []
   'kubb:lifecycle:end': []

--- a/packages/studio/src/ws.test.ts
+++ b/packages/studio/src/ws.test.ts
@@ -1,4 +1,4 @@
-import { Hookable, type KubbHooks, type KubbPluginStartContext } from '@kubb/core'
+import { Hookable, memoryStorage, type Config, type KubbHooks, type KubbPluginStartContext } from '@kubb/core'
 import type WebSocket from 'ws'
 import { describe, expect, it, vi } from 'vitest'
 import type { AgentMessage } from './protocol/index.ts'
@@ -47,5 +47,38 @@ describe('setupEventsStream', () => {
     await hooks.callHook('studio:warn', { message: 'Ignored save: editing kubb.config.ts was not granted' })
 
     expect(socket.send).not.toHaveBeenCalled()
+  })
+
+  it('reports installed plugin versions and missing plugins when generation ends', async () => {
+    const socket = fakeSocket()
+    const hooks = new Hookable<KubbHooks>()
+    setupEventsStream(socket.ws, hooks)
+    const config = {
+      plugins: [{ name: '@kubb/core' }, { name: '@kubb/missing-plugin' }, { name: '@kubb/core' }],
+    } as Config
+
+    await hooks.callHook('kubb:generation:end', {
+      config,
+      storage: memoryStorage(),
+    })
+
+    expect(socket.sent()).toStrictEqual([
+      {
+        type: 'agent:data',
+        payload: {
+          type: 'kubb:generation:end',
+          data: [
+            {
+              config,
+              storage: {},
+              peerDependencies: { '@kubb/core': expect.any(String) },
+              missingDependencies: ['@kubb/missing-plugin'],
+            },
+          ],
+          timestamp: expect.any(Number),
+          seq: 0,
+        },
+      },
+    ])
   })
 })

--- a/packages/studio/src/ws.ts
+++ b/packages/studio/src/ws.ts
@@ -1,3 +1,5 @@
+import { readFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
 import { getElapsedMs, inParallel } from '@internals/utils'
 import { Diagnostics, type Hookable, type KubbHooks } from '@kubb/core'
 import WebSocket from 'ws'
@@ -25,6 +27,43 @@ const CONNECT_TIMEOUT_MS = 5_000
  * automatically once the socket is collected.
  */
 const eventSeqCounters = new WeakMap<WebSocket, number>()
+const require = createRequire(import.meta.url)
+
+type PackageJSON = {
+  version?: string
+}
+
+async function resolvePeerDependencies(names: Array<string>): Promise<{
+  peerDependencies: Record<string, string>
+  missingDependencies: Array<string>
+}> {
+  const uniqueNames = [...new Set(names)]
+  const peerDependencies: Record<string, string> = {}
+  const missingDependencies: Array<string> = []
+
+  const versions = await Promise.all(
+    uniqueNames.map(async (name) => {
+      try {
+        const path = require.resolve(`${name}/package.json`)
+        const packageJSON = JSON.parse(await readFile(path, 'utf8')) as PackageJSON
+        return packageJSON.version
+      } catch {
+        return undefined
+      }
+    }),
+  )
+
+  for (const [index, name] of uniqueNames.entries()) {
+    const version = versions[index]
+    if (version) {
+      peerDependencies[name] = version
+    } else {
+      missingDependencies.push(name)
+    }
+  }
+
+  return { peerDependencies, missingDependencies }
+}
 
 function nextEventSeq(ws: WebSocket): number {
   const seq = eventSeqCounters.get(ws) ?? 0
@@ -178,6 +217,7 @@ export function setupEventsStream(ws: WebSocket, hooks: Hookable<KubbHooks>): ()
   })
 
   on('kubb:generation:end', async ({ config, storage, diagnostics = [], status, hrStart, filesCreated }) => {
+    const { peerDependencies, missingDependencies } = await resolvePeerDependencies(config.plugins.map(({ name }) => name))
     const paths = await storage.readKeys()
     const files: Record<string, string> = {}
     await inParallel({
@@ -191,7 +231,7 @@ export function setupEventsStream(ws: WebSocket, hooks: Hookable<KubbHooks>): ()
 
     sendDataMessage({
       type: 'kubb:generation:end',
-      data: [{ config, storage: files }],
+      data: [{ config, storage: files, peerDependencies, missingDependencies }],
     })
 
     if (!hrStart) {


### PR DESCRIPTION
### Motivation

- Report which plugin packages and versions are actually installed (and which are missing) when a generation finishes so Studio can display resolved dependency information.
- Use package resolution of configured plugin package names and expose the results as peer-style dependency data instead of the previously described resolved-dependency approach.

### Description

- Extend the Studio protocol so the `kubb:generation:end` payload includes `peerDependencies: Record<string,string>` and `missingDependencies: Array<string>`.
- Add resolution logic in `packages/studio/src/ws.ts` that deduplicates plugin names, resolves each plugin's `package.json` via `require.resolve`, reads the `version`, and aggregates missing entries when resolution fails.
- Include the resolved `peerDependencies` and `missingDependencies` in the `agent:data` message emitted for `kubb:generation:end` and update the WebSocket stream behavior accordingly.
- Add a unit test in `packages/studio/src/ws.test.ts` that asserts installed-version reporting and missing-package detection, and add a `.changeset` to release `@kubb/studio` as a minor version.

### Testing

- Ran repository pre-checks (`git diff --check`) and staged the modified files for commit, then committed the changes successfully.
- Added a Vitest unit that covers the new reporting behavior in `packages/studio/src/ws.test.ts`, but the test was not executed in this environment.
- Attempted to run `pnpm --filter @kubb/studio test` and typecheck, but the environment could not download the required `pnpm` binary so tests and typecheck did not run here.
- Created a changeset (`.changeset/tidy-ants-report.md`) to publish the change to npm as a minor release for `@kubb/studio`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6aa5c0c48cdc83239fde65f691dd4a29)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generation results now display installed plugin versions.
  * Missing plugin dependencies are identified and reported in generation results.
  * Generation-end event data now includes dependency information for integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->