### PR TITLE
feat(cli): poll remote input URLs in watch mode

### DIFF
--- a/.changeset/watch-url-inputs.md
+++ b/.changeset/watch-url-inputs.md
@@ -1,0 +1,5 @@
+---
+"@kubb/cli": minor
+---
+
+`kubb generate --watch` now works with URL inputs. A remote document emits no filesystem events, so watch mode polls the URL (every 2 seconds) and regenerates when the response body changes. Each poll request times out after 10 seconds, so a hung server never stalls the watcher. An unreachable server is reported once per outage and polling continues. After recovery, a rebuild only happens when the document actually changed, unless the server was already down at startup, in which case the first successful poll regenerates so the output catches up. Previously `--watch` was silently ignored for URL inputs and the CLI exited after a single build.

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -66,7 +66,7 @@ export const command = defineWithTypes<{ extensions: DryRunExtensions }>()({
     },
     watch: {
       type: 'boolean',
-      description: 'Watch mode based on the input file',
+      description: 'Watch mode: watches an input file for changes, or polls an input URL',
       short: 'w',
       default: false,
     },

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -20,6 +20,18 @@ export const WATCHER_IGNORED_PATHS = '**/{.git,node_modules}/**' as const
 export const WATCHER_DEBOUNCE_MS = 100
 
 /**
+ * Interval in milliseconds between polls of a remote `input` URL in watch mode. A remote document
+ * emits no filesystem events, so watch mode falls back to fetching it and comparing bodies.
+ */
+export const URL_WATCHER_INTERVAL_MS = 2_000
+
+/**
+ * Upper bound in milliseconds for a single URL watcher request, covering both the response headers
+ * and the body read. A server that hangs mid-response would otherwise stall polling forever.
+ */
+export const URL_WATCHER_TIMEOUT_MS = 10_000
+
+/**
  * Upper bound in milliseconds for the npm update check, so a slow registry never stalls a run.
  */
 export const UPDATE_CHECK_TIMEOUT_MS = 3_000

--- a/packages/cli/src/runners/generate/run.ts
+++ b/packages/cli/src/runners/generate/run.ts
@@ -24,7 +24,7 @@ import { KUBB_NPM_PACKAGE_URL, UPDATE_CHECK_TIMEOUT_MS } from '../../constants.t
 import { buildTelemetryEvent, sendTelemetry } from '../../Telemetry.ts'
 import setupReporters, { selectReporters } from '../../loggers/utils.ts'
 import { logError, logInfo, logStep } from '../../loggers/output.ts'
-import { getConfigs, isNewerVersion, runHook, runPostGenerate, startWatcher } from './utils.ts'
+import { fetchUrlBody, getConfigs, isNewerVersion, runHook, runPostGenerate, startUrlWatcher, startWatcher } from './utils.ts'
 import { FORMATTER_PREFERENCE, LINTER_PREFERENCE } from '@internals/utils'
 import { detectTool, formatters, linters } from '../../tools.ts'
 
@@ -317,7 +317,8 @@ export async function run({ input, configPath, logLevel: logLevelKey, watch, rep
     let anyFailed = false
     for (const config of configs) {
       const effectiveInput = input ?? config.input
-      const watchPath = typeof effectiveInput === 'string' && getInputKind(effectiveInput) === 'file' ? effectiveInput : undefined
+      const inputKind = typeof effectiveInput === 'string' ? getInputKind(effectiveInput) : undefined
+      const watchPath = inputKind === 'file' || inputKind === 'url' ? (effectiveInput as string) : undefined
       if (watchPath && watch) {
         const watchedPaths = [watchPath]
         // Don't removeAll() between builds, that would also drop logger and lifecycle
@@ -328,15 +329,26 @@ export async function run({ input, configPath, logLevel: logLevelKey, watch, rep
           logStep(styleText('yellow', `Watching for changes in ${paths.join(' and ')}`))
         }
 
-        // The watcher ignores chokidar's startup events, so run the first build here. A failing
-        // first build keeps watching, since the user can fix the input and save.
+        // For a URL input, capture the document before the build: it becomes the watcher's
+        // change-detection baseline, so an edit landing before the first poll still rebuilds.
+        // When the server is down the baseline stays undefined and the watcher rebuilds on its
+        // first successful poll, so recovery with an unchanged document still generates output.
+        const initialBody = inputKind === 'url' ? await fetchUrlBody(watchPath) : undefined
+
+        // The watchers ignore their startup state (chokidar's initial events, the baseline
+        // above), so run the first build here. A failing first build keeps watching, since
+        // the user can fix the input and save.
         try {
           await build(watchedPaths)
         } catch (buildError) {
           await hooks.callHook('kubb:error', { error: toError(buildError) })
         }
 
-        await startWatcher(watchedPaths, build, { info: logInfo, error: logError })
+        if (inputKind === 'url') {
+          startUrlWatcher(watchPath, build, { log: { info: logInfo, error: logError }, initialBody })
+        } else {
+          await startWatcher(watchedPaths, build, { info: logInfo, error: logError })
+        }
       } else {
         try {
           const succeeded = await generate({ input, config, logLevel, hooks, dryRun })

--- a/packages/cli/src/runners/generate/utils.test.ts
+++ b/packages/cli/src/runners/generate/utils.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 import process from 'node:process'
 import { Hookable, type KubbHooks } from '@kubb/core'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { createSerialRunner, getConfigs, isNewerVersion, runHook, runPostGenerate } from './utils.ts'
+import { createSerialRunner, fetchUrlBody, getConfigs, isNewerVersion, runHook, runPostGenerate, startUrlWatcher } from './utils.ts'
 
 const node = process.execPath
 
@@ -262,5 +262,213 @@ describe('createSerialRunner', () => {
     shouldFail = false
     await runner()
     expect(errors).toStrictEqual(['run exploded'])
+  })
+})
+
+describe('startUrlWatcher', () => {
+  const url = 'http://localhost:1234/openapi.json'
+  const stops: Array<() => void> = []
+  const quiet = { info: (_message: string) => {}, error: (_message: string) => {} }
+
+  /**
+   * Feeds the watcher one queued response per poll, repeating the last entry once the queue is
+   * drained. A string resolves as the response body; an Error rejects the fetch like an
+   * unreachable server does.
+   */
+  function stubFetchQueue(queue: Array<string | Error>) {
+    let polls = 0
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        const item = queue[Math.min(polls, queue.length - 1)]
+        polls += 1
+        if (item instanceof Error) throw item
+        return { ok: true, status: 200, text: async () => item }
+      }),
+    )
+    return () => polls
+  }
+
+  /**
+   * Stubs fetch with a request that never settles until its signal aborts, the shape of a server
+   * that accepts the connection but never finishes the response.
+   */
+  function stubHungFetch(onAbort?: () => void) {
+    const fetchMock = vi.fn(
+      (_input: unknown, init?: { signal?: AbortSignal }) =>
+        new Promise<never>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            onAbort?.()
+            reject(new Error('aborted'))
+          })
+        }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    return fetchMock
+  }
+
+  function watch(cb: (path: Array<string>) => Promise<void>, options: { log?: typeof quiet; initialBody?: string; timeoutMs?: number } = {}) {
+    const stop = startUrlWatcher(url, cb, { log: quiet, intervalMs: 5, ...options })
+    stops.push(stop)
+    return stop
+  }
+
+  afterEach(() => {
+    for (const stop of stops.splice(0)) stop()
+    vi.unstubAllGlobals()
+  })
+
+  it('stays quiet while polls match the initial body', async () => {
+    const pollCount = stubFetchQueue(['{"openapi":"3.1.0"}'])
+    let builds = 0
+
+    watch(
+      async () => {
+        builds += 1
+      },
+      { initialBody: '{"openapi":"3.1.0"}' },
+    )
+
+    await vi.waitFor(() => expect(pollCount()).toBeGreaterThanOrEqual(3))
+    expect(builds).toBe(0)
+  })
+
+  it('rebuilds when the response body changes', async () => {
+    stubFetchQueue(['v1', 'v1', 'v2'])
+    const builtWith: Array<Array<string>> = []
+
+    watch(
+      async (paths) => {
+        builtWith.push(paths)
+      },
+      { initialBody: 'v1' },
+    )
+
+    await vi.waitFor(() => expect(builtWith).toStrictEqual([[url]]))
+  })
+
+  it('rebuilds when the document changed between the initial build and the first poll', async () => {
+    stubFetchQueue(['v2'])
+    let builds = 0
+
+    watch(
+      async () => {
+        builds += 1
+      },
+      { initialBody: 'v1' },
+    )
+
+    await vi.waitFor(() => expect(builds).toBe(1))
+  })
+
+  it('rebuilds on the first successful poll when no initial body was captured', async () => {
+    const down = new Error('fetch failed')
+    const pollCount = stubFetchQueue([down, down, 'v1', 'v1'])
+    let builds = 0
+
+    watch(async () => {
+      builds += 1
+    })
+
+    // The server was down at startup, so nothing was generated yet: recovery rebuilds even
+    // though the body never changed, and sets the baseline so later polls stay quiet.
+    await vi.waitFor(() => expect(builds).toBe(1))
+    await vi.waitFor(() => expect(pollCount()).toBeGreaterThanOrEqual(5))
+    expect(builds).toBe(1)
+  })
+
+  it('reports an outage once and rebuilds after recovery only when the body changed', async () => {
+    const down = new Error('fetch failed')
+    const pollCount = stubFetchQueue(['v1', down, down, 'v1', 'v2'])
+    const errors: Array<string> = []
+    let builds = 0
+
+    watch(
+      async () => {
+        builds += 1
+      },
+      {
+        initialBody: 'v1',
+        log: {
+          info: (_message: string) => {},
+          error: (message: string) => {
+            errors.push(message)
+          },
+        },
+      },
+    )
+
+    // Recovery with an unchanged body (poll 4) stays quiet; only the real change rebuilds.
+    await vi.waitFor(() => expect(builds).toBe(1))
+    expect(pollCount()).toBeGreaterThanOrEqual(5)
+    expect(errors).toHaveLength(1)
+  })
+
+  it('times out a request that never settles and keeps polling', async () => {
+    const fetchMock = stubHungFetch()
+
+    watch(async () => {}, { timeoutMs: 10 })
+
+    await vi.waitFor(() => expect(fetchMock.mock.calls.length).toBeGreaterThanOrEqual(2))
+  })
+
+  it('aborts the in-flight request when stopped', async () => {
+    let aborted = false
+    const fetchMock = stubHungFetch(() => {
+      aborted = true
+    })
+
+    const stop = watch(async () => {}, { timeoutMs: 10_000 })
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    stop()
+
+    await vi.waitFor(() => expect(aborted).toBe(true))
+  })
+
+  it('stops polling once the returned stop function runs', async () => {
+    const pollCount = stubFetchQueue(['v1'])
+    const stop = watch(async () => {}, { initialBody: 'v1' })
+
+    await vi.waitFor(() => expect(pollCount()).toBeGreaterThanOrEqual(2))
+    stop()
+    const settled = pollCount()
+
+    await new Promise((resolve) => setTimeout(resolve, 30))
+    expect(pollCount()).toBeLessThanOrEqual(settled + 1)
+  })
+})
+
+describe('fetchUrlBody', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns the body for a 2xx response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: true, status: 200, text: async () => '{"openapi":"3.1.0"}' })),
+    )
+
+    await expect(fetchUrlBody('http://localhost:1234/openapi.json')).resolves.toBe('{"openapi":"3.1.0"}')
+  })
+
+  it('returns undefined for a non-2xx response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 500, text: async () => 'nope' })),
+    )
+
+    await expect(fetchUrlBody('http://localhost:1234/openapi.json')).resolves.toBeUndefined()
+  })
+
+  it('returns undefined when the request fails', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('fetch failed')
+      }),
+    )
+
+    await expect(fetchUrlBody('http://localhost:1234/openapi.json')).resolves.toBeUndefined()
   })
 })

--- a/packages/cli/src/runners/generate/utils.ts
+++ b/packages/cli/src/runners/generate/utils.ts
@@ -8,7 +8,7 @@ import type { CLIOptions, Config, KubbHooks, PossibleConfig, PostGenerateCommand
 import { NonZeroExitError, x } from 'tinyexec'
 import { type LoadConfigResult, type LoadConfigSource, loadConfig } from 'unconfig'
 import { isGreater, isValid, truncate } from 'verkit'
-import { WATCHER_DEBOUNCE_MS, WATCHER_IGNORED_PATHS } from '../../constants.ts'
+import { URL_WATCHER_INTERVAL_MS, URL_WATCHER_TIMEOUT_MS, WATCHER_DEBOUNCE_MS, WATCHER_IGNORED_PATHS } from '../../constants.ts'
 
 const loader = createModuleLoader()
 
@@ -302,4 +302,116 @@ export async function startWatcher(
       void runBuild()
     }, WATCHER_DEBOUNCE_MS)
   })
+}
+
+/**
+ * Fetches the body of a remote spec URL, `undefined` when the server does not answer with a
+ * readable 2xx body within the timeout. The caller seeds `startUrlWatcher` with the result, so
+ * the watcher compares polls against the content the initial build ran on.
+ */
+export async function fetchUrlBody(url: string, timeoutMs: number = URL_WATCHER_TIMEOUT_MS): Promise<string | undefined> {
+  try {
+    const response = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) })
+    if (!response.ok) return undefined
+    return await response.text()
+  } catch {
+    return undefined
+  }
+}
+
+type UrlWatcherOptions = {
+  /**
+   * Sink for watcher messages, `console.log` by default.
+   */
+  log?: WatcherLog
+  /**
+   * Time in milliseconds between polls.
+   */
+  intervalMs?: number
+  /**
+   * Upper bound in milliseconds for one poll request, covering headers and body read.
+   */
+  timeoutMs?: number
+  /**
+   * Body the initial build ran against, the baseline for change detection. When omitted (the
+   * server was unreachable at startup), the first successful poll rebuilds so the output catches
+   * up as soon as the server responds.
+   */
+  initialBody?: string
+}
+
+/**
+ * Polls a remote spec URL and calls `cb` whenever the response body changes. A remote document
+ * emits no filesystem events, so this is the URL counterpart of `startWatcher`.
+ *
+ * `initialBody` seeds the change detection, so an edit landing between the initial build and the
+ * first poll still rebuilds. An unreachable server (the API restarting between saves) is reported
+ * once per outage and polling continues; after it recovers, a rebuild happens only when the body
+ * actually differs from the last one seen, so a plain restart with an unchanged spec stays quiet.
+ * Each request is aborted after `timeoutMs`, so a hung response delays at most one poll.
+ *
+ * Returns a function that stops polling and aborts the in-flight request, so callers (and tests)
+ * can shut the watcher down without signaling the process.
+ */
+export function startUrlWatcher(url: string, cb: (path: Array<string>) => Promise<void>, options: UrlWatcherOptions = {}): () => void {
+  const { log = { info: console.log, error: console.log }, intervalMs = URL_WATCHER_INTERVAL_MS, timeoutMs = URL_WATCHER_TIMEOUT_MS, initialBody } = options
+
+  let lastBody = initialBody
+  let offline = false
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let controller: AbortController | null = null
+  let stopped = false
+
+  const stop = () => {
+    stopped = true
+    if (timer) clearTimeout(timer)
+    controller?.abort()
+  }
+  process.once('SIGINT', stop)
+  process.once('SIGTERM', stop)
+
+  // Builds never overlap on the shared hooks emitter: a change during a build queues exactly
+  // one rerun.
+  const runBuild = createSerialRunner({
+    run: () => cb([url]),
+    onError: () => log.error(styleText('red', 'Watcher failed')),
+  })
+
+  const poll = async (): Promise<void> => {
+    controller = new AbortController()
+    try {
+      // The signal also aborts the body read, so a response that stalls mid-stream still times out.
+      const signal = AbortSignal.any([controller.signal, AbortSignal.timeout(timeoutMs)])
+      const response = await fetch(url, { signal })
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`)
+      }
+      const body = await response.text()
+      if (offline) {
+        offline = false
+        log.info(styleText('yellow', `${url} is reachable again`))
+      }
+      const changed = lastBody !== undefined && body !== lastBody
+      if (changed) {
+        log.info(styleText('yellow', styleText('bold', `Change detected: ${url}`)))
+      }
+      if (changed || lastBody === undefined) {
+        void runBuild()
+      }
+      lastBody = body
+    } catch {
+      // `lastBody` survives the outage so recovery rebuilds only on real content changes.
+      if (!offline && !stopped) {
+        offline = true
+        log.error(styleText('red', `Cannot reach ${url}, polling until it responds again`))
+      }
+    }
+    if (!stopped) {
+      timer = setTimeout(() => void poll(), intervalMs)
+    }
+  }
+
+  void poll()
+
+  return stop
 }


### PR DESCRIPTION
## 🎯 Changes

`--watch` with a URL input used to run one build and exit, with no hint that the flag did nothing: the watcher is chokidar, and a remote document has no file to watch. Watch mode now polls the URL every 2 seconds and rebuilds when the response body changes. An unreachable server is logged once per outage, and recovery rebuilds only when the document actually changed, so an API restart with an unchanged spec stays quiet. Start with `startUrlWatcher` in `packages/cli/src/runners/generate/utils.ts`.

## 🧪 How to test

- Step 1: `pnpm install && pnpm build`, then in a scratch folder create `openapi.json` (any valid spec) and serve it: `npx serve -l 8087 .`
- Step 2: add a `kubb.config.ts` with `input: 'http://localhost:8087/openapi.json'` and run `kubb generate --watch`. The CLI stays up and logs `Watching for changes in http://localhost:8087/openapi.json` instead of exiting.
- Step 3: edit `openapi.json`. Within 2 seconds the CLI logs `Change detected` and regenerates. Stopping the server logs a single `Cannot reach ...` line and polling resumes on its own.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/kubb-labs/kubb/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm run test`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is for the docs (no release).
- [ ] This change is breaking, and the body says what breaks and what a user has to do.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Watch mode now supports remote URL inputs in addition to local files.
  * Remote documents are checked every two seconds and automatically regenerate when their content changes.
  * Temporary connection issues are reported once while monitoring continues; recovery triggers rebuilding only after a document change.
* **Documentation**
  * Updated the watch mode description to clarify support for files and URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->